### PR TITLE
Improve function calling implementation (#279)

### DIFF
--- a/camel/utils/functions.py
+++ b/camel/utils/functions.py
@@ -18,20 +18,11 @@ import socket
 import time
 import zipfile
 from functools import wraps
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    List,
-    Optional,
-    Set,
-    Tuple,
-    TypeVar,
-    cast,
-)
+from typing import Any, Callable, Dict, List, Optional, Set, TypeVar, cast
 from urllib.parse import urlparse
 
 import requests
+from docstring_parser import parse
 
 from camel.typing import ModelType, TaskType
 
@@ -151,55 +142,56 @@ def parse_doc(func: Callable) -> Dict[str, Any]:
         Dict[str, Any]: A dictionary with the function's name,
             description, and parameters.
     """
-
-    doc = inspect.getdoc(func)
-    if not doc:
+    if not func.__doc__:
         raise ValueError(
             f"Invalid function {func.__name__}: no docstring provided.")
+    try:
+        docstring = parse(func.__doc__)
+    except Exception:
+        raise ValueError(
+            f"Invalid docstring {func.__name__}: Currently only support ReST, "
+            f"Google, Numpydoc-style and Epydoc docstring style.")
+
+    func_description = docstring.short_description
+    if not func_description:
+        raise ValueError(f"Invalid function {func.__name__}: "
+                         f"no function description provided.")
+
+    # https://platform.openai.com/docs/api-reference/chat/create#functions
+    signature = inspect.signature(func)
+
+    required = []
+    for param_name, param in signature.parameters.items():
+        if param.default == inspect.Parameter.empty:
+            required.append(param_name)
 
     properties = {}
-    required = []
+    for param in docstring.params:
+        if param.arg_name in required:
+            if param.description:
+                properties[param.arg_name] = {
+                    "type": param.type_name,
+                    "description": param.description,
+                }
+            else:
+                raise ValueError(f"Miss description for "
+                                 f"parameter '{param.arg_name}'")
 
-    parts = re.split(r'\n\s*\n', doc)
-    func_desc = parts[0].strip()
-
-    args_section = next((p for p in parts if 'Args:' in p), None)
-    if args_section:
-        args_descs: List[Tuple[str, str, str, ]] = re.findall(
-            r'(\w+)\s*\((\w+)\):\s*(.*)', args_section)
-        properties = {
-            name.strip(): {
-                'type': type,
-                'description': desc
-            }
-            for name, type, desc in args_descs
-        }
-        for name in properties:
-            required.append(name)
-
-    # Parameters from the function signature
-    sign_params = list(inspect.signature(func).parameters.keys())
-    if len(sign_params) != len(required):
-        raise ValueError(
-            f"Number of parameters in function signature ({len(sign_params)})"
-            f" does not match that in docstring ({len(required)}).")
-
-    for param in sign_params:
-        if param not in required:
-            raise ValueError(f"Parameter '{param}' in function signature"
+    for param_name in required:
+        if param_name not in properties.keys():
+            raise ValueError(f"Parameter '{param_name}' in function signature"
                              " is missing in the docstring.")
 
-    parameters = {
-        "type": "object",
-        "properties": properties,
-        "required": required,
-    }
-
-    # Construct the function dictionary
+    # Construct the function dictionary according to
+    # https://platform.openai.com/docs/api-reference/chat/create#functions
     function_dict = {
         "name": func.__name__,
-        "description": func_desc,
-        "parameters": parameters,
+        "description": docstring.short_description,
+        "parameters": {
+            "type": "object",
+            "properties": properties,
+            "required": required,
+        }
     }
 
     return function_dict

--- a/poetry.lock
+++ b/poetry.lock
@@ -554,6 +554,7 @@ files = [
     {file = "contourpy-1.1.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:18a64814ae7bce73925131381603fff0116e2df25230dfc80d6d690aa6e20b37"},
     {file = "contourpy-1.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90c81f22b4f572f8a2110b0b741bb64e5a6427e0a198b2cdc1fbaf85f352a3aa"},
     {file = "contourpy-1.1.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:53cc3a40635abedbec7f1bde60f8c189c49e84ac180c665f2cd7c162cc454baa"},
+    {file = "contourpy-1.1.0-cp310-cp310-win32.whl", hash = "sha256:9b2dd2ca3ac561aceef4c7c13ba654aaa404cf885b187427760d7f7d4c57cff8"},
     {file = "contourpy-1.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:1f795597073b09d631782e7245016a4323cf1cf0b4e06eef7ea6627e06a37ff2"},
     {file = "contourpy-1.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0b7b04ed0961647691cfe5d82115dd072af7ce8846d31a5fac6c142dcce8b882"},
     {file = "contourpy-1.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:27bc79200c742f9746d7dd51a734ee326a292d77e7d94c8af6e08d1e6c15d545"},
@@ -562,6 +563,7 @@ files = [
     {file = "contourpy-1.1.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5cec36c5090e75a9ac9dbd0ff4a8cf7cecd60f1b6dc23a374c7d980a1cd710e"},
     {file = "contourpy-1.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1f0cbd657e9bde94cd0e33aa7df94fb73c1ab7799378d3b3f902eb8eb2e04a3a"},
     {file = "contourpy-1.1.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:181cbace49874f4358e2929aaf7ba84006acb76694102e88dd15af861996c16e"},
+    {file = "contourpy-1.1.0-cp311-cp311-win32.whl", hash = "sha256:edb989d31065b1acef3828a3688f88b2abb799a7db891c9e282df5ec7e46221b"},
     {file = "contourpy-1.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:fb3b7d9e6243bfa1efb93ccfe64ec610d85cfe5aec2c25f97fbbd2e58b531256"},
     {file = "contourpy-1.1.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:bcb41692aa09aeb19c7c213411854402f29f6613845ad2453d30bf421fe68fed"},
     {file = "contourpy-1.1.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:5d123a5bc63cd34c27ff9c7ac1cd978909e9c71da12e05be0231c608048bb2ae"},
@@ -570,6 +572,7 @@ files = [
     {file = "contourpy-1.1.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:317267d915490d1e84577924bd61ba71bf8681a30e0d6c545f577363157e5e94"},
     {file = "contourpy-1.1.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d551f3a442655f3dcc1285723f9acd646ca5858834efeab4598d706206b09c9f"},
     {file = "contourpy-1.1.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:e7a117ce7df5a938fe035cad481b0189049e8d92433b4b33aa7fc609344aafa1"},
+    {file = "contourpy-1.1.0-cp38-cp38-win32.whl", hash = "sha256:108dfb5b3e731046a96c60bdc46a1a0ebee0760418951abecbe0fc07b5b93b27"},
     {file = "contourpy-1.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:d4f26b25b4f86087e7d75e63212756c38546e70f2a92d2be44f80114826e1cd4"},
     {file = "contourpy-1.1.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:bc00bb4225d57bff7ebb634646c0ee2a1298402ec10a5fe7af79df9a51c1bfd9"},
     {file = "contourpy-1.1.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:189ceb1525eb0655ab8487a9a9c41f42a73ba52d6789754788d1883fb06b2d8a"},
@@ -578,6 +581,7 @@ files = [
     {file = "contourpy-1.1.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:143dde50520a9f90e4a2703f367cf8ec96a73042b72e68fcd184e1279962eb6f"},
     {file = "contourpy-1.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e94bef2580e25b5fdb183bf98a2faa2adc5b638736b2c0a4da98691da641316a"},
     {file = "contourpy-1.1.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:ed614aea8462735e7d70141374bd7650afd1c3f3cb0c2dbbcbe44e14331bf002"},
+    {file = "contourpy-1.1.0-cp39-cp39-win32.whl", hash = "sha256:71551f9520f008b2950bef5f16b0e3587506ef4f23c734b71ffb7b89f8721999"},
     {file = "contourpy-1.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:438ba416d02f82b692e371858143970ed2eb6337d9cdbbede0d8ad9f3d7dd17d"},
     {file = "contourpy-1.1.0-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:a698c6a7a432789e587168573a864a7ea374c6be8d4f31f9d87c001d5a843493"},
     {file = "contourpy-1.1.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:397b0ac8a12880412da3551a8cb5a187d3298a72802b45a3bd1805e204ad8439"},
@@ -770,6 +774,17 @@ python-versions = "*"
 files = [
     {file = "distlib-0.3.7-py2.py3-none-any.whl", hash = "sha256:2e24928bc811348f0feb63014e97aaae3037f2cf48712d51ae61df7fd6075057"},
     {file = "distlib-0.3.7.tar.gz", hash = "sha256:9dafe54b34a028eafd95039d5e5d4851a13734540f1331060d31c9916e7147a8"},
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.15"
+description = "Parse Python docstrings in reST, Google and Numpydoc format"
+optional = false
+python-versions = ">=3.6,<4.0"
+files = [
+    {file = "docstring_parser-0.15-py3-none-any.whl", hash = "sha256:d1679b86250d269d06a99670924d6bce45adc00b08069dae8c47d98e89b667a9"},
+    {file = "docstring_parser-0.15.tar.gz", hash = "sha256:48ddc093e8b1865899956fcc03b03e66bb7240c310fac5af81814580c55bf682"},
 ]
 
 [[package]]
@@ -1482,6 +1497,16 @@ files = [
     {file = "MarkupSafe-2.1.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:5bbe06f8eeafd38e5d0a4894ffec89378b6c6a625ff57e3028921f8ff59318ac"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win32.whl", hash = "sha256:dd15ff04ffd7e05ffcb7fe79f1b98041b8ea30ae9234aed2a9168b5797c3effb"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win_amd64.whl", hash = "sha256:134da1eca9ec0ae528110ccc9e48041e0828d79f24121a1a146161103c76e686"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:f698de3fd0c4e6972b92290a45bd9b1536bffe8c6759c62471efaa8acb4c37bc"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:aa57bd9cf8ae831a362185ee444e15a93ecb2e344c8e52e4d721ea3ab6ef1823"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffcc3f7c66b5f5b7931a5aa68fc9cecc51e685ef90282f4a82f0f5e9b704ad11"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47d4f1c5f80fc62fdd7777d0d40a2e9dda0a05883ab11374334f6c4de38adffd"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1f67c7038d560d92149c060157d623c542173016c4babc0c1913cca0564b9939"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:9aad3c1755095ce347e26488214ef77e0485a3c34a50c5a5e2471dff60b9dd9c"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:14ff806850827afd6b07a5f32bd917fb7f45b046ba40c57abdb636674a8b559c"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8f9293864fe09b8149f0cc42ce56e3f0e54de883a9de90cd427f191c346eb2e1"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-win32.whl", hash = "sha256:715d3562f79d540f251b99ebd6d8baa547118974341db04f5ad06d5ea3eb8007"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-win_amd64.whl", hash = "sha256:1b8dd8c3fd14349433c79fa8abeb573a55fc0fdd769133baac1f5e07abf54aeb"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8e254ae696c88d98da6555f5ace2279cf7cd5b3f52be2b5cf97feafe883b58d2"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb0932dc158471523c9637e807d9bfb93e06a95cbf010f1a38b98623b929ef2b"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9402b03f1a1b4dc4c19845e5c749e3ab82d5078d16a2a4c2cd2df62d57bb0707"},
@@ -1931,11 +1956,11 @@ files = [
 [package.dependencies]
 numpy = [
     {version = ">=1.21.0", markers = "python_version <= \"3.9\" and platform_system == \"Darwin\" and platform_machine == \"arm64\" and python_version >= \"3.8\""},
-    {version = ">=1.19.3", markers = "platform_system == \"Linux\" and platform_machine == \"aarch64\" and python_version >= \"3.8\" and python_version < \"3.10\" or python_version > \"3.9\" and python_version < \"3.10\" or python_version >= \"3.9\" and platform_system != \"Darwin\" and python_version < \"3.10\" or python_version >= \"3.9\" and platform_machine != \"arm64\" and python_version < \"3.10\""},
-    {version = ">=1.17.3", markers = "(platform_system != \"Darwin\" and platform_system != \"Linux\") and python_version >= \"3.8\" and python_version < \"3.9\" or platform_system != \"Darwin\" and python_version >= \"3.8\" and python_version < \"3.9\" and platform_machine != \"aarch64\" or platform_machine != \"arm64\" and python_version >= \"3.8\" and python_version < \"3.9\" and platform_system != \"Linux\" or (platform_machine != \"arm64\" and platform_machine != \"aarch64\") and python_version >= \"3.8\" and python_version < \"3.9\""},
+    {version = ">=1.23.5", markers = "python_version >= \"3.11\""},
     {version = ">=1.21.4", markers = "python_version >= \"3.10\" and platform_system == \"Darwin\" and python_version < \"3.11\""},
     {version = ">=1.21.2", markers = "platform_system != \"Darwin\" and python_version >= \"3.10\" and python_version < \"3.11\""},
-    {version = ">=1.23.5", markers = "python_version >= \"3.11\""},
+    {version = ">=1.19.3", markers = "platform_system == \"Linux\" and platform_machine == \"aarch64\" and python_version >= \"3.8\" and python_version < \"3.10\" or python_version > \"3.9\" and python_version < \"3.10\" or python_version >= \"3.9\" and platform_system != \"Darwin\" and python_version < \"3.10\" or python_version >= \"3.9\" and platform_machine != \"arm64\" and python_version < \"3.10\""},
+    {version = ">=1.17.3", markers = "(platform_system != \"Darwin\" and platform_system != \"Linux\") and python_version >= \"3.8\" and python_version < \"3.9\" or platform_system != \"Darwin\" and python_version >= \"3.8\" and python_version < \"3.9\" and platform_machine != \"aarch64\" or platform_machine != \"arm64\" and python_version >= \"3.8\" and python_version < \"3.9\" and platform_system != \"Linux\" or (platform_machine != \"arm64\" and platform_machine != \"aarch64\") and python_version >= \"3.8\" and python_version < \"3.9\""},
 ]
 
 [[package]]
@@ -2055,8 +2080,8 @@ files = [
 [package.dependencies]
 numpy = [
     {version = ">=1.20.3", markers = "python_version < \"3.10\""},
-    {version = ">=1.21.0", markers = "python_version >= \"3.10\" and python_version < \"3.11\""},
     {version = ">=1.23.2", markers = "python_version >= \"3.11\""},
+    {version = ">=1.21.0", markers = "python_version >= \"3.10\" and python_version < \"3.11\""},
 ]
 python-dateutil = ">=2.8.2"
 pytz = ">=2020.1"
@@ -4117,4 +4142,4 @@ huggingface-agent = ["accelerate", "datasets", "diffusers", "opencv-python", "se
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.1"
-content-hash = "ef8ff37a1b548adebcf6eadabd284867344f03bc388a94b074c1e9dc89db2bbc"
+content-hash = "4d7b75ae0edccdf4b579e7b53d339270c735b432e1c78d0d9c99bcabf769d84e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ soundfile = { version = "^0", optional = true }
 sentencepiece = { version = "^0", optional = true }
 opencv-python = { version = "^4", optional = true }
 wikipedia = { version = "^1", optional = true }
+docstring-parser = "^0.15"
 
 [tool.poetry.extras]
 huggingface-agent = [

--- a/test/utils/test_parse_doc.py
+++ b/test/utils/test_parse_doc.py
@@ -18,7 +18,7 @@ from camel.utils import parse_doc
 
 def test_parse_doc_valid():
 
-    def add(a, b):
+    def add_google_style(a, b):
         """Adds two numbers.
 
         Args:
