### PR TITLE
fix: add anthropic message_to_prompt part back

### DIFF
--- a/camel/utils/token_counting.py
+++ b/camel/utils/token_counting.py
@@ -93,6 +93,32 @@ def messages_to_prompt(messages: List[OpenAIMessage], model: ModelType) -> str:
             else:
                 ret += role + ":"
         return ret
+    elif model.is_anthropic:
+        # use XML tag to decorate prompt
+        # https://docs.anthropic.com/claude/docs/constructing-a-prompt#mark-different-parts-of-the-prompt
+        # https://docs.anthropic.com/claude/docs/roleplay-dialogue
+        # https://docs.anthropic.com/claude/docs/human-and-assistant-formatting
+        from anthropic import AI_PROMPT, HUMAN_PROMPT
+
+        system_message = str(system_message)
+        ret = f"\n{system_message}\n"
+        for msg in messages[1:]:
+            role, content = msg["role"], msg["content"]
+            # Claude does not perform well if the system message RULE OF USER/ASSISTANT is sent twice. (see role_playing/RolePlaying.init_chat())
+            # Here is a special treatment for Claude to remove the redundant system message.
+            if not isinstance(content, str):
+                raise ValueError(
+                    "Currently multimodal context is not "
+                    "supported by the token counter."
+                )
+            if content.startswith(system_message):
+                ret = content
+                continue
+            if role == "user":
+                ret += f"{HUMAN_PROMPT} {content}"
+            elif role == "assisstant":
+                ret += f"{AI_PROMPT} {content}"
+        return ret
     else:
         raise ValueError(f"Invalid model type: {model}")
 


### PR DESCRIPTION
## Description

issue: https://github.com/camel-ai/camel/pull/288/files#r1614789022

## Motivation and Context


- [ ] I have raised an issue to propose this change ([required](https://github.com/camel-ai/camel/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of example)

## Implemented Tasks

- [ ] Subtask 1
- [ ] Subtask 2
- [ ] Subtask 3

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ ] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide. (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation accordingly.
