### PR TITLE
fix: that user cannot see question when using human_toolkit

### DIFF
--- a/camel/toolkits/human_toolkit.py
+++ b/camel/toolkits/human_toolkit.py
@@ -18,6 +18,18 @@ from typing import List
 from camel.toolkits.base import BaseToolkit
 from camel.toolkits.function_tool import FunctionTool
 
+# Add a new logging level called NOTICE, which is the same as WARNING
+# Used for logging questions, and it will be shown in the console
+NOTICE_LEVEL = 30  # same as WARNING
+logging.addLevelName(NOTICE_LEVEL, "NOTICE")
+
+
+def notice(self, message, *args, **kwargs):
+    if self.isEnabledFor(NOTICE_LEVEL):
+        self._log(NOTICE_LEVEL, message, args, **kwargs)
+
+
+logging.Logger.notice = notice  # type: ignore[attr-defined]
 logger = logging.getLogger(__name__)
 
 
@@ -36,7 +48,7 @@ class HumanToolkit(BaseToolkit):
         Returns:
             str: The answer from the human.
         """
-        logger.info(f"Question: {question}")
+        logger.notice(f"Question: {question}")  # type: ignore[attr-defined]
         reply = input("Your reply: ")
         logger.info(f"User reply: {reply}")
         return reply


### PR DESCRIPTION
## Motivation and Context

Currently, when calling ask_human_via_console, the question will not appear in console, causing difficulty for the user. Because the logger.info() cannot be shown in the console. 

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of example)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide. (**required**)
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [x] I have updated the documentation accordingly.
