### PR TITLE
fix: `ChatAgent` memory passing

### DIFF
--- a/camel/agents/chat_agent.py
+++ b/camel/agents/chat_agent.py
@@ -184,7 +184,7 @@ class ChatAgent(BaseAgent):
         self.input_memory_records = (
             [record.memory_record for record in memory.retrieve()]
             if memory
-            else []
+            else None
         )
 
         self.terminated: bool = False

--- a/camel/agents/chat_agent.py
+++ b/camel/agents/chat_agent.py
@@ -308,6 +308,8 @@ class ChatAgent(BaseAgent):
         )
         self.memory.clear()
         self.memory.write_record(system_record)
+
+        # Write input memory records back if they exist
         if self.input_memory_records:
             self.memory.write_records(self.input_memory_records)
 

--- a/camel/agents/chat_agent.py
+++ b/camel/agents/chat_agent.py
@@ -181,9 +181,15 @@ class ChatAgent(BaseAgent):
             context_creator, window_size=message_window_size
         )
 
+        input_memory_records = [
+            context_record.memory_record
+            for context_record in self.memory.retrieve()
+        ]
+
         self.terminated: bool = False
         self.response_terminators = response_terminators or []
         self.init_messages()
+        self.memory.write_records(input_memory_records)
 
     def reset(self):
         r"""Resets the :obj:`ChatAgent` to its initial state and returns the
@@ -349,6 +355,9 @@ class ChatAgent(BaseAgent):
 
             try:
                 openai_messages, num_tokens = self.memory.get_context()
+                print("$$$$")
+                print(openai_messages)
+                print("$$$$")
             except RuntimeError as e:
                 return self.step_token_exceed(
                     e.args[1], tool_calls, "max_tokens_exceeded"

--- a/camel/agents/chat_agent.py
+++ b/camel/agents/chat_agent.py
@@ -181,11 +181,11 @@ class ChatAgent(BaseAgent):
             context_creator, window_size=message_window_size
         )
 
-        if memory:
-            self.input_memory_records = [
-                context_record.memory_record
-                for context_record in memory.retrieve()
-            ]
+        self.input_memory_records = (
+            [record.memory_record for record in memory.retrieve()]
+            if memory
+            else []
+        )
 
         self.terminated: bool = False
         self.response_terminators = response_terminators or []

--- a/camel/agents/chat_agent.py
+++ b/camel/agents/chat_agent.py
@@ -181,15 +181,15 @@ class ChatAgent(BaseAgent):
             context_creator, window_size=message_window_size
         )
 
-        input_memory_records = [
-            context_record.memory_record
-            for context_record in self.memory.retrieve()
-        ]
+        if memory:
+            self.input_memory_records = [
+                context_record.memory_record
+                for context_record in memory.retrieve()
+            ]
 
         self.terminated: bool = False
         self.response_terminators = response_terminators or []
         self.init_messages()
-        self.memory.write_records(input_memory_records)
 
     def reset(self):
         r"""Resets the :obj:`ChatAgent` to its initial state and returns the
@@ -308,6 +308,8 @@ class ChatAgent(BaseAgent):
         )
         self.memory.clear()
         self.memory.write_record(system_record)
+        if self.input_memory_records:
+            self.memory.write_records(self.input_memory_records)
 
     def record_message(self, message: BaseMessage) -> None:
         r"""Records the externally provided message into the agent memory as if


### PR DESCRIPTION
## Description

The passed `memory` would be cleaned in `self.init_messages()`, we need to added the passed `memory` back after this step

```
    def init_messages(self) -> None:
        r"""Initializes the stored messages list with the initial system
        message.
        """
        system_record = MemoryRecord(
            message=self.system_message,
            role_at_backend=OpenAIBackendRole.SYSTEM,
        )
        self.memory.clear()
        self.memory.write_record(system_record)
```

## Motivation and Context



- [ ] I have raised an issue to propose this change ([required](https://github.com/camel-ai/camel/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of example)

## Implemented Tasks

- [ ] Subtask 1
- [ ] Subtask 2
- [ ] Subtask 3

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ ] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide. (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation accordingly.
