### PR TITLE
fix: Resolve Open Source Model Initialization in model_factory.py

### DIFF
--- a/camel/models/model_factory.py
+++ b/camel/models/model_factory.py
@@ -61,5 +61,9 @@ class ModelFactory:
         else:
             raise ValueError(f"Unknown model type `{model_type}` is input")
 
-        inst = model_class(model_type, model_config_dict, api_key)
+        if model_type.is_open_source:
+            inst = model_class(model_type, model_config_dict)
+        else:
+            inst = model_class(model_type, model_config_dict, api_key)
+
         return inst


### PR DESCRIPTION
## Description

Add a if judgement at the end of model_factory.py. If the model type is open source model, do not pass api_key to the initialization. Otherwise, pass api_key to the initialization since I find out that recently, all other models' initialization contains api key.

## Motivation and Context

close #645 

- [x] I have raised an issue to propose this change ([required](https://github.com/camel-ai/camel/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of example)

## Implemented Tasks

- [ ] Subtask 1
- [ ] Subtask 2
- [ ] Subtask 3

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide. (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation accordingly.
