### PR TITLE
Add test for covering method `run` of Open-source models

### DIFF
--- a/camel/models/open_source_model.py
+++ b/camel/models/open_source_model.py
@@ -89,7 +89,7 @@ class OpenSourceModel(BaseModelBackend):
         self,
         messages: List[Dict],
     ) -> Dict[str, Any]:
-        r"""Run inference of OpenAI chat completion.
+        r"""Run inference of OpenAI-API-style chat completion.
 
         Args:
             messages (List[Dict]): Message list with the chat history

--- a/camel/utils/__init__.py
+++ b/camel/utils/__init__.py
@@ -20,6 +20,7 @@ from .functions import (
     download_tasks,
     parse_doc,
     get_task_list,
+    check_server_running,
 )
 from .token_counting import (
     get_model_encoding,
@@ -39,6 +40,7 @@ __all__ = [
     'parse_doc',
     'get_task_list',
     'get_model_encoding',
+    'check_server_running',
     'BaseTokenCounter',
     'OpenAITokenCounter',
     'OpenSourceTokenCounter',

--- a/camel/utils/functions.py
+++ b/camel/utils/functions.py
@@ -14,6 +14,7 @@
 import inspect
 import os
 import re
+import socket
 import time
 import zipfile
 from functools import wraps
@@ -28,6 +29,7 @@ from typing import (
     TypeVar,
     cast,
 )
+from urllib.parse import urlparse
 
 import requests
 
@@ -224,3 +226,25 @@ def get_task_list(task_response: str) -> List[str]:
             if task_name.strip() and task_id.isnumeric():
                 new_tasks_list.append(task_name)
     return new_tasks_list
+
+
+def check_server_running(server_url: str) -> bool:
+    r"""Check whether the port refered by the URL to the server
+    is open.
+
+    Args:
+        server_url (str): The URL to the server running LLM inference
+            service.
+
+    Returns:
+        bool: Whether the port is open for packets (server is running).
+    """
+    parsed_url = urlparse(server_url)
+    url_tuple = (parsed_url.hostname, parsed_url.port)
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    result = sock.connect_ex(url_tuple)
+    sock.close()
+
+    # if the port is open, the result should be 0.
+    return result == 0

--- a/test/models/test_open_source_model.py
+++ b/test/models/test_open_source_model.py
@@ -22,12 +22,13 @@ from camel.configs import (
 )
 from camel.models import OpenSourceModel
 from camel.typing import ModelType
-from camel.utils import OpenSourceTokenCounter
+from camel.utils import OpenSourceTokenCounter, check_server_running
 
 MODEL_PATH_MAP = {
     ModelType.VICUNA: "lmsys/vicuna-7b-v1.5",
     ModelType.VICUNA_16K: "lmsys/vicuna-7b-v1.5-16k",
 }
+DEFAULT_SERVER_URL = "http://localhost:8000/v1"
 
 
 @pytest.mark.model_backend
@@ -40,7 +41,7 @@ def test_open_source_model(model_type):
     model_name = model_path.split('/')[-1]
     model_config = OpenSourceConfig(
         model_path=model_path,
-        server_url="http://localhost:8000/v1",
+        server_url=DEFAULT_SERVER_URL,
     )
     model_config_dict = model_config.__dict__
     model = OpenSourceModel(model_type, model_config_dict)
@@ -56,12 +57,31 @@ def test_open_source_model(model_type):
 
 
 @pytest.mark.model_backend
+@pytest.mark.parametrize("model_type", [ModelType.VICUNA])
+@pytest.mark.skipif(not check_server_running(DEFAULT_SERVER_URL),
+                    reason="No server running LLM inference is provided.")
+def test_open_source_model_run(model_type):
+    model_path = MODEL_PATH_MAP[model_type]
+    model_config = OpenSourceConfig(
+        model_path=model_path,
+        server_url=DEFAULT_SERVER_URL,
+    )
+    model_config_dict = model_config.__dict__
+    model = OpenSourceModel(model_type, model_config_dict)
+
+    messages = [{"role": "user", "content": "Tell me a joke."}]
+    response = model.run(messages)
+
+    assert isinstance(response, dict)
+
+
+@pytest.mark.model_backend
 def test_open_source_model_close_source_model_type():
     model_type = ModelType.GPT_3_5_TURBO
     model_path = MODEL_PATH_MAP[ModelType.VICUNA]
     model_config = OpenSourceConfig(
         model_path=model_path,
-        server_url="http://localhost:8000/v1",
+        server_url=DEFAULT_SERVER_URL,
     )
     model_config_dict = model_config.__dict__
 
@@ -91,7 +111,7 @@ def test_open_source_model_unexpected_argument():
     model_path = MODEL_PATH_MAP[ModelType.VICUNA]
     model_config = OpenSourceConfig(
         model_path=model_path,
-        server_url="http://localhost:8000/v1",
+        server_url=DEFAULT_SERVER_URL,
         api_params=FunctionCallingConfig(),
     )
     model_config_dict = model_config.__dict__
@@ -109,7 +129,7 @@ def test_open_source_model_invalid_model_path():
     model_path = "vicuna-7b-v1.5"
     model_config = OpenSourceConfig(
         model_path=model_path,
-        server_url="http://localhost:8000/v1",
+        server_url=DEFAULT_SERVER_URL,
     )
     model_config_dict = model_config.__dict__
 
@@ -127,7 +147,7 @@ def test_open_source_model_unmatched_model_path():
     model_path = MODEL_PATH_MAP[ModelType.VICUNA]
     model_config = OpenSourceConfig(
         model_path=model_path,
-        server_url="http://localhost:8000/v1",
+        server_url=DEFAULT_SERVER_URL,
     )
     model_config_dict = model_config.__dict__
 
@@ -143,7 +163,7 @@ def test_open_source_model_missing_model_path():
     model_type = ModelType.VICUNA
     model_config = OpenSourceConfig(
         model_path=None,
-        server_url="http://localhost:8000/v1",
+        server_url=DEFAULT_SERVER_URL,
     )
     model_config_dict = model_config.__dict__
 


### PR DESCRIPTION
## Description

Add a new test function to cover method `run` of open-source models. This will firstly detect whether the server is running on the default URL (by checking whether the port is open) and will skip this test if the port is closed (for currently no automatic launching functionality). 
The coverage for open-source model class is now 94%.

![VT26~MQIM(RUPZVW~N~M2S5](https://github.com/camel-ai/camel/assets/55635778/dedd5a05-bf8f-4af4-82e9-52ad976ad56f)

## Motivation and Context

Why is this change required? What problem does it solve?
close #286 
- [x] I have raised an issue to propose this change ([required](https://github.com/camel-ai/camel/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of example)

## Implemented Tasks

- [ ] Subtask 1
- [ ] Subtask 2
- [ ] Subtask 3

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide. (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation accordingly.
