### PR TITLE
fix: remove gpt-4-32k model

### DIFF
--- a/camel/types/enums.py
+++ b/camel/types/enums.py
@@ -95,7 +95,6 @@ class ModelType(Enum):
         return self in {
             ModelType.GPT_3_5_TURBO,
             ModelType.GPT_4,
-            ModelType.GPT_4_32K,
             ModelType.GPT_4_TURBO,
             ModelType.GPT_4O,
             ModelType.GPT_4O_MINI,
@@ -109,7 +108,6 @@ class ModelType(Enum):
         return self in {
             ModelType.GPT_3_5_TURBO,
             ModelType.GPT_4,
-            ModelType.GPT_4_32K,
             ModelType.GPT_4_TURBO,
             ModelType.GPT_4O,
         }
@@ -230,7 +228,6 @@ class ModelType(Enum):
         }:
             return 16_384
         elif self in {
-            ModelType.GPT_4_32K,
             ModelType.MISTRAL_CODESTRAL,
             ModelType.MISTRAL_7B,
             ModelType.MISTRAL_MIXTRAL_8x7B,

--- a/camel/types/enums.py
+++ b/camel/types/enums.py
@@ -26,7 +26,6 @@ class RoleType(Enum):
 class ModelType(Enum):
     GPT_3_5_TURBO = "gpt-3.5-turbo"
     GPT_4 = "gpt-4"
-    GPT_4_32K = "gpt-4-32k"
     GPT_4_TURBO = "gpt-4-turbo"
     GPT_4O = "gpt-4o"
     GPT_4O_MINI = "gpt-4o-mini"

--- a/test/models/test_azure_openai_model.py
+++ b/test/models/test_azure_openai_model.py
@@ -37,7 +37,7 @@ from camel.utils import OpenAITokenCounter
     [
         ModelType.GPT_3_5_TURBO,
         ModelType.GPT_4,
-=        ModelType.GPT_4_TURBO,
+        ModelType.GPT_4_TURBO,
         ModelType.GPT_4O,
     ],
 )

--- a/test/models/test_azure_openai_model.py
+++ b/test/models/test_azure_openai_model.py
@@ -37,8 +37,7 @@ from camel.utils import OpenAITokenCounter
     [
         ModelType.GPT_3_5_TURBO,
         ModelType.GPT_4,
-        ModelType.GPT_4_32K,
-        ModelType.GPT_4_TURBO,
+=        ModelType.GPT_4_TURBO,
         ModelType.GPT_4O,
     ],
 )
@@ -58,7 +57,6 @@ def test_openai_model(model_type):
     [
         ModelType.GPT_3_5_TURBO,
         ModelType.GPT_4,
-        ModelType.GPT_4_32K,
         ModelType.GPT_4_TURBO,
         ModelType.GPT_4O,
     ],

--- a/test/models/test_litellm_model.py
+++ b/test/models/test_litellm_model.py
@@ -27,7 +27,6 @@ from camel.utils import LiteLLMTokenCounter
     [
         ModelType.GPT_3_5_TURBO,
         ModelType.GPT_4,
-        ModelType.GPT_4_32K,
         ModelType.GPT_4_TURBO,
         ModelType.GPT_4O,
     ],

--- a/test/models/test_ollama_model.py
+++ b/test/models/test_ollama_model.py
@@ -27,7 +27,6 @@ from camel.utils import OpenAITokenCounter
     [
         ModelType.GPT_3_5_TURBO,
         ModelType.GPT_4,
-        ModelType.GPT_4_32K,
         ModelType.GPT_4_TURBO,
         ModelType.GPT_4O,
     ],

--- a/test/models/test_openai_model.py
+++ b/test/models/test_openai_model.py
@@ -27,7 +27,6 @@ from camel.utils import OpenAITokenCounter
     [
         ModelType.GPT_3_5_TURBO,
         ModelType.GPT_4,
-        ModelType.GPT_4_32K,
         ModelType.GPT_4_TURBO,
         ModelType.GPT_4O,
         ModelType.GPT_4O_MINI,

--- a/test/models/test_vllm_model.py
+++ b/test/models/test_vllm_model.py
@@ -27,7 +27,6 @@ from camel.utils import OpenAITokenCounter
     [
         ModelType.GPT_3_5_TURBO,
         ModelType.GPT_4,
-        ModelType.GPT_4_32K,
         ModelType.GPT_4_TURBO,
         ModelType.GPT_4O,
     ],


### PR DESCRIPTION
OpenAI does not support gpt-4-32k model anymore.

error:
``` bash
    raise self._make_status_error_from_response(err.response) from None
openai.NotFoundError: Error code: 404 - {'error': {'message': 'The model `gpt-4-32k` does not exist or you do not have access to it.', 'type': 'invalid_request_error', 'param': None, 'code': 'model_not_found'}}
```

refer to:
https://platform.openai.com/docs/models