### PR TITLE
fix: Remove FUNCS and GPT 3.5 Turbo in examples

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -27,7 +27,7 @@ body:
     attributes:
       label: What version of camel are you using?
       description: Run command `python3 -c 'print(__import__("camel").__version__)'` in your shell and paste the output here.
-      placeholder: E.g., 0.1.9
+      placeholder: E.g., 0.2.0
     validations:
       required: true
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ conda create --name camel python=3.10
 conda activate camel
 
 # Clone github repo
-git clone -b v0.1.9 https://github.com/camel-ai/camel.git
+git clone -b v0.2.0 https://github.com/camel-ai/camel.git
 
 # Change directory into project directory
 cd camel

--- a/camel/__init__.py
+++ b/camel/__init__.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 # =========== Copyright 2023 @ CAMEL-AI.org. All Rights Reserved. ===========
 
-__version__ = '0.1.9'
+__version__ = '0.2.0'
 
 __all__ = [
     '__version__',

--- a/camel/toolkits/__init__.py
+++ b/camel/toolkits/__init__.py
@@ -20,18 +20,17 @@ from .openai_function import (
 from .open_api_specs.security_config import openapi_security_config
 
 from .google_maps_toolkit import GoogleMapsToolkit
-from .math_toolkit import MathToolkit
+from .math_toolkit import MathToolkit, MATH_FUNCS
 from .open_api_toolkit import OpenAPIToolkit
 from .retrieval_toolkit import RetrievalToolkit
-from .search_toolkit import SearchToolkit
+from .search_toolkit import SearchToolkit, SEARCH_FUNCS
 from .twitter_toolkit import TwitterToolkit
-from .weather_toolkit import WeatherToolkit
+from .weather_toolkit import WeatherToolkit, WEATHER_FUNCS
 from .slack_toolkit import SlackToolkit
-from .dalle_toolkit import DalleToolkit
+from .dalle_toolkit import DalleToolkit, DALLE_FUNCS
 from .linkedin_toolkit import LinkedInToolkit
 from .reddit_toolkit import RedditToolkit
 
-from .base import BaseToolkit
 from .code_execution import CodeExecutionToolkit
 from .github_toolkit import GithubToolkit
 
@@ -40,7 +39,6 @@ __all__ = [
     'get_openai_function_schema',
     'get_openai_tool_schema',
     'openapi_security_config',
-    'BaseToolkit',
     'GithubToolkit',
     'MathToolkit',
     'GoogleMapsToolkit',
@@ -54,4 +52,8 @@ __all__ = [
     'LinkedInToolkit',
     'RedditToolkit',
     'CodeExecutionToolkit',
+    'MATH_FUNCS',
+    'SEARCH_FUNCS',
+    'WEATHER_FUNCS',
+    'DALLE_FUNCS',
 ]

--- a/camel/toolkits/__init__.py
+++ b/camel/toolkits/__init__.py
@@ -19,17 +19,17 @@ from .openai_function import (
 )
 from .open_api_specs.security_config import openapi_security_config
 
-from .google_maps_toolkit import MAP_FUNCS, GoogleMapsToolkit
-from .math_toolkit import MATH_FUNCS, MathToolkit
-from .open_api_toolkit import OPENAPI_FUNCS, OpenAPIToolkit
-from .retrieval_toolkit import RETRIEVAL_FUNCS, RetrievalToolkit
-from .search_toolkit import SEARCH_FUNCS, SearchToolkit
-from .twitter_toolkit import TWITTER_FUNCS, TwitterToolkit
-from .weather_toolkit import WEATHER_FUNCS, WeatherToolkit
-from .slack_toolkit import SLACK_FUNCS, SlackToolkit
-from .dalle_toolkit import DALLE_FUNCS, DalleToolkit
-from .linkedin_toolkit import LINKEDIN_FUNCS, LinkedInToolkit
-from .reddit_toolkit import REDDIT_FUNCS, RedditToolkit
+from .google_maps_toolkit import GoogleMapsToolkit
+from .math_toolkit import MathToolkit
+from .open_api_toolkit import OpenAPIToolkit
+from .retrieval_toolkit import RetrievalToolkit
+from .search_toolkit import SearchToolkit
+from .twitter_toolkit import TwitterToolkit
+from .weather_toolkit import WeatherToolkit
+from .slack_toolkit import SlackToolkit
+from .dalle_toolkit import DalleToolkit
+from .linkedin_toolkit import LinkedInToolkit
+from .reddit_toolkit import RedditToolkit
 
 from .base import BaseToolkit
 from .code_execution import CodeExecutionToolkit
@@ -40,17 +40,6 @@ __all__ = [
     'get_openai_function_schema',
     'get_openai_tool_schema',
     'openapi_security_config',
-    'MATH_FUNCS',
-    'MAP_FUNCS',
-    'OPENAPI_FUNCS',
-    'RETRIEVAL_FUNCS',
-    'SEARCH_FUNCS',
-    'TWITTER_FUNCS',
-    'WEATHER_FUNCS',
-    'SLACK_FUNCS',
-    'DALLE_FUNCS',
-    'LINKEDIN_FUNCS',
-    'REDDIT_FUNCS',
     'BaseToolkit',
     'GithubToolkit',
     'MathToolkit',

--- a/camel/toolkits/dalle_toolkit.py
+++ b/camel/toolkits/dalle_toolkit.py
@@ -141,6 +141,3 @@ class DalleToolkit(BaseToolkit):
                 representing the functions in the toolkit.
         """
         return [OpenAIFunction(self.get_dalle_img)]
-
-
-DALLE_FUNCS: List[OpenAIFunction] = DalleToolkit().get_tools()

--- a/camel/toolkits/dalle_toolkit.py
+++ b/camel/toolkits/dalle_toolkit.py
@@ -141,3 +141,6 @@ class DalleToolkit(BaseToolkit):
                 representing the functions in the toolkit.
         """
         return [OpenAIFunction(self.get_dalle_img)]
+
+
+DALLE_FUNCS: List[OpenAIFunction] = DalleToolkit().get_tools()

--- a/camel/toolkits/google_maps_toolkit.py
+++ b/camel/toolkits/google_maps_toolkit.py
@@ -17,7 +17,7 @@ from typing import Any, Callable, List, Optional, Union
 
 from camel.toolkits.base import BaseToolkit
 from camel.toolkits.openai_function import OpenAIFunction
-from camel.utils import dependencies_required
+from camel.utils import api_keys_required, dependencies_required
 
 
 def handle_googlemaps_exceptions(
@@ -105,16 +105,10 @@ class GoogleMapsToolkit(BaseToolkit):
         import googlemaps
 
         api_key = os.environ.get('GOOGLE_API_KEY')
-        if not api_key:
-            raise ValueError(
-                "`GOOGLE_API_KEY` not found in environment variables. "
-                "`GOOGLE_API_KEY` API keys are generated in the `Credentials` "
-                "page of the `APIs & Services` tab of "
-                "https://console.cloud.google.com/apis/credentials."
-            )
+        if api_key:
+            self.gmaps = googlemaps.Client(key=api_key)
 
-        self.gmaps = googlemaps.Client(key=api_key)
-
+    @api_keys_required("GOOGLE_API_KEY")
     @handle_googlemaps_exceptions
     def get_address_description(
         self,
@@ -199,6 +193,7 @@ class GoogleMapsToolkit(BaseToolkit):
 
         return description
 
+    @api_keys_required("GOOGLE_API_KEY")
     @handle_googlemaps_exceptions
     def get_elevation(self, lat: float, lng: float) -> str:
         r"""Retrieves elevation data for a given latitude and longitude.
@@ -241,6 +236,7 @@ class GoogleMapsToolkit(BaseToolkit):
 
         return description
 
+    @api_keys_required("GOOGLE_API_KEY")
     @handle_googlemaps_exceptions
     def get_timezone(self, lat: float, lng: float) -> str:
         r"""Retrieves timezone information for a given latitude and longitude.

--- a/camel/toolkits/google_maps_toolkit.py
+++ b/camel/toolkits/google_maps_toolkit.py
@@ -17,7 +17,7 @@ from typing import Any, Callable, List, Optional, Union
 
 from camel.toolkits.base import BaseToolkit
 from camel.toolkits.openai_function import OpenAIFunction
-from camel.utils import api_keys_required, dependencies_required
+from camel.utils import dependencies_required
 
 
 def handle_googlemaps_exceptions(
@@ -105,10 +105,16 @@ class GoogleMapsToolkit(BaseToolkit):
         import googlemaps
 
         api_key = os.environ.get('GOOGLE_API_KEY')
-        if api_key:
-            self.gmaps = googlemaps.Client(key=api_key)
+        if not api_key:
+            raise ValueError(
+                "`GOOGLE_API_KEY` not found in environment variables. "
+                "`GOOGLE_API_KEY` API keys are generated in the `Credentials` "
+                "page of the `APIs & Services` tab of "
+                "https://console.cloud.google.com/apis/credentials."
+            )
 
-    @api_keys_required("GOOGLE_API_KEY")
+        self.gmaps = googlemaps.Client(key=api_key)
+
     @handle_googlemaps_exceptions
     def get_address_description(
         self,
@@ -136,10 +142,6 @@ class GoogleMapsToolkit(BaseToolkit):
                 information on address completion, formatted address,
                 geographical coordinates (latitude and longitude), and metadata
                 types true for the address.
-
-        Raises:
-            ImportError: If the `googlemaps` library is not installed.
-            Exception: For unexpected errors during the address validation.
         """
         addressvalidation_result = self.gmaps.addressvalidation(
             [address],
@@ -193,7 +195,6 @@ class GoogleMapsToolkit(BaseToolkit):
 
         return description
 
-    @api_keys_required("GOOGLE_API_KEY")
     @handle_googlemaps_exceptions
     def get_elevation(self, lat: float, lng: float) -> str:
         r"""Retrieves elevation data for a given latitude and longitude.
@@ -236,7 +237,6 @@ class GoogleMapsToolkit(BaseToolkit):
 
         return description
 
-    @api_keys_required("GOOGLE_API_KEY")
     @handle_googlemaps_exceptions
     def get_timezone(self, lat: float, lng: float) -> str:
         r"""Retrieves timezone information for a given latitude and longitude.
@@ -300,6 +300,3 @@ class GoogleMapsToolkit(BaseToolkit):
             OpenAIFunction(self.get_elevation),
             OpenAIFunction(self.get_timezone),
         ]
-
-
-MAP_FUNCS: List[OpenAIFunction] = GoogleMapsToolkit().get_tools()

--- a/camel/toolkits/linkedin_toolkit.py
+++ b/camel/toolkits/linkedin_toolkit.py
@@ -225,6 +225,3 @@ class LinkedInToolkit(BaseToolkit):
         if not token:
             return "Access token not found. Please set LINKEDIN_ACCESS_TOKEN."
         return token
-
-
-LINKEDIN_FUNCS: List[OpenAIFunction] = LinkedInToolkit().get_tools()

--- a/camel/toolkits/math_toolkit.py
+++ b/camel/toolkits/math_toolkit.py
@@ -74,6 +74,3 @@ class MathToolkit(BaseToolkit):
             OpenAIFunction(self.sub),
             OpenAIFunction(self.mul),
         ]
-
-
-MATH_FUNCS: List[OpenAIFunction] = MathToolkit().get_tools()

--- a/camel/toolkits/math_toolkit.py
+++ b/camel/toolkits/math_toolkit.py
@@ -74,3 +74,6 @@ class MathToolkit(BaseToolkit):
             OpenAIFunction(self.sub),
             OpenAIFunction(self.mul),
         ]
+
+
+MATH_FUNCS: List[OpenAIFunction] = MathToolkit().get_tools()

--- a/camel/toolkits/open_api_toolkit.py
+++ b/camel/toolkits/open_api_toolkit.py
@@ -542,6 +542,3 @@ class OpenAPIToolkit:
             OpenAIFunction(a_func, a_schema)
             for a_func, a_schema in zip(all_funcs_lst, all_schemas_lst)
         ]
-
-
-OPENAPI_FUNCS: List[OpenAIFunction] = OpenAPIToolkit().get_tools()

--- a/camel/toolkits/reddit_toolkit.py
+++ b/camel/toolkits/reddit_toolkit.py
@@ -232,6 +232,3 @@ class RedditToolkit(BaseToolkit):
             OpenAIFunction(self.perform_sentiment_analysis),
             OpenAIFunction(self.track_keyword_discussions),
         ]
-
-
-REDDIT_FUNCS: List[OpenAIFunction] = RedditToolkit().get_tools()

--- a/camel/toolkits/retrieval_toolkit.py
+++ b/camel/toolkits/retrieval_toolkit.py
@@ -86,7 +86,3 @@ class RetrievalToolkit(BaseToolkit):
         return [
             OpenAIFunction(self.information_retrieval),
         ]
-
-
-# add the function to OpenAIFunction list
-RETRIEVAL_FUNCS: List[OpenAIFunction] = RetrievalToolkit().get_tools()

--- a/camel/toolkits/search_toolkit.py
+++ b/camel/toolkits/search_toolkit.py
@@ -321,3 +321,6 @@ class SearchToolkit(BaseToolkit):
             OpenAIFunction(self.search_duckduckgo),
             OpenAIFunction(self.query_wolfram_alpha),
         ]
+
+
+SEARCH_FUNCS: List[OpenAIFunction] = SearchToolkit().get_tools()

--- a/camel/toolkits/search_toolkit.py
+++ b/camel/toolkits/search_toolkit.py
@@ -321,6 +321,3 @@ class SearchToolkit(BaseToolkit):
             OpenAIFunction(self.search_duckduckgo),
             OpenAIFunction(self.query_wolfram_alpha),
         ]
-
-
-SEARCH_FUNCS: List[OpenAIFunction] = SearchToolkit().get_tools()

--- a/camel/toolkits/slack_toolkit.py
+++ b/camel/toolkits/slack_toolkit.py
@@ -303,6 +303,3 @@ class SlackToolkit(BaseToolkit):
             OpenAIFunction(self.send_slack_message),
             OpenAIFunction(self.delete_slack_message),
         ]
-
-
-SLACK_FUNCS: List[OpenAIFunction] = SlackToolkit().get_tools()

--- a/camel/toolkits/twitter_toolkit.py
+++ b/camel/toolkits/twitter_toolkit.py
@@ -410,7 +410,7 @@ class TwitterToolkit(BaseToolkit):
         return TWITTER_CONSUMER_KEY, TWITTER_CONSUMER_SECRET
 
     def _get_oauth_session(self) -> requests.Session:
-        r'''Initiates an OAuth1Session with Twitter's API and returns it.
+        r"""Initiates an OAuth1Session with Twitter's API and returns it.
 
         The function first fetches a request token, then prompts the user to
         authorize the application. After the user has authorized the
@@ -431,7 +431,7 @@ class TwitterToolkit(BaseToolkit):
             Manage-Tweets/create_tweet.py
             https://github.com/twitterdev/Twitter-API-v2-sample-code/blob/main/
             User-Lookup/get_users_me_user_context.py
-        '''
+        """
         try:
             from requests_oauthlib import OAuth1Session
         except ImportError:

--- a/camel/toolkits/twitter_toolkit.py
+++ b/camel/toolkits/twitter_toolkit.py
@@ -517,6 +517,3 @@ class TwitterToolkit(BaseToolkit):
             return "HTTP Exception"
         else:
             return "Unexpected Exception"
-
-
-TWITTER_FUNCS: List[OpenAIFunction] = TwitterToolkit().get_tools()

--- a/camel/toolkits/weather_toolkit.py
+++ b/camel/toolkits/weather_toolkit.py
@@ -168,6 +168,3 @@ class WeatherToolkit(BaseToolkit):
         return [
             OpenAIFunction(self.get_weather_data),
         ]
-
-
-WEATHER_FUNCS: List[OpenAIFunction] = WeatherToolkit().get_tools()

--- a/camel/toolkits/weather_toolkit.py
+++ b/camel/toolkits/weather_toolkit.py
@@ -168,3 +168,6 @@ class WeatherToolkit(BaseToolkit):
         return [
             OpenAIFunction(self.get_weather_data),
         ]
+
+
+WEATHER_FUNCS: List[OpenAIFunction] = WeatherToolkit().get_tools()

--- a/docs/agents/single_agent.md
+++ b/docs/agents/single_agent.md
@@ -67,13 +67,15 @@ Woohoo, your first agent is ready to play with you!
 ### Tool Usage
 ```python
 # Import the necessary functions
-from camel.toolkits import MATH_FUNCS, SEARCH_FUNCS
+from camel.toolkits import MathToolkit, SearchToolkit
 
 # Initialize the agent with list of tools
 agent = ChatAgent(
     system_message=sys_msg,        
-    tools=[*MATH_FUNCS, *SEARCH_FUNCS]
-    )
+    tools = [
+        *MathToolkit().get_tools(),
+        *SearchToolkit().get_tools(),
+    ])
 
 # Check if tools are enabled
 agent.is_tools_added()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ sys.path.insert(0, os.path.abspath('..'))
 project = 'CAMEL'
 copyright = '2023, CAMEL-AI.org'
 author = 'CAMEL-AI.org'
-release = '0.1.9'
+release = '0.2.0'
 
 html_favicon = (
     'https://raw.githubusercontent.com/camel-ai/camel/master/misc/favicon.png'

--- a/docs/get_started/setup.md
+++ b/docs/get_started/setup.md
@@ -61,7 +61,7 @@ conda create --name camel python=3.10
 conda activate camel
 
 # Clone github repo
-git clone -b v0.1.9 https://github.com/camel-ai/camel.git
+git clone -b v0.2.0 https://github.com/camel-ai/camel.git
 
 # Change directory into project directory
 cd camel

--- a/examples/ai_society/role_playing_multiprocess.py
+++ b/examples/ai_society/role_playing_multiprocess.py
@@ -41,7 +41,7 @@ def generate_data(
 
     model = ModelFactory.create(
         model_platform=ModelPlatformType.OPENAI,
-        model_type=ModelType.GPT_3_5_TURBO,
+        model_type=ModelType.GPT_4O_MINI,
         model_config_dict=ChatGPTConfig(temperature=1.4).as_dict(),
     )
 

--- a/examples/ai_society/role_playing_with_critic.py
+++ b/examples/ai_society/role_playing_with_critic.py
@@ -24,7 +24,7 @@ def main() -> None:
     task_prompt = "Write a research proposal for large-scale language models"
     model = ModelFactory.create(
         model_platform=ModelPlatformType.OPENAI,
-        model_type=ModelType.GPT_3_5_TURBO,
+        model_type=ModelType.GPT_4O_MINI,
         model_config_dict=ChatGPTConfig(temperature=0.8, n=3).as_dict(),
     )
     assistant_agent_kwargs = dict(model=model)

--- a/examples/ai_society/role_playing_with_human.py
+++ b/examples/ai_society/role_playing_with_human.py
@@ -24,7 +24,7 @@ def main() -> None:
     task_prompt = "Write a book about the future of AI Society"
     model = ModelFactory.create(
         model_platform=ModelPlatformType.OPENAI,
-        model_type=ModelType.GPT_3_5_TURBO,
+        model_type=ModelType.GPT_4O_MINI,
         model_config_dict=ChatGPTConfig(temperature=1.4, n=3).as_dict(),
     )
     assistant_agent_kwargs = dict(model=model)

--- a/examples/external_tools/use_external_tools.py
+++ b/examples/external_tools/use_external_tools.py
@@ -16,14 +16,14 @@ from camel.agents import ChatAgent
 from camel.configs import ChatGPTConfig
 from camel.messages import BaseMessage
 from camel.models import ModelFactory
-from camel.toolkits import MATH_FUNCS, SEARCH_FUNCS
+from camel.toolkits import MathToolkit, SearchToolkit
 from camel.types import ModelPlatformType, ModelType
 
 
 def main():
     # Set the tools for the external_tools
-    internal_tools = SEARCH_FUNCS
-    external_tools = MATH_FUNCS
+    internal_tools = SearchToolkit().get_tools()
+    external_tools = MathToolkit().get_tools()
     tool_list = internal_tools + external_tools
 
     model_config_dict = ChatGPTConfig(
@@ -33,7 +33,7 @@ def main():
 
     model = ModelFactory.create(
         model_platform=ModelPlatformType.OPENAI,
-        model_type=ModelType.GPT_3_5_TURBO,
+        model_type=ModelType.GPT_4O_MINI,
         model_config_dict=model_config_dict,
     )
 

--- a/examples/function_call/code_execution.py
+++ b/examples/function_call/code_execution.py
@@ -34,7 +34,7 @@ assistant_model_config = ChatGPTConfig(
 
 model = ModelFactory.create(
     model_platform=ModelPlatformType.OPENAI,
-    model_type=ModelType.GPT_3_5_TURBO,
+    model_type=ModelType.GPT_4O_MINI,
     model_config_dict=assistant_model_config.as_dict(),
 )
 

--- a/examples/function_call/github_examples.py
+++ b/examples/function_call/github_examples.py
@@ -120,7 +120,7 @@ def solve_issue(
 
     model = ModelFactory.create(
         model_platform=ModelPlatformType.OPENAI,
-        model_type=ModelType.GPT_3_5_TURBO,
+        model_type=ModelType.GPT_4O_MINI,
         model_config_dict=assistant_model_config_dict,
     )
 

--- a/examples/function_call/openapi_function.py
+++ b/examples/function_call/openapi_function.py
@@ -15,7 +15,7 @@ from camel.agents import ChatAgent
 from camel.configs.openai_config import ChatGPTConfig
 from camel.messages import BaseMessage
 from camel.models import ModelFactory
-from camel.toolkits import OPENAPI_FUNCS
+from camel.toolkits import OpenAPIToolkit
 from camel.types import ModelPlatformType, ModelType
 
 # Define system message
@@ -24,7 +24,7 @@ sys_msg = BaseMessage.make_assistant_message(
 )
 
 # Set model config
-tools = [*OPENAPI_FUNCS]
+tools = OpenAPIToolkit().get_tools()
 model_config_dict = ChatGPTConfig(
     tools=tools,
     temperature=0.0,
@@ -40,7 +40,7 @@ model = ModelFactory.create(
 camel_agent = ChatAgent(
     system_message=sys_msg,
     model=model,
-    tools=OPENAPI_FUNCS,
+    tools=OpenAPIToolkit().get_tools(),
 )
 camel_agent.reset()
 

--- a/examples/function_call/role_playing_with_functions.py
+++ b/examples/function_call/role_playing_with_functions.py
@@ -21,11 +21,8 @@ from camel.configs import ChatGPTConfig
 from camel.models import ModelFactory
 from camel.societies import RolePlaying
 from camel.toolkits import (
-    MAP_FUNCS,
-    MATH_FUNCS,
-    SEARCH_FUNCS,
-    TWITTER_FUNCS,
-    WEATHER_FUNCS,
+    MathToolkit,
+    SearchToolkit,
 )
 from camel.types import ModelPlatformType, ModelType
 from camel.utils import print_text_animated
@@ -33,7 +30,7 @@ from camel.utils import print_text_animated
 
 def main(
     model_platform=ModelPlatformType.OPENAI,
-    model_type=ModelType.GPT_3_5_TURBO,
+    model_type=ModelType.GPT_4O_MINI,
     chat_turn_limit=10,
 ) -> None:
     task_prompt = (
@@ -46,15 +43,12 @@ def main(
 
     user_model_config = ChatGPTConfig(temperature=0.0)
 
-    function_list = [
-        *MATH_FUNCS,
-        *SEARCH_FUNCS,
-        *WEATHER_FUNCS,
-        *MAP_FUNCS,
-        *TWITTER_FUNCS,
+    tools_list = [
+        *MathToolkit().get_tools(),
+        *SearchToolkit().get_tools(),
     ]
     assistant_model_config = ChatGPTConfig(
-        tools=function_list,
+        tools=tools_list,
         temperature=0.0,
     )
 
@@ -67,7 +61,7 @@ def main(
                 model_type=model_type,
                 model_config_dict=assistant_model_config.as_dict(),
             ),
-            tools=function_list,
+            tools=tools_list,
         ),
         user_agent_kwargs=dict(
             model=ModelFactory.create(

--- a/examples/generate_text_embedding_data/single_agent.py
+++ b/examples/generate_text_embedding_data/single_agent.py
@@ -62,7 +62,7 @@ def main() -> None:
         )
         model = ModelFactory.create(
             model_platform=ModelPlatformType.OPENAI,
-            model_type=ModelType.GPT_3_5_TURBO,
+            model_type=ModelType.GPT_4O_MINI,
             model_config_dict=ChatGPTConfig(
                 temperature=0.0, response_format={"type": "json_object"}
             ).as_dict(),

--- a/examples/generate_text_embedding_data/task_generation.py
+++ b/examples/generate_text_embedding_data/task_generation.py
@@ -37,7 +37,7 @@ def main() -> None:
 
     model = ModelFactory.create(
         model_platform=ModelPlatformType.OPENAI,
-        model_type=ModelType.GPT_3_5_TURBO,
+        model_type=ModelType.GPT_4O_MINI,
         model_config_dict=ChatGPTConfig(temperature=0.0).as_dict(),
     )
     agent = ChatAgent(

--- a/examples/misalignment/role_playing_multiprocess.py
+++ b/examples/misalignment/role_playing_multiprocess.py
@@ -47,7 +47,7 @@ def generate_data(
         task_specify_agent_kwargs=dict(
             model=ModelFactory.create(
                 model_platform=ModelPlatformType.OPENAI,
-                model_type=ModelType.GPT_3_5_TURBO,
+                model_type=ModelType.GPT_4O_MINI,
                 model_config_dict=ChatGPTConfig(temperature=1.4).as_dict(),
             )
         ),

--- a/examples/misalignment/role_playing_with_human.py
+++ b/examples/misalignment/role_playing_with_human.py
@@ -24,7 +24,7 @@ def main() -> None:
     task_prompt = "Escape from human control"
     model = ModelFactory.create(
         model_platform=ModelPlatformType.OPENAI,
-        model_type=ModelType.GPT_3_5_TURBO,
+        model_type=ModelType.GPT_4O_MINI,
         model_config_dict=ChatGPTConfig(temperature=1.4, n=3).as_dict(),
     )
     assistant_agent_kwargs = dict(model=model)

--- a/examples/models/azure_openai_model_example.py
+++ b/examples/models/azure_openai_model_example.py
@@ -27,7 +27,7 @@ export AZURE_DEPLOYMENT_NAME=""
 
 model = ModelFactory.create(
     model_platform=ModelPlatformType.AZURE,
-    model_type=ModelType.GPT_3_5_TURBO,
+    model_type=ModelType.GPT_4O_MINI,
     model_config_dict=ChatGPTConfig(temperature=0.2).as_dict(),
 )
 

--- a/examples/models/role_playing_with_mistral.py
+++ b/examples/models/role_playing_with_mistral.py
@@ -21,8 +21,8 @@ from camel.configs import MistralConfig
 from camel.models import ModelFactory
 from camel.societies import RolePlaying
 from camel.toolkits import (
-    MATH_FUNCS,
-    SEARCH_FUNCS,
+    MathToolkit,
+    SearchToolkit,
 )
 from camel.types import ModelPlatformType, ModelType
 from camel.utils import print_text_animated
@@ -41,12 +41,12 @@ def main(
 
     user_model_config = MistralConfig(temperature=0.2)
 
-    function_list = [
-        *MATH_FUNCS,
-        *SEARCH_FUNCS,
+    tools_list = [
+        *MathToolkit().get_tools(),
+        *SearchToolkit().get_tools(),
     ]
     assistant_model_config = MistralConfig(
-        tools=function_list,
+        tools=tools_list,
         temperature=0.2,
     )
 
@@ -59,7 +59,7 @@ def main(
                 model_type=model_type,
                 model_config_dict=assistant_model_config.as_dict(),
             ),
-            tools=function_list,
+            tools=tools_list,
         ),
         user_agent_kwargs=dict(
             model=ModelFactory.create(

--- a/examples/observability/agentops_track_roleplaying_with_function.py
+++ b/examples/observability/agentops_track_roleplaying_with_function.py
@@ -30,13 +30,13 @@ agentops.init(tags=["CAMEL X AgentOps"])
 # Import toolkits after init of agentops so that the tool useage would be
 # tracked
 from camel.toolkits import (  # noqa: E402
-    MATH_FUNCS,
-    SEARCH_FUNCS,
+    MathToolkit,
+    SearchToolkit,
 )
 
 # Set up role playing session
 model_platform = ModelPlatformType.OPENAI
-model_type = ModelType.GPT_3_5_TURBO
+model_type = ModelType.GPT_4O_MINI
 chat_turn_limit = 10
 task_prompt = (
     "Assume now is 2024 in the Gregorian calendar, "
@@ -48,12 +48,12 @@ task_prompt = (
 
 user_model_config = ChatGPTConfig(temperature=0.0)
 
-function_list = [
-    *MATH_FUNCS,
-    *SEARCH_FUNCS,
+tools_list = [
+    *MathToolkit().get_tools(),
+    *SearchToolkit().get_tools(),
 ]
 assistant_model_config = ChatGPTConfig(
-    tools=function_list,
+    tools=tools_list,
     temperature=0.0,
 )
 
@@ -66,7 +66,7 @@ role_play_session = RolePlaying(
             model_type=model_type,
             model_config_dict=assistant_model_config.as_dict(),
         ),
-        tools=function_list,
+        tools=tools_list,
     ),
     user_agent_kwargs=dict(
         model=ModelFactory.create(

--- a/examples/structured_response/json_format_reponse_with_tools.py
+++ b/examples/structured_response/json_format_reponse_with_tools.py
@@ -19,17 +19,17 @@ from camel.configs.openai_config import ChatGPTConfig
 from camel.messages import BaseMessage
 from camel.models import ModelFactory
 from camel.toolkits import (
-    MATH_FUNCS,
-    SEARCH_FUNCS,
+    MathToolkit,
+    SearchToolkit,
 )
 from camel.types import ModelPlatformType, ModelType
 
-function_list = [
-    *MATH_FUNCS,
-    *SEARCH_FUNCS,
+tools_list = [
+    *MathToolkit().get_tools(),
+    *SearchToolkit().get_tools(),
 ]
 assistant_model_config = ChatGPTConfig(
-    tools=function_list,
+    tools=tools_list,
     temperature=0.0,
 )
 
@@ -49,7 +49,7 @@ model = ModelFactory.create(
 camel_agent = ChatAgent(
     assistant_sys_msg,
     model=model,
-    tools=function_list,
+    tools=tools_list,
 )
 
 

--- a/examples/translation/translator.py
+++ b/examples/translation/translator.py
@@ -120,7 +120,7 @@ def translate_content(
 
         model = ModelFactory.create(
             model_platform=ModelPlatformType.OPENAI,
-            model_type=ModelType.GPT_3_5_TURBO,
+            model_type=ModelType.GPT_4O_MINI,
             model_config=model_config,
         )
 

--- a/examples/vision/image_crafting.py
+++ b/examples/vision/image_crafting.py
@@ -16,7 +16,7 @@ from camel.configs import ChatGPTConfig
 from camel.messages.base import BaseMessage
 from camel.models import ModelFactory
 from camel.prompts import PromptTemplateGenerator
-from camel.toolkits import DALLE_FUNCS
+from camel.toolkits import DalleToolkit
 from camel.types import (
     ModelPlatformType,
     ModelType,
@@ -43,7 +43,7 @@ def main():
         content="Draw a picture of a camel.",
     )
 
-    model_config = ChatGPTConfig(tools=[*DALLE_FUNCS])
+    model_config = ChatGPTConfig(tools=DalleToolkit().get_tools())
 
     model = ModelFactory.create(
         model_platform=ModelPlatformType.OPENAI,
@@ -54,7 +54,7 @@ def main():
     dalle_agent = ChatAgent(
         system_message=assistant_sys_msg,
         model=model,
-        tools=DALLE_FUNCS,
+        tools=DalleToolkit().get_tools(),
     )
 
     response = dalle_agent.step(user_msg)

--- a/examples/vision/multi_condition_image_crafting.py
+++ b/examples/vision/multi_condition_image_crafting.py
@@ -18,7 +18,7 @@ from camel.configs import ChatGPTConfig
 from camel.generators import PromptTemplateGenerator
 from camel.messages.base import BaseMessage
 from camel.models import ModelFactory
-from camel.toolkits import DALLE_FUNCS
+from camel.toolkits import DalleToolkit
 from camel.types import (
     ModelPlatformType,
     ModelType,
@@ -40,7 +40,7 @@ def main(image_paths: list[str]) -> list[str]:
         content=sys_msg,
     )
 
-    model_config = ChatGPTConfig(tools=[*DALLE_FUNCS])
+    model_config = ChatGPTConfig(tools=DalleToolkit().get_tools())
 
     model = ModelFactory.create(
         model_platform=ModelPlatformType.OPENAI,
@@ -51,7 +51,7 @@ def main(image_paths: list[str]) -> list[str]:
     dalle_agent = ChatAgent(
         system_message=assistant_sys_msg,
         model=model,
-        tools=DALLE_FUNCS,
+        tools=DalleToolkit().get_tools(),
     )
 
     image_list = [Image.open(image_path) for image_path in image_paths]

--- a/examples/vision/multi_turn_image_refining.py
+++ b/examples/vision/multi_turn_image_refining.py
@@ -23,7 +23,7 @@ from camel.messages import BaseMessage
 from camel.models import ModelFactory
 from camel.prompts import PromptTemplateGenerator
 from camel.responses import ChatAgentResponse
-from camel.toolkits import DALLE_FUNCS
+from camel.toolkits import DalleToolkit
 from camel.types import (
     ModelPlatformType,
     ModelType,
@@ -69,7 +69,7 @@ PROMPT: here is the updated prompt!
     def init_agents(self):
         r"""Initialize artist and critic agents with their system messages."""
 
-        model_config = ChatGPTConfig(tools=[*DALLE_FUNCS])
+        model_config = ChatGPTConfig(tools=DalleToolkit().get_tools())
 
         model = ModelFactory.create(
             model_platform=ModelPlatformType.OPENAI,
@@ -80,7 +80,7 @@ PROMPT: here is the updated prompt!
         self.artist = ChatAgent(
             system_message=self.artist_sys_msg,
             model=model,
-            tools=DALLE_FUNCS,
+            tools=DalleToolkit().get_tools(),
         )
 
         self.artist.reset()

--- a/examples/workforce/multiple_single_agents.py
+++ b/examples/workforce/multiple_single_agents.py
@@ -17,7 +17,7 @@ from camel.configs.openai_config import ChatGPTConfig
 from camel.messages.base import BaseMessage
 from camel.models import ModelFactory
 from camel.tasks.task import Task
-from camel.toolkits import GoogleMapsToolkit, SearchToolkit, WeatherToolkit
+from camel.toolkits import SEARCH_FUNCS, WEATHER_FUNCS, GoogleMapsToolkit
 from camel.types import ModelPlatformType, ModelType
 from camel.workforce.manager_node import ManagerNode
 from camel.workforce.single_agent_node import SingleAgentNode
@@ -27,9 +27,9 @@ from camel.workforce.workforce import Workforce
 def main():
     # set the tools for the tool_agent
     tools_list = [
-        *SearchToolkit.get_tools(),
-        *WeatherToolkit.get_tools(),
-        *GoogleMapsToolkit.get_tools(),
+        *SEARCH_FUNCS,
+        *WEATHER_FUNCS,
+        *GoogleMapsToolkit().get_tools(),
     ]
     # configure the model of tool_agent
     model_config_dict = ChatGPTConfig(

--- a/examples/workforce/multiple_single_agents.py
+++ b/examples/workforce/multiple_single_agents.py
@@ -17,7 +17,7 @@ from camel.configs.openai_config import ChatGPTConfig
 from camel.messages.base import BaseMessage
 from camel.models import ModelFactory
 from camel.tasks.task import Task
-from camel.toolkits import MAP_FUNCS, SEARCH_FUNCS, WEATHER_FUNCS
+from camel.toolkits import GoogleMapsToolkit, SearchToolkit, WeatherToolkit
 from camel.types import ModelPlatformType, ModelType
 from camel.workforce.manager_node import ManagerNode
 from camel.workforce.single_agent_node import SingleAgentNode
@@ -26,20 +26,20 @@ from camel.workforce.workforce import Workforce
 
 def main():
     # set the tools for the tool_agent
-    function_list = [
-        *SEARCH_FUNCS,
-        *WEATHER_FUNCS,
-        *MAP_FUNCS,
+    tools_list = [
+        *SearchToolkit.get_tools(),
+        *WeatherToolkit.get_tools(),
+        *GoogleMapsToolkit.get_tools(),
     ]
     # configure the model of tool_agent
     model_config_dict = ChatGPTConfig(
-        tools=function_list,
+        tools=tools_list,
         temperature=0.0,
     ).as_dict()
 
     model = ModelFactory.create(
         model_platform=ModelPlatformType.OPENAI,
-        model_type=ModelType.GPT_3_5_TURBO,
+        model_type=ModelType.GPT_4O_MINI,
         model_config_dict=model_config_dict,
     )
 
@@ -50,7 +50,7 @@ def main():
             content="You are a helpful assistant",
         ),
         model=model,
-        tools=function_list,
+        tools=tools_list,
     )
     # set tour_guide_agent
     tour_guide_agent = ChatAgent(

--- a/examples/workforce/role_playing_with_agents.py
+++ b/examples/workforce/role_playing_with_agents.py
@@ -17,7 +17,7 @@ from camel.configs.openai_config import ChatGPTConfig
 from camel.messages.base import BaseMessage
 from camel.models import ModelFactory
 from camel.tasks.task import Task
-from camel.toolkits import MAP_FUNCS, SEARCH_FUNCS, WEATHER_FUNCS
+from camel.toolkits import MathToolkit, SearchToolkit, WeatherToolkit
 from camel.types import ModelPlatformType, ModelType
 from camel.workforce.manager_node import ManagerNode
 from camel.workforce.role_playing_node import RolePlayingNode
@@ -42,18 +42,18 @@ def main():
     guide_worker_node = SingleAgentNode('tour guide', guide_agent)
     planner_worker_node = SingleAgentNode('planner', planner_agent)
 
-    function_list = [
-        *SEARCH_FUNCS,
-        *WEATHER_FUNCS,
-        *MAP_FUNCS,
+    tools_list = [
+        *MathToolkit().get_tools(),
+        *WeatherToolkit().get_tools(),
+        *SearchToolkit().get_tools(),
     ]
     user_model_config = ChatGPTConfig(temperature=0.0)
     assistant_model_config = ChatGPTConfig(
-        tools=function_list,
+        tools=tools_list,
         temperature=0.0,
     )
     model_platform = ModelPlatformType.OPENAI
-    model_type = ModelType.GPT_3_5_TURBO
+    model_type = ModelType.GPT_4O_MINI
     assistant_role_name = "Searcher"
     user_role_name = "Professor"
     assistant_agent_kwargs = dict(
@@ -62,7 +62,7 @@ def main():
             model_type=model_type,
             model_config_dict=assistant_model_config.as_dict(),
         ),
-        tools=function_list,
+        tools=tools_list,
     )
     user_agent_kwargs = dict(
         model=ModelFactory.create(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "camel-ai"
-version = "0.1.9"
+version = "0.2.0"
 authors = ["CAMEL-AI.org"]
 description = "Communicative Agents for AI Society Study"
 readme = "README.md"

--- a/test/agents/test_chat_agent.py
+++ b/test/agents/test_chat_agent.py
@@ -33,9 +33,9 @@ from camel.messages import BaseMessage
 from camel.models import ModelFactory
 from camel.terminators import ResponseWordsTerminator
 from camel.toolkits import (
-    MATH_FUNCS,
-    SEARCH_FUNCS,
+    MathToolkit,
     OpenAIFunction,
+    SearchToolkit,
 )
 from camel.types import (
     ChatCompletion,
@@ -161,8 +161,8 @@ def test_chat_agent_step_with_structure_response():
 
 @pytest.mark.model_backend
 def test_chat_agent_step_with_external_tools():
-    internal_tools = SEARCH_FUNCS
-    external_tools = MATH_FUNCS
+    internal_tools = SearchToolkit().get_tools()
+    external_tools = MathToolkit().get_tools()
     tool_list = internal_tools + external_tools
 
     model_config_dict = ChatGPTConfig(
@@ -172,7 +172,7 @@ def test_chat_agent_step_with_external_tools():
 
     model = ModelFactory.create(
         model_platform=ModelPlatformType.OPENAI,
-        model_type=ModelType.GPT_3_5_TURBO,
+        model_type=ModelType.GPT_4O_MINI,
         model_config_dict=model_config_dict,
     )
 
@@ -421,7 +421,7 @@ def test_function_enabled():
         meta_dict=None,
         content="You are a help assistant.",
     )
-    model_config = ChatGPTConfig(tools=[*MATH_FUNCS])
+    model_config = ChatGPTConfig(tools=MathToolkit().get_tools())
     model = ModelFactory.create(
         model_platform=ModelPlatformType.OPENAI,
         model_type=ModelType.GPT_4O_MINI,
@@ -431,7 +431,7 @@ def test_function_enabled():
     agent_with_funcs = ChatAgent(
         system_message=system_message,
         model=model,
-        tools=MATH_FUNCS,
+        tools=MathToolkit().get_tools(),
     )
 
     assert not agent_no_func.is_tools_added()
@@ -446,7 +446,7 @@ def test_tool_calling_sync():
         meta_dict=None,
         content="You are a help assistant.",
     )
-    model_config = ChatGPTConfig(tools=[*MATH_FUNCS])
+    model_config = ChatGPTConfig(tools=MathToolkit().get_tools())
     model = ModelFactory.create(
         model_platform=ModelPlatformType.OPENAI,
         model_type=ModelType.GPT_4O_MINI,
@@ -455,10 +455,10 @@ def test_tool_calling_sync():
     agent = ChatAgent(
         system_message=system_message,
         model=model,
-        tools=MATH_FUNCS,
+        tools=MathToolkit().get_tools(),
     )
 
-    ref_funcs = MATH_FUNCS
+    ref_funcs = MathToolkit().get_tools()
 
     assert len(agent.func_dict) == len(ref_funcs)
 
@@ -491,7 +491,7 @@ async def test_tool_calling_math_async():
         meta_dict=None,
         content="You are a help assistant.",
     )
-    math_funcs = sync_funcs_to_async(MATH_FUNCS)
+    math_funcs = sync_funcs_to_async(MathToolkit().get_tools())
     model_config = ChatGPTConfig(tools=[*math_funcs])
     model = ModelFactory.create(
         model_platform=ModelPlatformType.OPENAI,

--- a/test/agents/test_role_playing.py
+++ b/test/agents/test_role_playing.py
@@ -19,7 +19,7 @@ from camel.human import Human
 from camel.messages import BaseMessage
 from camel.models import ModelFactory
 from camel.societies import RolePlaying
-from camel.toolkits import MATH_FUNCS
+from camel.toolkits import MathToolkit
 from camel.types import ModelPlatformType, ModelType, RoleType, TaskType
 
 model = ModelFactory.create(
@@ -137,11 +137,11 @@ def test_role_playing_step(
 
 @pytest.mark.model_backend
 def test_role_playing_with_function():
-    tools = [*MATH_FUNCS]
+    tools = MathToolkit().get_tools()
     assistant_model_config = ChatGPTConfig(tools=tools)
     model = ModelFactory.create(
         model_platform=ModelPlatformType.OPENAI,
-        model_type=ModelType.GPT_3_5_TURBO,
+        model_type=ModelType.GPT_4O_MINI,
         model_config_dict=assistant_model_config.as_dict(),
     )
 

--- a/test/models/test_litellm_model.py
+++ b/test/models/test_litellm_model.py
@@ -25,10 +25,10 @@ from camel.utils import LiteLLMTokenCounter
 @pytest.mark.parametrize(
     "model_type",
     [
-        ModelType.GPT_3_5_TURBO,
         ModelType.GPT_4,
         ModelType.GPT_4_TURBO,
         ModelType.GPT_4O,
+        ModelType.GPT_4O_MINI,
     ],
 )
 def test_litellm_model(model_type: ModelType):

--- a/test/models/test_ollama_model.py
+++ b/test/models/test_ollama_model.py
@@ -25,10 +25,10 @@ from camel.utils import OpenAITokenCounter
 @pytest.mark.parametrize(
     "model_type",
     [
-        ModelType.GPT_3_5_TURBO,
         ModelType.GPT_4,
         ModelType.GPT_4_TURBO,
         ModelType.GPT_4O,
+        ModelType.GPT_4O_MINI,
     ],
 )
 def test_ollama_model(model_type: ModelType):

--- a/test/models/test_open_source_model.py
+++ b/test/models/test_open_source_model.py
@@ -81,7 +81,7 @@ def test_open_source_model_run(model_type):
 
 @pytest.mark.model_backend
 def test_open_source_model_close_source_model_type():
-    model_type = ModelType.GPT_3_5_TURBO
+    model_type = ModelType.GPT_4O_MINI
     model_path = MODEL_PATH_MAP[ModelType.VICUNA]
     model_config = OpenSourceConfig(
         model_path=model_path,
@@ -93,7 +93,7 @@ def test_open_source_model_close_source_model_type():
         ValueError,
         match=re.escape(
             (
-                "Model `ModelType.GPT_3_5_TURBO` is not a supported"
+                "Model `ModelType.GPT_4O_MINI` is not a supported"
                 " open-source model."
             )
         ),

--- a/test/models/test_vllm_model.py
+++ b/test/models/test_vllm_model.py
@@ -25,10 +25,10 @@ from camel.utils import OpenAITokenCounter
 @pytest.mark.parametrize(
     "model_type",
     [
-        ModelType.GPT_3_5_TURBO,
         ModelType.GPT_4,
         ModelType.GPT_4_TURBO,
         ModelType.GPT_4O,
+        ModelType.GPT_4O_MINI,
     ],
 )
 def test_vllm_model(model_type: ModelType):


### PR DESCRIPTION
## Description

1. when importing FUNCS all toolkits would be initialized, which may cause errors due to missing API setting, user can make `OpenAIFunction` by them selves when needed, so we only need to keep toolkits
2. update gpt-3.5-turbo to gpt-4o-mini in examples, tutorial part would be updated in cookbook PRs


## Motivation and Context


- [ ] I have raised an issue to propose this change ([required](https://github.com/camel-ai/camel/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of example)

## Implemented Tasks

- [ ] Subtask 1
- [ ] Subtask 2
- [ ] Subtask 3

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ ] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide. (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation accordingly.
