### PR TITLE
feat: Auto retrieval support Element as input

### DIFF
--- a/camel/retrievers/vector_retriever.py
+++ b/camel/retrievers/vector_retriever.py
@@ -13,7 +13,7 @@
 # =========== Copyright 2023 @ CAMEL-AI.org. All Rights Reserved. ===========
 import os
 import warnings
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 from urllib.parse import urlparse
 
 from camel.embeddings import BaseEmbedding, OpenAIEmbedding
@@ -25,6 +25,11 @@ from camel.storages import (
     VectorDBQuery,
     VectorRecord,
 )
+
+try:
+    from unstructured.documents.elements import Element
+except ImportError:
+    Element = None
 
 DEFAULT_TOP_K_RESULTS = 1
 DEFAULT_SIMILARITY_THRESHOLD = 0.75
@@ -69,7 +74,7 @@ class VectorRetriever(BaseRetriever):
 
     def process(
         self,
-        content: str,
+        content: Union[str, Element],
         chunk_type: str = "chunk_by_title",
         **kwargs: Any,
     ) -> None:
@@ -78,18 +83,22 @@ class VectorRetriever(BaseRetriever):
         vector storage.
 
         Args:
-            contents (str): Local file path, remote URL or string content.
+            content (Union[str, Element]): Local file path, remote URL,
+                string content or Element object.
             chunk_type (str): Type of chunking going to apply. Defaults to
                 "chunk_by_title".
             **kwargs (Any): Additional keyword arguments for content parsing.
         """
-        # Check if the content is URL
-        parsed_url = urlparse(content)
-        is_url = all([parsed_url.scheme, parsed_url.netloc])
-        if is_url or os.path.exists(content):
-            elements = self.uio.parse_file_or_url(content, **kwargs)
+        if isinstance(content, Element):
+            elements = [content]
         else:
-            elements = [self.uio.create_element_from_text(text=content)]
+            # Check if the content is URL
+            parsed_url = urlparse(content)
+            is_url = all([parsed_url.scheme, parsed_url.netloc])
+            if is_url or os.path.exists(content):
+                elements = self.uio.parse_file_or_url(content, **kwargs) or []
+            else:
+                elements = [self.uio.create_element_from_text(text=content)]
         if elements:
             chunks = self.uio.chunk_elements(
                 chunk_type=chunk_type, elements=elements
@@ -110,7 +119,12 @@ class VectorRetriever(BaseRetriever):
             # Prepare the payload for each vector record, includes the content
             # path, chunk metadata, and chunk text
             for vector, chunk in zip(batch_vectors, batch_chunks):
-                content_path_info = {"content path": content}
+                if isinstance(content, str):
+                    content_path_info = {"content path": content}
+                elif isinstance(content, Element):
+                    content_path_info = {
+                        "content path": content.metadata.file_directory
+                    }
                 chunk_metadata = {"metadata": chunk.metadata.to_dict()}
                 chunk_text = {"text": str(chunk)}
                 combined_dict = {

--- a/test/retrievers/test_auto_retriever.py
+++ b/test/retrievers/test_auto_retriever.py
@@ -18,6 +18,7 @@ from unittest.mock import patch
 
 import pytest
 
+from camel.loaders import UnstructuredIO
 from camel.retrievers import AutoRetriever
 from camel.storages import QdrantStorage
 from camel.types import StorageType
@@ -100,3 +101,38 @@ def test_run_vector_retriever(auto_retriever):
     )
 
     assert "No suitable information retrieved from" in str(result_unrelated)
+
+
+def test_run_vector_retriever_with_element_input(auto_retriever):
+    uio = UnstructuredIO()
+    test_element = uio.create_element_from_text(
+        text="""Introducing 🦀 CRAB: Cross-environment Agent Benchmark for 
+        Multimodal Language Model Agents
+
+    🦀 CRAB provides an end-to-end and easy-to-use framework to build 
+    multimodal agents, operate environments, and create benchmarks to evaluate 
+    them, featuring three key components:
+
+    - 🔀 Cross-environment support - agents can operate tasks in 📱 Android 
+    and 💻 Ubuntu.
+    - 🕸️ Graph evaluator - provides a fine-grain evaluation metric for agents.
+    - 🤖 Task generation - composes subtasks to automatically generate tasks.
+
+    By connecting all devices to agents, 🦀CRAB unlocks greater capabilities 
+    for human-like tasks than ever before.
+
+    Use 🦀 CRAB to benchmark your multimodal agents! """,
+        file_directory="https://x.com/CamelAIOrg/status/1821970132606058943",
+    )
+
+    output = auto_retriever.run_vector_retriever(
+        query="CRAB provides an end-to-end and easy-to-use framework to build"
+        " multimodal agents",
+        contents=test_element,
+        return_detailed_info=True,
+    )
+
+    assert (
+        output["Retrieved Context"][0]['content path']
+        == 'https://x.com/CamelAIOrg/status/1821970132606058943'
+    )


### PR DESCRIPTION
## Description

Auto retrieval support Element as input

## Motivation and Context

```
    uio = UnstructuredIO()
    test_element = uio.create_element_from_text(
        text="""Introducing 🦀 CRAB: Cross-environment Agent Benchmark for 
        Multimodal Language Model Agents

    🦀 CRAB provides an end-to-end and easy-to-use framework to build 
    multimodal agents, operate environments, and create benchmarks to evaluate 
    them, featuring three key components:

    - 🔀 Cross-environment support - agents can operate tasks in 📱 Android 
    and 💻 Ubuntu.
    - 🕸️ Graph evaluator - provides a fine-grain evaluation metric for agents.
    - 🤖 Task generation - composes subtasks to automatically generate tasks.

    By connecting all devices to agents, 🦀CRAB unlocks greater capabilities 
    for human-like tasks than ever before.

    Use 🦀 CRAB to benchmark your multimodal agents! """,
        file_directory="https://x.com/CamelAIOrg/status/1821970132606058943",
    )

    output = auto_retriever.run_vector_retriever(
        query="CRAB provides an end-to-end and easy-to-use framework to build"
        " multimodal agents",
        contents=test_element,
        return_detailed_info=True,
    )
```

- [x] I have raised an issue to propose this change ([required](https://github.com/camel-ai/camel/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of example)

## Implemented Tasks

- [ ] Subtask 1
- [ ] Subtask 2
- [ ] Subtask 3

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ ] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide. (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation accordingly.
