### PR TITLE
fix: Remove collection name generator in auto_retriever

### DIFF
--- a/camel/retrievers/auto_retriever.py
+++ b/camel/retrievers/auto_retriever.py
@@ -14,9 +14,7 @@
 import datetime
 import os
 import re
-from pathlib import Path
 from typing import Collection, List, Optional, Sequence, Tuple, Union
-from urllib.parse import urlparse
 
 from camel.embeddings import BaseEmbedding, OpenAIEmbedding
 from camel.retrievers.vector_retriever import VectorRetriever
@@ -112,35 +110,12 @@ class AutoRetriever:
         Returns:
             str: A sanitized, valid collection name suitable for use.
         """
+
         if isinstance(content, Element):
             content = content.metadata.file_directory
 
-        # Check if the content is URL
-        parsed_url = urlparse(content)
-        is_url = all([parsed_url.scheme, parsed_url.netloc])
+        collection_name = re.sub(r'[^a-zA-Z0-9]', '', content)[:20]
 
-        # Convert given path into a collection name, ensuring it only
-        # contains numbers, letters, and underscores
-        if is_url:
-            # For URLs, remove https://, replace /, and any characters not
-            # allowed by Milvus with _
-            collection_name = re.sub(
-                r'[^0-9a-zA-Z]+',
-                '_',
-                content.replace("https://", ""),
-            )
-        elif os.path.exists(content):
-            # For file paths, get the stem and replace spaces with _, also
-            # ensuring only allowed characters are present
-            collection_name = re.sub(r'[^0-9a-zA-Z]+', '_', Path(content).stem)
-        else:
-            # the content is string input
-            collection_name = content[:10]
-
-        # Ensure the collection name does not start or end with underscore
-        collection_name = collection_name.strip("_")
-        # Limit the maximum length of the collection name to 30 characters
-        collection_name = collection_name[:30]
         return collection_name
 
     def _get_file_modified_date_from_file(


### PR DESCRIPTION
## Description

We have one method to generate collection name based on user's content path or url, but the generated name may not follow collection naming rule of the vector DB, we also can't use the timestamp as default name since the vector DB will be created each time running the RAG since the name of collection changes based on time

## Motivation and Context

 `close #859 ` 

- [ ] I have raised an issue to propose this change ([required](https://github.com/camel-ai/camel/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of example)

## Implemented Tasks

- [ ] Subtask 1
- [ ] Subtask 2
- [ ] Subtask 3

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ ] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide. (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation accordingly.
