### PR TITLE
Modified search wiki test

### DIFF
--- a/test/functions/test_search_functions.py
+++ b/test/functions/test_search_functions.py
@@ -11,6 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # =========== Copyright 2023 @ CAMEL-AI.org. All Rights Reserved. ===========
+import wikipedia
+
 from camel.functions.search_functions import search_wiki
 
 
@@ -33,16 +35,6 @@ def test_search_wiki_not_found():
 
 
 def tests_search_wiki_with_ambiguity():
-    expected_output = (
-        "New York, often called New York State, is a state in the"
-        " Northeastern United States. A Mid-Atlantic state, New York"
-        " borders New England, and has an international border with Canada."
-        " With almost 19.7 million residents, it is the fourth-most populous "
-        "state in the United States and seventh-most densely populated as of "
-        "2022. New York is the 27th-largest U.S. state by area, with a total "
-        "area of 54,556 square miles (141,300 km2).New York has a varied "
-        "geography. The southeastern part of the state, known as Downstate, "
-        "encompasses New York City (the most populous city in the United "
-        "States), Long Island (the most populous island in the United States)"
-        ", and the lower Hudson Valley.")
+    expected_output = wikipedia.summary("New York (state)", sentences=5,
+                                        auto_suggest=False)
     assert search_wiki("New York") == expected_output

--- a/test/functions/test_search_functions.py
+++ b/test/functions/test_search_functions.py
@@ -34,7 +34,7 @@ def test_search_wiki_not_found():
         "entity to be searched.")
 
 
-def tests_search_wiki_with_ambiguity():
+def test_search_wiki_with_ambiguity():
     expected_output = wikipedia.summary("New York (state)", sentences=5,
                                         auto_suggest=False)
     assert search_wiki("New York") == expected_output


### PR DESCRIPTION
## Description

Modified the test `tests_search_wiki_with_ambiguity` by directly setting `expected_output` to be the summary of entity `New York (state)`. By doing this, this test can test whether the function does find the correct term and accurately check the summary content.

## Motivation and Context

Why is this change required? What problem does it solve?
close #260 

- [x] I have raised an issue to propose this change ([required](https://github.com/camel-ai/camel/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of example)

## Implemented Tasks

- [ ] Subtask 1
- [ ] Subtask 2
- [ ] Subtask 3

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide. (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation accordingly.
