### PR TITLE
fix/retriever_module_follow_LSP

### DIFF
--- a/camel/retrievers/auto_retriever.py
+++ b/camel/retrievers/auto_retriever.py
@@ -252,10 +252,12 @@ class AutoRetriever():
                     # Clear the vector storage
                     vector_storage_instance.clear()
                     # Process and store the content to the vector storage
-                    vr.process(content_input_path, vector_storage_instance)
+                    vr = VectorRetriever(storage=vector_storage_instance)
+                    vr.process(content_input_path)
+                vr = VectorRetriever(storage=vector_storage_instance,
+                                     similarity_threshold=similarity_threshold)
                 # Retrieve info by given query from the vector storage
-                retrieved_info = vr.query(query, vector_storage_instance,
-                                          top_k, similarity_threshold)
+                retrieved_info = vr.query(query, top_k)
                 # Reorganize the retrieved info with original query
                 for info in retrieved_info:
                     retrieved_infos += "\n" + str(info)

--- a/camel/retrievers/base.py
+++ b/camel/retrievers/base.py
@@ -28,7 +28,7 @@ class BaseRetriever(ABC):
 
     @abstractmethod
     def process(self, content_input_path: str,
-                chunk_type: str = "chunk_by_title", **kwargs: Any) -> None:
+                chunk_type: str = "chunk_by_title") -> None:
         r"""Processes content from a file or URL, divides it into chunks by
         using `Unstructured IO`,then stored internally. This method must be
         called before executing queries with the retriever.
@@ -38,13 +38,12 @@ class BaseRetriever(ABC):
                 processed.
             chunk_type (str): Type of chunking going to apply. Defaults to
                 "chunk_by_title".
-            **kwargs (Any): Additional keyword arguments for content parsing.
         """
         pass
 
     @abstractmethod
-    def query(self, query: str, top_k: int = DEFAULT_TOP_K_RESULTS,
-              **kwargs: Any) -> List[Dict[str, Any]]:
+    def query(self, query: str,
+              top_k: int = DEFAULT_TOP_K_RESULTS) -> List[Dict[str, Any]]:
         r"""Query the results. Subclasses should implement this
         method according to their specific needs.
 
@@ -53,7 +52,5 @@ class BaseRetriever(ABC):
             top_k (int, optional): The number of top results to return during
                 retriever. Must be a positive integer. Defaults to
                 `DEFAULT_TOP_K_RESULTS`.
-            **kwargs (Any): Flexible keyword arguments for additional
-                parameters, like `similarity_threshold`.
         """
         pass

--- a/camel/retrievers/bm25_retriever.py
+++ b/camel/retrievers/bm25_retriever.py
@@ -56,7 +56,7 @@ class BM25Retriever(BaseRetriever):
         self.chunks: List[Any] = []
 
     def process(self, content_input_path: str,
-                chunk_type: str = "chunk_by_title", **kwargs: Any) -> None:
+                chunk_type: str = "chunk_by_title") -> None:
         r"""Processes content from a file or URL, divides it into chunks by
         using `Unstructured IO`,then stored internally. This method must be
         called before executing queries with the retriever.
@@ -66,15 +66,13 @@ class BM25Retriever(BaseRetriever):
                 processed.
             chunk_type (str): Type of chunking going to apply. Defaults to
                 "chunk_by_title".
-            **kwargs (Any): Additional keyword arguments for content parsing.
         """
         from rank_bm25 import BM25Okapi
 
         # Load and preprocess documents
         self.content_input_path = content_input_path
         unstructured_modules = UnstructuredIO()
-        elements = unstructured_modules.parse_file_or_url(
-            content_input_path, **kwargs)
+        elements = unstructured_modules.parse_file_or_url(content_input_path)
         self.chunks = unstructured_modules.chunk_elements(
             chunk_type=chunk_type, elements=elements)
 
@@ -82,7 +80,7 @@ class BM25Retriever(BaseRetriever):
         tokenized_corpus = [str(chunk).split(" ") for chunk in self.chunks]
         self.bm25 = BM25Okapi(tokenized_corpus)
 
-    def query(  # type: ignore
+    def query(
         self,
         query: str,
         top_k: int = DEFAULT_TOP_K_RESULTS,

--- a/camel/storages/vectordb_storages/qdrant.py
+++ b/camel/storages/vectordb_storages/qdrant.py
@@ -180,7 +180,9 @@ class QdrantStorage(BaseVectorStorage):
             VectorDistance.COSINE: Distance.COSINE,
             VectorDistance.EUCLIDEAN: Distance.EUCLID,
         }
-        self._client.recreate_collection(
+        # `recreate_collection` method will be removed in the future by
+        # Qdrant.
+        self._client.create_collection(
             collection_name=collection_name,
             vectors_config=VectorParams(
                 size=size,

--- a/test/retrievers/test_bm25_retriever.py
+++ b/test/retrievers/test_bm25_retriever.py
@@ -26,20 +26,30 @@ def test_bm25retriever_initialization():
     assert retriever.chunks == []
 
 
-@patch('camel.loaders.UnstructuredIO')
-def test_process(mock_unstructured_modules):
-    mock_unstructured_modules.return_value.parse_file_or_url.return_value = [
-        'Your parsed content'
-    ]
-    mock_unstructured_modules.return_value.chunk_elements.return_value = [
-        'Chunk 1', 'Chunk 2'
-    ]
+@pytest.fixture
+def bm25_retriever():
+    return BM25Retriever()
 
-    retriever = BM25Retriever()
-    retriever.process('https://www.camel-ai.org/')
 
-    assert retriever.content_input_path == 'https://www.camel-ai.org/'
-    assert len(retriever.chunks) == 4
+@patch('camel.retrievers.bm25_retriever.UnstructuredIO')
+def test_process(mock_unstructured_modules, bm25_retriever):
+    # Create a mock chunk with metadata
+    mock_chunk = MagicMock()
+    mock_chunk.metadata.to_dict.return_value = {'mock_key': 'mock_value'}
+
+    # Setup mock behavior
+    mock_unstructured_instance = mock_unstructured_modules.return_value
+    mock_unstructured_instance.parse_file_or_url.return_value = [
+        "mock_element"
+    ]
+    mock_unstructured_instance.chunk_elements.return_value = [mock_chunk]
+
+    bm25_retriever.process(content_input_path="mock_path")
+
+    # Assert that methods are called as expected
+    mock_unstructured_instance.parse_file_or_url.assert_called_once_with(
+        "mock_path")
+    mock_unstructured_instance.chunk_elements.assert_called_once()
 
 
 @patch('camel.retrievers.BM25Retriever')


### PR DESCRIPTION
## Description

1. The original design of vector retriever didn't follow Liskov Substitution Principle
2. `recreate_collection` method will be removed in the future by Qdrant.
3. test of bm25_retriever is making real http request, which is slow

## Motivation and Context
1. refactor the retriever module, move storage into attribute, make the class follow Liskov Substitution Principle
2. use `create_collection` instead of `recreate_collection` in Qdrant module
3. use mock to do the pytest

- [ ] I have raised an issue to propose this change ([required](https://github.com/camel-ai/camel/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of example)

## Implemented Tasks

- [ ] Subtask 1
- [ ] Subtask 2
- [ ] Subtask 3

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ ] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide. (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation accordingly.
