### PR TITLE
fix: Remove collection name generator in auto_retriever

### DIFF
--- a/camel/storages/vectordb_storages/milvus.py
+++ b/camel/storages/vectordb_storages/milvus.py
@@ -210,7 +210,7 @@ class MilvusStorage(BaseVectorStorage):
         """
         timestamp = datetime.now().isoformat()
         transformed_name = re.sub(r'[^a-zA-Z0-9_]', '_', timestamp)
-        valid_name = "Time" + transformed_name
+        valid_name = "TIME" + transformed_name
         return valid_name
 
     def _get_collection_info(self, collection_name: str) -> Dict[str, Any]:

--- a/camel/storages/vectordb_storages/qdrant.py
+++ b/camel/storages/vectordb_storages/qdrant.py
@@ -214,8 +214,14 @@ class QdrantStorage(BaseVectorStorage):
         return False
 
     def _generate_collection_name(self) -> str:
-        r"""Generates a collection name if user doesn't provide"""
-        return datetime.now().isoformat()
+        r"""Generates a collection name if user doesn't provide.
+
+        Returns:
+            str: A unique, valid collection name.
+        """
+        timestamp = datetime.now().isoformat()
+        valid_name = "TIME" + timestamp
+        return valid_name
 
     def _get_collection_info(self, collection_name: str) -> Dict[str, Any]:
         r"""Retrieves details of an existing collection.

--- a/test/retrievers/test_auto_retriever.py
+++ b/test/retrievers/test_auto_retriever.py
@@ -46,7 +46,7 @@ def auto_retriever(temp_storage_path):
 
 def test__initialize_vector_storage(auto_retriever):
     # with tempfile.TemporaryDirectory() as tmpdir:
-    storage_custom = auto_retriever._initialize_vector_storage("collection")
+    storage_custom = auto_retriever._initialize_vector_storage()
     assert isinstance(storage_custom, QdrantStorage)
 
 


### PR DESCRIPTION
## Description

We have one method to generate collection name based on user's content path or url, but the generated name may not follow collection naming rule of the vector DB,  use the timestamp as default name would be more high efficiency and more robust

## Motivation and Context
`#859`

- [x] I have raised an issue to propose this change ([required](https://github.com/camel-ai/camel/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of example)

## Implemented Tasks

- [ ] Subtask 1
- [ ] Subtask 2
- [ ] Subtask 3

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ ] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide. (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation accordingly.
