### PR TITLE
feat: allow users self setting token counter from ModelFactory #589

### DIFF
--- a/camel/models/litellm_model.py
+++ b/camel/models/litellm_model.py
@@ -28,6 +28,7 @@ class LiteLLMModel:
         self,
         model_type: str,
         model_config_dict: Dict[str, Any],
+        token_counter: Optional[LiteLLMTokenCounter] = None,
         api_key: Optional[str] = None,
         url: Optional[str] = None,
     ) -> None:
@@ -46,7 +47,7 @@ class LiteLLMModel:
         self.model_type = model_type
         self.model_config_dict = model_config_dict
         self._client = None
-        self._token_counter: Optional[LiteLLMTokenCounter] = None
+        self._token_counter = token_counter
         self.check_model_config()
         self._url = url
         self._api_key = api_key

--- a/camel/models/ollama_model.py
+++ b/camel/models/ollama_model.py
@@ -28,6 +28,7 @@ class OllamaModel:
         self,
         model_type: str,
         model_config_dict: Dict[str, Any],
+        token_counter: Optional[BaseTokenCounter] = None,
         url: Optional[str] = None,
     ) -> None:
         r"""Constructor for Ollama backend with OpenAI compatibility.
@@ -50,7 +51,7 @@ class OllamaModel:
             base_url=url,
             api_key="ollama",  # required but ignored
         )
-        self._token_counter: Optional[BaseTokenCounter] = None
+        self._token_counter = token_counter
         self.check_model_config()
 
     @property
@@ -61,7 +62,7 @@ class OllamaModel:
             BaseTokenCounter: The token counter following the model's
                 tokenization style.
         """
-        # NOTE: Use OpenAITokenCounter temporarily
+        # NOTE: Use OpenAITokenCounter temporarily. If other token counter is used for OllamaModel in the future, OpenAITokenCounter(ModelType.GPT_3_5_TURBO) will be the default token counter if the specific token counter is not provided.
         if not self._token_counter:
             self._token_counter = OpenAITokenCounter(ModelType.GPT_3_5_TURBO)
         return self._token_counter

--- a/camel/models/zhipuai_model.py
+++ b/camel/models/zhipuai_model.py
@@ -35,6 +35,7 @@ class ZhipuAIModel(BaseModelBackend):
         self,
         model_type: ModelType,
         model_config_dict: Dict[str, Any],
+        token_counter: Optional[BaseTokenCounter] = None,
         api_key: Optional[str] = None,
         url: Optional[str] = None,
     ) -> None:
@@ -63,7 +64,7 @@ class ZhipuAIModel(BaseModelBackend):
             api_key=self._api_key,
             base_url=self._url,
         )
