### PR TITLE
Fix typo in `value_for_tiktoken`

### DIFF
--- a/camel/types/enums.py
+++ b/camel/types/enums.py
@@ -39,7 +39,7 @@ class ModelType(Enum):
 
     @property
     def value_for_tiktoken(self) -> str:
-        return self.value if self is ModelType.STUB else "gpt-3.5-turbo"
+        return self.value if self is not ModelType.STUB else "gpt-3.5-turbo"
 
     @property
     def is_openai(self) -> bool:


### PR DESCRIPTION
## Description

Fix typo in `value_for_tiktoken`

