### PR TITLE
fix: Fix type hint for output_schema parameter in ChatAgent class with Optional[Type[BaseModel]] and resolve the case of the complex Pydantic class

### DIFF
--- a/camel/agents/chat_agent.py
+++ b/camel/agents/chat_agent.py
@@ -23,6 +23,7 @@ from typing import (
     List,
     Optional,
     Tuple,
+    Type,
     Union,
 )
 
@@ -307,7 +308,7 @@ class ChatAgent(BaseAgent):
     def step(
         self,
         input_message: BaseMessage,
-        output_schema: Optional[BaseModel] = None,
+        output_schema: Optional[Type[BaseModel]] = None,
     ) -> ChatAgentResponse:
         r"""Performs a single step in the chat session by generating a response
         to the input message.
@@ -318,8 +319,8 @@ class ChatAgent(BaseAgent):
                 either `user` or `assistant` but it will be set to `user`
                 anyway since for the self agent any incoming message is
                 external.
-            output_schema (Optional[BaseModel]): An optional pydantic model
-                that includes value types and field descriptions used to
+            output_schema (Optional[type[BaseModel]]): An optional pydantic
+                model that includes value types and field descriptions used to
                 generate a structured response by LLM. This schema helps
                 in defining the expected output format.
 
@@ -438,7 +439,7 @@ class ChatAgent(BaseAgent):
     async def step_async(
         self,
         input_message: BaseMessage,
-        output_schema: Optional[BaseModel] = None,
+        output_schema: Optional[Type[BaseModel]] = None,
     ) -> ChatAgentResponse:
         r"""Performs a single step in the chat session by generating a response
         to the input message. This agent step can call async function calls.
@@ -449,8 +450,8 @@ class ChatAgent(BaseAgent):
                 either `user` or `assistant` but it will be set to `user`
                 anyway since for the self agent any incoming message is
                 external.
-            output_schema (Optional[BaseModel]): An optional pydantic model
-                that includes value types and field descriptions used to
+            output_schema (Optional[Type[BaseModel】]): An optional pydantic
+                model that includes value types and field descriptions used to
                 generate a structured response by LLM. This schema helps
                 in defining the expected output format.
 


### PR DESCRIPTION
## Description

This Pull Request introduces enhanced type hints to the `step` and `step_async` method of our CamelAgent class, ensuring better type safety and clarity in its usage. The output_schema parameter previously lacked explicit typing, which led to potential misuse and confusion within our codebase and among module consumers. This update specifies that output_schema can optionally accept a type that is a subclass of BaseModel from Pydantic.

If the method is called with an instance of a BaseModel subclass (not the class itself), like this:
``` python
        from pydantic import BaseModel, Field

        class PersonaResponse(BaseModel):
            persona_name: str = Field(description="The name of the persona")
            persona_description: str = Field(
                description="The description of the persona"
            )

        class PersonaListResponse(BaseModel):
            personas: list[PersonaResponse] = Field(
                description="A list of related personas"
            )
```

MyPy will raise an error indicating that it expected a type (Type[BaseModel]), but got an instance instead. The error might look like:
```
error: Argument "output_schema" to "step" of "ChatAgent" has incompatible type "type[PersonaResponse]"; expected "BaseModel | None"  [arg-type]      
error: Argument "output_schema" to "step" of "ChatAgent" has incompatible type "type[PersonaListResponse]"; expected "BaseModel | None"  [arg-type]  
```