### PR TITLE
fix: Remove orig_elements in unstructured element metadata

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -26,7 +26,7 @@ body:
     attributes:
       label: What version of camel are you using?
       description: Run command `python3 -c 'print(__import__("camel").__version__)'` in your shell and paste the output here.
-      placeholder: E.g., 0.2.4
+      placeholder: E.g., 0.2.5
     validations:
       required: true
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ conda create --name camel python=3.10
 conda activate camel
 
 # Clone github repo
-git clone -b v0.2.4 https://github.com/camel-ai/camel.git
+git clone -b v0.2.5 https://github.com/camel-ai/camel.git
 
 # Change directory into project directory
 cd camel

--- a/camel/__init__.py
+++ b/camel/__init__.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 # =========== Copyright 2023 @ CAMEL-AI.org. All Rights Reserved. ===========
 
-__version__ = '0.2.4'
+__version__ = '0.2.5'
 
 __all__ = [
     '__version__',

--- a/camel/retrievers/vector_retriever.py
+++ b/camel/retrievers/vector_retriever.py
@@ -149,7 +149,11 @@ class VectorRetriever(BaseRetriever):
                             "content path": content.metadata.file_directory
                             or ""
                         }
+
                     chunk_metadata = {"metadata": chunk.metadata.to_dict()}
+                    # Remove the 'orig_elements' key if it exists
+                    chunk_metadata["metadata"].pop("orig_elements", "")
+
                     chunk_text = {"text": str(chunk)}
                     combined_dict = {
                         **content_path_info,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ sys.path.insert(0, os.path.abspath('..'))
 project = 'CAMEL'
 copyright = '2024, CAMEL-AI.org'
 author = 'CAMEL-AI.org'
-release = '0.2.4'
+release = '0.2.5'
 
 html_favicon = (
     'https://raw.githubusercontent.com/camel-ai/camel/master/misc/favicon.png'

--- a/docs/cookbooks/agents_message.ipynb
+++ b/docs/cookbooks/agents_message.ipynb
@@ -101,7 +101,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install \"camel-ai==0.2.4\""
+        "!pip install \"camel-ai==0.2.5\""
       ]
     },
     {

--- a/docs/cookbooks/agents_prompting.ipynb
+++ b/docs/cookbooks/agents_prompting.ipynb
@@ -64,7 +64,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install \"camel-ai==0.2.4\""
+        "!pip install \"camel-ai==0.2.5\""
       ]
     },
     {

--- a/docs/cookbooks/agents_society.ipynb
+++ b/docs/cookbooks/agents_society.ipynb
@@ -192,7 +192,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install \"camel-ai==0.2.4\""
+        "!pip install \"camel-ai==0.2.5\""
       ]
     },
     {

--- a/docs/cookbooks/agents_tracking.ipynb
+++ b/docs/cookbooks/agents_tracking.ipynb
@@ -64,7 +64,7 @@
       },
       "outputs": [],
       "source": [
-        "%pip install camel-ai[all]==0.2.4\n",
+        "%pip install camel-ai[all]==0.2.5\n",
         "%pip install agentops==0.3.10"
       ]
     },

