### PR TITLE
Remove `model_type` from the `RolePlaying`

### DIFF
--- a/camel/societies/role_playing.py
+++ b/camel/societies/role_playing.py
@@ -24,7 +24,7 @@ from camel.generators import SystemMessageGenerator
 from camel.human import Human
 from camel.messages import BaseMessage
 from camel.prompts import TextPrompt
-from camel.typing import ModelType, RoleType, TaskType
+from camel.typing import RoleType, TaskType
 
 
 class RolePlaying:
@@ -48,8 +48,6 @@ class RolePlaying:
             in the loop. (default: :obj:`False`)
         critic_criteria (str, optional): Critic criteria for the critic agent.
             If not specified, set the criteria to improve task performance.
-        model_type (ModelType, optional): The type of backend model to use.
-            (default: :obj:`ModelType.GPT_3_5_TURBO`)
         task_type (TaskType, optional): The type of task to perform.
             (default: :obj:`TaskType.AI_SOCIETY`)
         assistant_agent_kwargs (Dict, optional): Additional arguments to pass
@@ -82,7 +80,6 @@ class RolePlaying:
         with_task_planner: bool = False,
         with_critic_in_the_loop: bool = False,
         critic_criteria: Optional[str] = None,
-        model_type: ModelType = ModelType.GPT_3_5_TURBO,
         task_type: TaskType = TaskType.AI_SOCIETY,
         assistant_agent_kwargs: Optional[Dict] = None,
         user_agent_kwargs: Optional[Dict] = None,
@@ -97,7 +94,6 @@ class RolePlaying:
         self.with_task_specify = with_task_specify
         self.with_task_planner = with_task_planner
         self.with_critic_in_the_loop = with_critic_in_the_loop
-        self.model_type = model_type
         self.task_type = task_type
         self.task_prompt = task_prompt
 
@@ -159,7 +155,6 @@ class RolePlaying:
                          user_role=user_role_name))
             task_specify_meta_dict.update(extend_task_specify_meta_dict or {})
             task_specify_agent = TaskSpecifyAgent(
-                self.model_type,
                 task_type=self.task_type,
                 output_language=output_language,
                 **(task_specify_agent_kwargs or {}),
@@ -187,7 +182,6 @@ class RolePlaying:
         """
         if self.with_task_planner:
             task_planner_agent = TaskPlannerAgent(
-                self.model_type,
                 output_language=output_language,
                 **(task_planner_agent_kwargs or {}),
             )
@@ -264,14 +258,12 @@ class RolePlaying:
         """
         self.assistant_agent = ChatAgent(
             init_assistant_sys_msg,
-            self.model_type,
             output_language=output_language,
             **(assistant_agent_kwargs or {}),
         )
         self.assistant_sys_msg = self.assistant_agent.system_message
         self.user_agent = ChatAgent(
             init_user_sys_msg,
-            self.model_type,
             output_language=output_language,
             **(user_agent_kwargs or {}),
         )
@@ -313,7 +305,6 @@ class RolePlaying:
                 )
                 self.critic = CriticAgent(
                     self.critic_sys_msg,
-                    self.model_type,
                     **(critic_kwargs or {}),
                 )
 

--- a/examples/ai_society/role_playing.py
+++ b/examples/ai_society/role_playing.py
@@ -20,11 +20,13 @@ from camel.utils import print_text_animated
 def main(model_type=None) -> None:
     task_prompt = "Develop a trading bot for the stock market"
     role_play_session = RolePlaying(
-        "Python Programmer",
-        "Stock Trader",
+        assistant_role_name="Python Programmer",
+        assistant_agent_kwargs=dict(model=model_type),
+        user_role_name="Stock Trader",
+        user_agent_kwargs=dict(model=model_type),
         task_prompt=task_prompt,
         with_task_specify=True,
-        model_type=model_type,
+        task_specify_agent_kwargs=dict(model=model_type),
     )
 
     print(

--- a/examples/ai_society/role_playing.py
+++ b/examples/ai_society/role_playing.py
@@ -14,6 +14,7 @@
 from colorama import Fore
 
 from camel.societies import RolePlaying
+from camel.typing import ModelType
 from camel.utils import print_text_animated
 
 
@@ -71,4 +72,4 @@ def main(model_type=None) -> None:
 
 
 if __name__ == "__main__":
-    main()
+    main(model_type=ModelType.GPT_3_5_TURBO_16K)

--- a/examples/ai_society/role_playing.py
+++ b/examples/ai_society/role_playing.py
@@ -14,7 +14,6 @@
 from colorama import Fore
 
 from camel.societies import RolePlaying
-from camel.typing import ModelType
 from camel.utils import print_text_animated
 
 
@@ -72,4 +71,4 @@ def main(model_type=None) -> None:
 
 
 if __name__ == "__main__":
-    main(model_type=ModelType.GPT_3_5_TURBO_16K)
+    main()

--- a/examples/ai_society/role_playing_multi_lingual.py
+++ b/examples/ai_society/role_playing_multi_lingual.py
@@ -20,11 +20,13 @@ from camel.utils import print_text_animated
 def main(model_type=None) -> None:
     task_prompt = "Develop a trading bot for the stock market"
     role_play_session = RolePlaying(
-        "Python Programmer",
-        "Stock Trader",
+        assistant_role_name="Python Programmer",
+        assistant_agent_kwargs=dict(model=model_type),
+        user_role_name="Stock Trader",
+        user_agent_kwargs=dict(model=ModelType.GPT_3_5_TURBO),
         task_prompt=task_prompt,
         with_task_specify=True,
-        model_type=model_type,
+        task_specify_agent_kwargs=dict(model=model_type),
         output_language="Chinese",  # Arabic, French, Spanish, ...
     )
 

--- a/examples/code/role_playing.py
+++ b/examples/code/role_playing.py
@@ -24,11 +24,13 @@ def main(model_type=None) -> None:
     domain = "Sociology"
     meta_dict = {"language": language, "domain": domain}
     role_play_session = RolePlaying(
-        f"{language} Programmer",
-        f"Person working in {domain}",
+        assistant_role_name=f"{language} Programmer",
+        assistant_agent_kwargs=dict(mode=model_type),
+        user_role_name=f"Person working in {domain}",
+        user_agent_kwargs=dict(mode=model_type),
         task_prompt=task_prompt,
         with_task_specify=True,
-        model_type=model_type,
+        task_specify_agent_kwargs=dict(mode=model_type),
         task_type=TaskType.CODE,
         extend_sys_msg_meta_dicts=[meta_dict, meta_dict],
         extend_task_specify_meta_dict=meta_dict,


### PR DESCRIPTION
## Description

Remove "global" `model_type` from the `RolePlaying`.
User can specify `model` in each `*agent_kwargs` instead, which is more flexible. Especially if user want to use different models for different agents during role playing.

This PR includes:
- Modification of `RolePlaying`
- Add / modify corresponding unit tests to `test/agents/test_role_playing.py`
- Modify current examples

## Motivation and Context

Fixes #190

- [x] I have raised an issue to propose this change ([required](https://github.com/camel-ai/camel/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (update in the documentation)
- [x] Example (update in the folder of example)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide. (**required**)
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [x] I have updated the documentation accordingly.
