### PR TITLE
fix: vector_retriever

### DIFF
--- a/camel/retrievers/vector_retriever.py
+++ b/camel/retrievers/vector_retriever.py
@@ -195,16 +195,9 @@ class VectorRetriever(BaseRetriever):
         db_query = VectorDBQuery(query_vector=query_vector, top_k=top_k)
         query_results = self.storage.query(query=db_query)
 
-        # If no results found, return a message
+        # If no results found, raise an error
         if not query_results:
-            return [
-                {
-                    'text': (
-                        "No suitable information retrieved "
-                        "Please check if the storage is empty"
-                    )
-                }
-            ]
+            raise ValueError("Please check if the vector storage is empty.")
 
         if query_results[0].record.payload is None:
             raise ValueError(

--- a/camel/retrievers/vector_retriever.py
+++ b/camel/retrievers/vector_retriever.py
@@ -195,6 +195,17 @@ class VectorRetriever(BaseRetriever):
         db_query = VectorDBQuery(query_vector=query_vector, top_k=top_k)
         query_results = self.storage.query(query=db_query)
 
+        # If no results found, return a message
+        if not query_results:
+            return [
+                {
+                    'text': (
+                        "No suitable information retrieved "
+                        "Please check if the storage is empty"
+                    )
+                }
+            ]
+
         if query_results[0].record.payload is None:
             raise ValueError(
                 "Payload of vector storage is None, please check the "

--- a/camel/retrievers/vector_retriever.py
+++ b/camel/retrievers/vector_retriever.py
@@ -197,7 +197,10 @@ class VectorRetriever(BaseRetriever):
 
         # If no results found, raise an error
         if not query_results:
-            raise ValueError("Please check if the vector storage is empty.")
+            raise ValueError(
+                "Query result is empty, please check if "
+                "the vector storage is empty."
+            )
 
         if query_results[0].record.payload is None:
             raise ValueError(

--- a/test/retrievers/test_vector_retriever.py
+++ b/test/retrievers/test_vector_retriever.py
@@ -109,7 +109,9 @@ def test_query_no_results(vector_retriever):
     vector_retriever.storage.query.return_value = []
 
     with pytest.raises(
-        ValueError, match="Please check if the vector storage is empty."
+        ValueError,
+        match="Query result is empty, please check if the "
+        "vector storage is empty.",
     ):
         vector_retriever.query(query, top_k=top_k)
 

--- a/test/retrievers/test_vector_retriever.py
+++ b/test/retrievers/test_vector_retriever.py
@@ -98,3 +98,37 @@ def test_query(vector_retriever):
     results = vector_retriever.query(query, top_k=top_k)
     assert len(results) == 1
     assert results[0]['similarity score'] == '0.8'
+
+
+# Test query with no results found
+def test_query_no_results(vector_retriever):
+    query = "test query"
+    top_k = 1
+    # Setup mock behavior for vector storage query
+    vector_retriever.storage.load = Mock()
+    vector_retriever.storage.query.return_value = []
+
+    with pytest.raises(
+        ValueError, match="Please check if the vector storage is empty."
+    ):
+        vector_retriever.query(query, top_k=top_k)
+
+
+# Test query with payload None
+def test_query_payload_none(vector_retriever):
+    query = "test query"
+    top_k = 1
+    # Setup mock behavior for vector storage query
+    vector_retriever.storage.load = Mock()
+    vector_retriever.storage.query.return_value = [
+        Mock(similarity=0.8, record=Mock(payload=None))
+    ]
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Payload of vector storage is None, "
+            "please check the collection."
+        ),
+    ):
+        vector_retriever.query(query, top_k=top_k)


### PR DESCRIPTION
## Description

Add a RaiseValue exception when the storage is empty to prevent index out of range errors.

## Motivation and Context

Currently, when attempting to access elements in storage and it is empty, an "IndexError: list index out of range" occurs. This change introduces a RaiseValue exception, which provides a more meaningful error message.

- [ ] I have raised an issue to propose this change ([required](https://github.com/camel-ai/camel/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of example)

## Implemented Tasks

- [ ] Subtask 1
- [ ] Subtask 2
- [ ] Subtask 3

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ ] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide. (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation accordingly.
