### PR TITLE
fix: use print instead of customized logger for human tool

### DIFF
--- a/camel/toolkits/human_toolkit.py
+++ b/camel/toolkits/human_toolkit.py
@@ -18,18 +18,6 @@ from typing import List
 from camel.toolkits.base import BaseToolkit
 from camel.toolkits.function_tool import FunctionTool
 
-# Add a new logging level called NOTICE, which is the same as WARNING
-# Used for logging questions, and it will be shown in the console
-NOTICE_LEVEL = 30  # same as WARNING
-logging.addLevelName(NOTICE_LEVEL, "NOTICE")
-
-
-def notice(self, message, *args, **kwargs):
-    if self.isEnabledFor(NOTICE_LEVEL):
-        self._log(NOTICE_LEVEL, message, args, **kwargs)
-
-
-logging.Logger.notice = notice  # type: ignore[attr-defined]
 logger = logging.getLogger(__name__)
 
 
@@ -48,7 +36,8 @@ class HumanToolkit(BaseToolkit):
         Returns:
             str: The answer from the human.
         """
-        logger.notice(f"Question: {question}")  # type: ignore[attr-defined]
+        print(f"Question: {question}")
+        logger.info(f"Question: {question}")
         reply = input("Your reply: ")
         logger.info(f"User reply: {reply}")
         return reply


### PR DESCRIPTION
## Description

Setting a new logging level with level 30 is not recognized by ONNX Runtime (which uses level 2 for Warning). The simplest solution would be to use print and then use logger.info

## Motivation and Context

 `close #1257`

- [x] I have raised an issue to propose this change ([required](https://github.com/camel-ai/camel/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of example)

## Implemented Tasks

- [ ] Subtask 1
- [ ] Subtask 2
- [ ] Subtask 3

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ ] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide. (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation accordingly.
