### PR TITLE
Fix master test fail

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -29,9 +29,8 @@ jobs:
       with:
         path: ./.venv
         key: ${{ runner.os }}-venv-docs-${{ hashFiles('pyproject.toml') }}
-        restore-keys: ${{ runner.os }}-venv-docs
     - name: Install the project dependencies
-      run: poetry install --with docs
+      run: poetry install --with docs -E all
     - name: Sphinx build
       run: |
         cd docs

--- a/.github/workflows/pytest_apps.yml
+++ b/.github/workflows/pytest_apps.yml
@@ -35,7 +35,7 @@ jobs:
         path: ./.venv
         key: ${{ runner.os }}-venv-${{ hashFiles('pyproject.toml') }}
     - name: Install the project dependencies
-      run: poetry install --with dev
+      run: poetry install --with dev -E all
     - name: Run pytest
       env:
         OPENAI_API_KEY: "${{ secrets.OPENAI_API_KEY }}"
@@ -63,7 +63,7 @@ jobs:
         path: ./.venv
         key: ${{ runner.os }}-venv-${{ hashFiles('pyproject.toml') }}
     - name: Install the project dependencies
-      run: poetry install --with dev
+      run: poetry install --with dev -E all
     - name: Run pytest
       env:
         OPENAI_API_KEY: "${{ secrets.OPENAI_API_KEY }}"

--- a/.github/workflows/pytest_apps.yml
+++ b/.github/workflows/pytest_apps.yml
@@ -34,7 +34,6 @@ jobs:
       with:
         path: ./.venv
         key: ${{ runner.os }}-venv-${{ hashFiles('pyproject.toml') }}
-        restore-keys: ${{ runner.os }}-venv
     - name: Install the project dependencies
       run: poetry install --with dev
     - name: Run pytest
@@ -63,7 +62,6 @@ jobs:
       with:
         path: ./.venv
         key: ${{ runner.os }}-venv-${{ hashFiles('pyproject.toml') }}
-        restore-keys: ${{ runner.os }}-venv
     - name: Install the project dependencies
       run: poetry install --with dev
     - name: Run pytest

--- a/.github/workflows/pytest_package.yml
+++ b/.github/workflows/pytest_package.yml
@@ -34,9 +34,8 @@ jobs:
       with:
         path: ./.venv
         key: ${{ runner.os }}-venv-${{ hashFiles('pyproject.toml') }}
-        restore-keys: ${{ runner.os }}-venv
     - name: Install the project dependencies
-      run: poetry install --with dev
+      run: poetry install --with dev -E all
     - name: Run pytest
       env:
         OPENAI_API_KEY: "${{ secrets.OPENAI_API_KEY }}"
@@ -64,9 +63,8 @@ jobs:
       with:
         path: ./.venv
         key: ${{ runner.os }}-venv-${{ hashFiles('pyproject.toml') }}
-        restore-keys: ${{ runner.os }}-venv
     - name: Install the project dependencies
-      run: poetry install --with dev
+      run: poetry install --with dev -E all
     - name: Run pytest
       env:
         OPENAI_API_KEY: "${{ secrets.OPENAI_API_KEY }}"
@@ -94,9 +92,8 @@ jobs:
       with:
         path: ./.venv
         key: ${{ runner.os }}-venv-${{ hashFiles('pyproject.toml') }}
-        restore-keys: ${{ runner.os }}-venv
     - name: Install the project dependencies
-      run: poetry install --with dev
+      run: poetry install --with dev -E all
     - name: Run pytest
       env:
         OPENAI_API_KEY: "${{ secrets.OPENAI_API_KEY }}"


### PR DESCRIPTION
## Description

Fix master branch test fail.

The caching environment prevent the pr branch from pytest fail. So I change the caching logic. However, it seems to be useless to cache the env without `poetry.lock`. How about just remove caching? 