-        self._token_counter: Optional[BaseTokenCounter] = None
+        self._token_counter = token_counter
 
     @api_keys_required("ZHIPUAI_API_KEY")
     def run(
@@ -100,7 +101,7 @@ class ZhipuAIModel(BaseModelBackend):
         """
 
         if not self._token_counter:
-            # It's a temporary setting for token counter.
+            # NOTE: It's a temporary setting for token counter. If other token counter is used for ZhipuAIModel in the future, OpenAITokenCounter(ModelType.GPT_3_5_TURBO) will be the default token counter if the specific token counter is not provided.
             self._token_counter = OpenAITokenCounter(ModelType.GPT_3_5_TURBO)
         return self._token_counter
 

--- a/camel/utils/token_counting.py
+++ b/camel/utils/token_counting.py
@@ -232,6 +232,7 @@ class OpenAITokenCounter(BaseTokenCounter):
             model (ModelType): Model type for which tokens will be counted.
         """
         self.model: str = model.value_for_tiktoken
+        self.model_type = model
 
         self.tokens_per_message: int
         self.tokens_per_name: int

--- a/test/models/test_model_factory.py
+++ b/test/models/test_model_factory.py
@@ -13,9 +13,11 @@
 # =========== Copyright 2023 @ CAMEL-AI.org. All Rights Reserved. ===========
 import pytest
 
-from camel.configs import ChatGPTConfig
+from camel.configs import *
 from camel.models import ModelFactory
+from camel.models.stub_model import StubTokenCounter
 from camel.types import ModelPlatformType, ModelType
+from camel.utils import *
 
 parametrize = pytest.mark.parametrize(
     'model_platform, model_type',
@@ -23,6 +25,46 @@ parametrize = pytest.mark.parametrize(
         (ModelPlatformType.OPENAI, ModelType.GPT_3_5_TURBO),
         (ModelPlatformType.OPENAI, ModelType.GPT_4_TURBO),
         (ModelPlatformType.OPENSOURCE, ModelType.STUB),
+    ],
+)
+
+parameterize_token_counter = pytest.mark.parametrize(
+    'model_platform, model_type, model_config_dict, token_counter, expected_counter_type, expected_model_type',
+    [
+        # Test OpenAI model
+        (ModelPlatformType.OPENAI, ModelType.GPT_3_5_TURBO, ChatGPTConfig().__dict__, None, OpenAITokenCounter, ModelType.GPT_3_5_TURBO),
+        (ModelPlatformType.OPENAI, ModelType.GPT_4, ChatGPTConfig().__dict__, None, OpenAITokenCounter, ModelType.GPT_4),
+
+        # Test Stub model
+        # Stub model uses StubTokenCounter as default
+        (ModelPlatformType.OPENSOURCE, ModelType.STUB, ChatGPTConfig().__dict__, None, StubTokenCounter, None),
+        (ModelPlatformType.OPENSOURCE, ModelType.STUB, ChatGPTConfig().__dict__, OpenAITokenCounter(ModelType.GPT_4), OpenAITokenCounter, ModelType.GPT_4),
+
+        # Test Anthropic model
+        # Anthropic model uses AnthropicTokenCounter as default
+        (ModelPlatformType.ANTHROPIC, ModelType.CLAUDE_2_0, AnthropicConfig().__dict__, None, AnthropicTokenCounter, ModelType.CLAUDE_2_0),
+        (ModelPlatformType.ANTHROPIC, ModelType.CLAUDE_2_0, AnthropicConfig().__dict__, OpenAITokenCounter(ModelType.GPT_3_5_TURBO), OpenAITokenCounter, ModelType.GPT_3_5_TURBO),
+
+        # Test OpenSource model (take VICUNA as an example)
+        (ModelPlatformType.OPENSOURCE, ModelType.VICUNA,
+         OpenSourceConfig(
+            model_path="lmsys/vicuna-7b-v1.5",
+            server_url="http://localhost:8000/v1",
+         ).__dict__,
+         None, OpenSourceTokenCounter, ModelType.VICUNA
+        ),
+
+        (ModelPlatformType.OPENSOURCE, ModelType.VICUNA,
+         OpenSourceConfig(
+             model_path="lmsys/vicuna-7b-v1.5",
+             server_url="http://localhost:8000/v1",
+         ).__dict__,
+         OpenAITokenCounter(ModelType.GPT_4), OpenAITokenCounter, ModelType.GPT_4
+        ),
+
+        # Test Ollama model
+        (ModelPlatformType.OLLAMA, "gpt-3.5-turbo", OllamaConfig().__dict__, None, OpenAITokenCounter, ModelType.GPT_3_5_TURBO),
+        (ModelPlatformType.OLLAMA, "gpt-3.5-turbo", OllamaConfig().__dict__, OpenAITokenCounter(ModelType.GPT_4), OpenAITokenCounter, ModelType.GPT_4),
     ],
 )
 
@@ -63,3 +105,23 @@ def test_model_factory(model_platform, model_type):
     assert 'role' in message
     assert isinstance(message['role'], str)
     assert message['role'] == 'assistant'
+
+
+@parameterize_token_counter
+def test_model_factory_self_set_token_counter(
+    model_platform,
+    model_type,
+    model_config_dict,
+    token_counter,
+    expected_counter_type,
+    expected_model_type,
+):
+    model_inst = ModelFactory.create(
+        model_platform=model_platform,
+        model_type=model_type,
+        token_counter=token_counter,
+        model_config_dict=model_config_dict,
+    )
+    assert isinstance(model_inst.token_counter, expected_counter_type)
+    if hasattr(model_inst.token_counter, 'model_type'):
+        assert model_inst.token_counter.model_type == expected_model_type


### PR DESCRIPTION
## Description

Allow users self setting token counter from ModelFactory. If not set, OpenAITokenCounter(ModelType.GPT_3_5_TURBO) will be used as default (except for Lite LLM, as LiteLLMTokenCounter is not a subclass with BaseTokenCounter)

## Motivation and Context

close #589

- [ ] I have raised an issue to propose this change ([required](https://github.com/camel-ai/camel/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of example)

## Implemented Tasks

- [ ] Subtask 1
- [ ] Subtask 2
- [ ] Subtask 3

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide. (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation accordingly.