@@ -27,8 +27,70 @@ def test_parse_doc_valid():
         """
         return a + b
 
-    parsed = parse_doc(add)
-    assert parsed['name'] == 'add'
+    parsed = parse_doc(add_google_style)
+    assert parsed['name'] == 'add_google_style'
+    assert parsed['description'] == 'Adds two numbers.'
+    assert parsed['parameters']['properties']['a']['type'] == 'int'
+    assert parsed['parameters']['properties']['b']['type'] == 'int'
+
+    def add_rest_style(a, b):
+        """
+        Adds two numbers.
+
+        :param a: The first number to be added.
+        :type a: int
+        :param b: The second number to be added.
+        :type b: int
+        :return: The sum of the two numbers.
+        :rtype: int
+        """
+        return a + b
+
+    parsed = parse_doc(add_rest_style)
+    assert parsed['name'] == 'add_rest_style'
+    assert parsed['description'] == 'Adds two numbers.'
+    assert parsed['parameters']['properties']['a']['type'] == 'int'
+    assert parsed['parameters']['properties']['b']['type'] == 'int'
+
+    def add_numpy_style(a, b):
+        """
+        Adds two numbers.
+
+        Parameters
+        ----------
+        a : int
+            The first number to be added.
+        b : int
+            The second number to be added.
+
+        Returns
+        -------
+        int
+            The sum of the two numbers.
+        """
+        return a + b
+
+    parsed = parse_doc(add_numpy_style)
+    assert parsed['name'] == 'add_numpy_style'
+    assert parsed['description'] == 'Adds two numbers.'
+    assert parsed['parameters']['properties']['a']['type'] == 'int'
+    assert parsed['parameters']['properties']['b']['type'] == 'int'
+
+    def add_epydoc_style(a, b):
+        """
+        Adds two numbers.
+
+        @param a: The first number to be added.
+        @type a: int
+        @param b: The second number to be added.
+        @type b: int
+        @return: The sum of the two numbers.
+        @rtype: int
+        """
+        return a + b
+
+    parsed = parse_doc(add_epydoc_style)
+    assert parsed['name'] == 'add_epydoc_style'
     assert parsed['description'] == 'Adds two numbers.'
     assert parsed['parameters']['properties']['a']['type'] == 'int'
     assert parsed['parameters']['properties']['b']['type'] == 'int'
@@ -57,13 +119,9 @@ def test_parse_doc_mismatch():
         return a * b * c
 
     with pytest.raises(
-            ValueError,
-            match=(r"Number of parameters in function signature "
-                   r"\(3\) does not match that in docstring \(2\).")):
+            ValueError, match="Parameter 'c' in function signature" +
+            " is missing in the docstring."):
         parse_doc(mul)
-
-
-def test_parse_doc_no_args_section():
 
     def return_param(a):
         """Return the parameter.
@@ -74,6 +132,19 @@ def test_parse_doc_no_args_section():
         return a
 
     with pytest.raises(
-            ValueError, match=("Parameter 'a' in function signature"
-                               " is missing in the docstring.")):
+            ValueError, match="Parameter 'a' in function signature" +
+            " is missing in the docstring."):
         parse_doc(return_param)
+
+
+def test_parse_doc_with_default_parameter():
+
+    def add_default(a, b=1):
+        """Return the parameter.
+            Args:
+                a (int): The first number to be added.
+                b (int): The second default number to be added.
+        """
+        return a + b
+
+    parse_doc(add_default)


### PR DESCRIPTION
## Description
As #279 metioned, the current function calling is implemented by parsing the docstring to JSON schema which causes inconsistency in docstring styles. The current function only supports the Google docstring style. For compatibility with more styles of docstring, I reimplemented the `parse_doc `function using the `docstring-parser` package which supports ReST, Google, Numpydoc-style and Epydoc docstrings.

## Motivation and Context
close #279 

- [ ] I have raised an issue to propose this change ([required](https://github.com/camel-ai/camel/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of example)

## Implemented Tasks

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide. (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation accordingly.
