### PR TITLE
Remove `__getattribute__` from `BaseMessage`

### DIFF
--- a/camel/messages/base.py
+++ b/camel/messages/base.py
@@ -45,65 +45,6 @@ class BaseMessage:
     role: str
     content: str
 
-    def __getattribute__(self, name: str) -> Any:
-        r"""Get attribute override to delegate string methods to the
-        :obj:`content`.
-
-        Args:
-            name (str): The name of the attribute.
-
-        Returns:
-            Any: The attribute value.
-        """
-        delegate_methods = [
-            method for method in dir(str) if not method.startswith('_')
-        ]
-        if name in delegate_methods:
-            content = super().__getattribute__('content')
-            if isinstance(content, str):
-                content_method = getattr(content, name, None)
-                if callable(content_method):
-
-                    def modify_arg(arg: Any) -> Any:
-                        r"""Modify the argument for delegate method.
-
-                        Args:
-                            arg (Any): The argument value.
-
-                        Returns:
-                            Any: The modified argument value.
-                        """
-                        if isinstance(arg, BaseMessage):
-                            return arg.content
-                        elif isinstance(arg, (list, tuple)):
-                            return type(arg)(modify_arg(item) for item in arg)
-                        else:
-                            return arg
-
-                    def wrapper(*args: Any, **kwargs: Any) -> Any:
-                        r"""Wrapper function for delegate method.
-
-                        Args:
-                            *args (Any): Variable length argument list.
-                            **kwargs (Any): Arbitrary keyword arguments.
-
-                        Returns:
-                            Any: The result of the delegate method.
-                        """
-                        modified_args = [modify_arg(arg) for arg in args]
-                        modified_kwargs = {
-                            k: modify_arg(v)
-                            for k, v in kwargs.items()
-                        }
-                        output = content_method(*modified_args,
-                                                **modified_kwargs)
-                        return self._create_new_instance(output) if isinstance(
-                            output, str) else output
-
-                    return wrapper
-
-        return super().__getattribute__(name)
-
     def _create_new_instance(self, content: str) -> "BaseMessage":
         r"""Create a new instance of the :obj:`BaseMessage` with updated
         content.

--- a/test/messages/test_message_base.py
+++ b/test/messages/test_message_base.py
@@ -29,11 +29,6 @@ def base_message() -> BaseMessage:
     )
 
 
-def test_base_message_get_attribute(base_message: BaseMessage):
-    assert base_message.upper().content == "TEST CONTENT"
-    assert base_message.startswith("test")
-
-
 def test_base_message_addition_operator(base_message: BaseMessage):
     new_message = base_message + "!"
     assert new_message.content == "test content!"


### PR DESCRIPTION
## Description

As discussed, the `__getattribute__` method may make `BaseMessage` too complicated. So we decide to remove it.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide. (**required**)
- [x] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
