### PR TITLE
Fix set_output_language

### DIFF
--- a/camel/agents/chat_agent.py
+++ b/camel/agents/chat_agent.py
@@ -103,6 +103,7 @@ class ChatAgent(BaseAgent):
         output_language: Optional[str] = None,
     ) -> None:
 
+        self.orig_sys_message: BaseMessage = system_message
         self.system_message: BaseMessage = system_message
         self.role_name: str = system_message.role_name
         self.role_type: RoleType = system_message.role_type
@@ -146,7 +147,7 @@ class ChatAgent(BaseAgent):
             BaseMessage: The updated system message object.
         """
         self.output_language = output_language
-        content = (self.system_message.content +
+        content = (self.orig_sys_message.content +
                    ("\nRegardless of the input language, "
                     f"you must output text in {output_language}."))
         self.system_message = self.system_message.create_new_instance(content)

--- a/test/agents/test_chat_agent.py
+++ b/test/agents/test_chat_agent.py
@@ -126,3 +126,14 @@ def test_set_output_language():
         content="You are a help assistant."
         "\nRegardless of the input language, you must output text in Arabic.")
     assert agent.system_message.content == updated_system_message.content
+
+    # Verify that the length of the system message is kept constant even when
+    # multiple set_output_language operations are called
+    agent.set_output_language("Chinese")
+    agent.set_output_language("English")
+    agent.set_output_language("French")
+    updated_system_message = BaseMessage(
+        role_name="assistant", role_type=RoleType.ASSISTANT, meta_dict=None,
+        content="You are a help assistant."
+        "\nRegardless of the input language, you must output text in French.")
+    assert agent.system_message.content == updated_system_message.content


### PR DESCRIPTION
## Description

Have discussed with @lightaime and decided only to keep an "original"("initial") system message which will be used for adding language-setting prompt. This will make the system message's length fixed even after multiple `set_output_language` operations are done. The corresponding test is added in `test_chat_agent.py`

## Motivation and Context

close #215
- [ ] I have raised an issue to propose this change ([required](https://github.com/camel-ai/camel/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of example)

## Implemented Tasks

- [ ] Subtask 1
- [ ] Subtask 2
- [ ] Subtask 3

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide. (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation accordingly.