--- a/docs/cookbooks/agents_with_memory.ipynb
+++ b/docs/cookbooks/agents_with_memory.ipynb
@@ -73,7 +73,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install \"camel-ai[all]==0.2.4\""
+        "!pip install \"camel-ai[all]==0.2.5\""
       ]
     },
     {

--- a/docs/cookbooks/agents_with_rag.ipynb
+++ b/docs/cookbooks/agents_with_rag.ipynb
@@ -29,6 +29,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "AwnfLQvMvtXo"
@@ -37,6 +38,7 @@
         "In this notebook, we show the useage of CAMEL Retrieve Module in both customized way and auto way. We will also show how to combine `AutoRetriever` with `ChatAgent`, and further combine `AutoRetriever` with `RolePlaying` by using `Function Calling`.\n",
         "\n",
         "4 main parts included:\n",
+        "\n",
         "- Customized RAG\n",
         "\n",
         "- Auto RAG\n",

--- a/docs/cookbooks/agents_with_rag.ipynb
+++ b/docs/cookbooks/agents_with_rag.ipynb
@@ -75,7 +75,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install \"camel-ai[all]==0.2.4\""
+        "!pip install \"camel-ai[all]==0.2.5\""
       ]
     },
     {

--- a/docs/cookbooks/agents_with_tools.ipynb
+++ b/docs/cookbooks/agents_with_tools.ipynb
@@ -77,7 +77,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install \"camel-ai[all]==0.2.4\""
+        "!pip install \"camel-ai[all]==0.2.5\""
       ]
     },
     {

--- a/docs/cookbooks/create_your_first_agent.ipynb
+++ b/docs/cookbooks/create_your_first_agent.ipynb
@@ -83,7 +83,7 @@
     {
       "cell_type": "code",
       "source": [
-        "!pip install \"camel-ai[all]==0.2.4\""
+        "!pip install \"camel-ai[all]==0.2.5\""
       ],
       "metadata": {
         "id": "UtcC3c-KVZmU"

--- a/docs/cookbooks/create_your_first_agents_society.ipynb
+++ b/docs/cookbooks/create_your_first_agents_society.ipynb
@@ -77,7 +77,7 @@
     {
       "cell_type": "code",
       "source": [
-        "!pip install \"camel-ai==0.2.4\""
+        "!pip install \"camel-ai==0.2.5\""
       ],
       "metadata": {
         "id": "RiwfwyyLYYxo"

--- a/docs/cookbooks/critic_agents_and_tree_search.ipynb
+++ b/docs/cookbooks/critic_agents_and_tree_search.ipynb
@@ -84,7 +84,7 @@
     {
       "cell_type": "code",
       "source": [
-        "%pip install \"camel-ai==0.2.4\""
+        "%pip install \"camel-ai==0.2.5\""
       ],
       "metadata": {
         "id": "UtcC3c-KVZmU"

--- a/docs/cookbooks/embodied_agents.ipynb
+++ b/docs/cookbooks/embodied_agents.ipynb
@@ -67,7 +67,7 @@
     {
       "cell_type": "code",
       "source": [
-        "%pip install \"camel-ai==0.2.4\""
+        "%pip install \"camel-ai==0.2.5\""
       ],
       "metadata": {
         "id": "UtcC3c-KVZmU"

--- a/docs/cookbooks/knowledge_graph.ipynb
+++ b/docs/cookbooks/knowledge_graph.ipynb
@@ -73,7 +73,7 @@
       },
       "outputs": [],
       "source": [
-        "pip install \"camel-ai[all]==0.2.4\""
+        "pip install \"camel-ai[all]==0.2.5\""
       ]
     },
     {

--- a/docs/cookbooks/model_speed_comparison.ipynb
+++ b/docs/cookbooks/model_speed_comparison.ipynb
@@ -63,7 +63,7 @@
     {
       "cell_type": "code",
       "source": [
-        "!pip install \"camel-ai==0.2.4\""
+        "!pip install \"camel-ai==0.2.5\""
       ],
       "metadata": {
         "id": "UtcC3c-KVZmU"

--- a/docs/cookbooks/roleplaying_scraper.ipynb
+++ b/docs/cookbooks/roleplaying_scraper.ipynb
@@ -89,7 +89,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install \"camel-ai[all]==0.2.4\""
+        "!pip install \"camel-ai[all]==0.2.5\""
       ]
     },
     {

--- a/docs/cookbooks/task_generation.ipynb
+++ b/docs/cookbooks/task_generation.ipynb
@@ -62,7 +62,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install \"camel-ai==0.2.4\""
+        "!pip install \"camel-ai==0.2.5\""
       ]
     },
     {

--- a/docs/cookbooks/video_analysis.ipynb
+++ b/docs/cookbooks/video_analysis.ipynb
@@ -28,7 +28,7 @@
    },
    "outputs": [],
    "source": [
-    "%pip install \"camel-ai[all]==0.2.4\""
+    "%pip install \"camel-ai[all]==0.2.5\""
    ]
   },
   {

--- a/docs/cookbooks/workforce_judge_committee.ipynb
+++ b/docs/cookbooks/workforce_judge_committee.ipynb
@@ -1,6 +1,7 @@
 {
   "cells": [
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "k-xIA7Qjuiwu"
@@ -27,10 +28,11 @@
       },
       "outputs": [],
       "source": [
-        "%pip install \"camel-ai[all]==0.2.4\""
+        "%pip install \"camel-ai[all]==0.2.5\""
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "mY3G7K9swEzz"
@@ -66,6 +68,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "FIz0b9O_wqkW"
@@ -112,6 +115,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "PnMcEXo_xxGF"
@@ -138,7 +142,7 @@
         "from camel.tasks import Task\n",
         "from camel.toolkits import FunctionTool, SearchToolkit\n",
         "from camel.types import ModelPlatformType, ModelType\n",
-        "from camel.workforce import Workforce\n",
+        "from camel.societies.workforce import Workforce\n",
         "\n",
         "def make_judge(\n",
         "    persona: str,\n",
@@ -176,6 +180,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "HtP_ej5CyUNT"
@@ -210,6 +215,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "z35CIla3zBF4"
@@ -383,6 +389,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "GG3CR8hX0p5w"
@@ -445,6 +452,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "-WXOG-Hr1ibN"
@@ -479,6 +487,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "HQx4rRNu3CbA"
@@ -657,6 +666,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "Ljbz3Jmc1VwQ"

--- a/docs/get_started/installation.md
+++ b/docs/get_started/installation.md
@@ -60,7 +60,7 @@ conda create --name camel python=3.10
 conda activate camel
 
 # Clone github repo
-git clone -b v0.2.4 https://github.com/camel-ai/camel.git
+git clone -b v0.2.5 https://github.com/camel-ai/camel.git
 
 # Change directory into project directory
 cd camel

--- a/docs/key_modules/workforce.md
+++ b/docs/key_modules/workforce.md
@@ -74,7 +74,7 @@ then add worker nodes to the workforce. Here is an example of how you can do
 this:
 
 ```python
-from camel.workforce import Workforce
+from camel.societies.workforce import Workforce
 
 # Create a workforce instance
 workforce = Workforce("A Simple Workforce")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "camel-ai"
-version = "0.2.4"
+version = "0.2.5"
 authors = ["CAMEL-AI.org"]
 description = "Communicative Agents for AI Society Study"
 readme = "README.md"


### PR DESCRIPTION
## Description

Unstructured IO added `orig_elements` into element metadata, but the `orig_elements` seems encoded representation of the original content, which could be very long, we need to put the element metadata as payload, which has limitation for the input length, this could lead to potential bug

## Motivation and Context

- [ ] I have raised an issue to propose this change ([required](https://github.com/camel-ai/camel/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of example)

## Implemented Tasks

- [ ] Subtask 1
- [ ] Subtask 2
- [ ] Subtask 3

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ ] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide. (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation accordingly.
