### PR TITLE
Moved all set_user_role_at_backend into Agent step

### DIFF
--- a/camel/agents/chat_agent.py
+++ b/camel/agents/chat_agent.py
@@ -161,6 +161,9 @@ class ChatAgent(BaseAgent):
 
         Args:
             input_message (ChatMessage): The input message to the agent.
+            Its `role` field that specifies the role at backen may be either
+            `user` or `assistant` but it will be set to `user` anyway since
+            for the self agent any incoming message is external.
 
         Returns:
             ChatAgentResponse: A struct
@@ -168,7 +171,8 @@ class ChatAgent(BaseAgent):
                 the chat session has terminated, and information about the chat
                 session.
         """
-        messages = self.update_messages(input_message)
+        msg_user_at_backend = input_message.set_user_role_at_backend()
+        messages = self.update_messages(msg_user_at_backend)
         if self.message_window_size is not None and len(
                 messages) > self.message_window_size:
             messages = [self.system_message

--- a/camel/agents/critic_agent.py
+++ b/camel/agents/critic_agent.py
@@ -168,7 +168,7 @@ class CriticAgent(ChatAgent):
         input_msg = copy.deepcopy(meta_chat_message)
         input_msg.content = flatten_options
 
-        option = self.get_option(input_msg.set_user_role_at_backend())
+        option = self.get_option(input_msg)
         output_msg = copy.deepcopy(meta_chat_message)
         output_msg.content = option
 

--- a/camel/agents/role_playing.py
+++ b/camel/agents/role_playing.py
@@ -266,8 +266,7 @@ class RolePlaying:
             whether or not the user agent terminated the conversation, and
             any additional user information.
         """
-        assistant_msg_rst = assistant_msg.set_user_role_at_backend()
-        user_response = self.user_agent.step(assistant_msg_rst)
+        user_response = self.user_agent.step(assistant_msg)
         if user_response.terminated or user_response.msgs is None:
             return (ChatAgentResponse([], False, {}),
                     ChatAgentResponse([], user_response.terminated,
@@ -275,8 +274,7 @@ class RolePlaying:
         user_msg = self.process_messages(user_response.msgs)
         self.user_agent.update_messages(user_msg)
 
-        user_msg_rst = user_msg.set_user_role_at_backend()
-        assistant_response = self.assistant_agent.step(user_msg_rst)
+        assistant_response = self.assistant_agent.step(user_msg)
         if assistant_response.terminated or assistant_response.msgs is None:
             return (ChatAgentResponse([], assistant_response.terminated,
                                       assistant_response.info),

--- a/camel/messages/chat_messages.py
+++ b/camel/messages/chat_messages.py
@@ -37,7 +37,7 @@ class ChatMessage(BaseMessage):
     role: str
     content: str = ""
 
-    def set_user_role_at_backend(self):
+    def set_user_role_at_backend(self) -> "ChatMessage":
         return self.__class__(
             role_name=self.role_name,
             role_type=self.role_type,

--- a/camel/messages/chat_messages.py
+++ b/camel/messages/chat_messages.py
@@ -37,7 +37,7 @@ class ChatMessage(BaseMessage):
     role: str
     content: str = ""
 
-    def set_user_role_at_backend(self: BaseMessage):
+    def set_user_role_at_backend(self):
         return self.__class__(
             role_name=self.role_name,
             role_type=self.role_type,

--- a/examples/code/role_playing_multiprocess.py
+++ b/examples/code/role_playing_multiprocess.py
@@ -125,8 +125,7 @@ def generate_data(language_idx: int, language_name: str, domain_idx: int,
 
     while message_counter < max_num_messages:
 
-        user_response = user_agent.step(
-            input_assistant_msg.set_user_role_at_backend())
+        user_response = user_agent.step(input_assistant_msg)
 
         # Condition 1: User terminates the chat
         if user_response.terminated:
@@ -138,8 +137,7 @@ def generate_data(language_idx: int, language_name: str, domain_idx: int,
         user_agent.update_messages(user_response.msg)
         print(f"User:\n{user_response.msg.content}\n")
 
-        assistant_response = assistant_agent.step(
-            user_response.msg.set_user_role_at_backend())
+        assistant_response = assistant_agent.step(user_response.msg)
 
         # Condition 2: Assistant terminates the chat
         if assistant_response.terminated:


### PR DESCRIPTION
## Description

Made setting user role at backend the responsibility of Agent step

## Motivation and Context

A developer using agents has to keep track of the role flag of the messages fed to agent.step() which may be flexible but error-prone.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Improvement: of the API usage flow