### PR TITLE
fix: Remove deprecated `min_tokens` parameter from mistral config.

### DIFF
--- a/camel/configs/mistral_config.py
+++ b/camel/configs/mistral_config.py
@@ -35,8 +35,6 @@ class MistralConfig(BaseConfig):
             tokens to generate, e.g. 0.9. Defaults to None.
         max_tokens (Optional[int], optional): the maximum number of tokens to
             generate, e.g. 100. Defaults to None.
-        min_tokens (Optional[int], optional): the minimum number of tokens to
-            generate, e.g. 100. Defaults to None.
         stop (Optional[Union[str,list[str]]]): Stop generation if this token
             is detected. Or if one of these tokens is detected when providing
             a string list.
@@ -58,7 +56,6 @@ class MistralConfig(BaseConfig):
     temperature: Optional[float] = None
     top_p: Optional[float] = None
     max_tokens: Optional[int] = None
-    min_tokens: Optional[int] = None
     stop: Optional[Union[str, list[str]]] = None
     random_seed: Optional[int] = None
     safe_prompt: bool = False


### PR DESCRIPTION
## Description

Fixes compatibility issue with Mistral SDK 1.2.0 which removed `min_tokens` parameter from `Chat.complete()`. References #1266 .

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [x] I have raised an issue to propose this change ([required](https://github.com/camel-ai/camel/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of example)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide. (**required**)
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [x] I have updated the documentation accordingly.
