### PR TITLE
chore: Add docker image building into CI/CD

### DIFF
--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -2,7 +2,7 @@ name: Publish Docker Image
 
 on:
   release:
-    types: [published]
+    types: [ published ]
 
 jobs:
   build-and-push:
@@ -27,4 +27,5 @@ jobs:
           docker buildx build --platform linux/amd64,linux/arm64 \
             --tag ghcr.io/camel-ai/camel:${{ github.ref_name }} \
             --sbom=false --provenance=false \
+            --file .container/minimal_build/Dockerfile \
             --push .


### PR DESCRIPTION
## Description

Update GitHub Workflow, so that building and publishing GHCR packages will be automatically processed when a new release is published.
