### PR TITLE
Fix: Import anthropic package when used since it's optional

### DIFF
--- a/camel/models/anthropic_model.py
+++ b/camel/models/anthropic_model.py
@@ -14,8 +14,6 @@
 import os
 from typing import Any, Dict, List, Literal, Optional, Union
 
-from anthropic.types.beta import BetaMessageParam
-
 from camel.configs import ANTHROPIC_API_PARAMS, AnthropicConfig
 from camel.messages import OpenAIMessage
 from camel.models.base_model import BaseModelBackend
@@ -99,6 +97,7 @@ class AnthropicModel(BaseModelBackend):
             self._token_counter = AnthropicTokenCounter(self.model_type)
         return self._token_counter
 
+    @dependencies_required('anthropic')
     def count_tokens_from_prompt(
         self, prompt: str, role: Literal["user", "assistant"]
     ) -> int:
@@ -112,6 +111,8 @@ class AnthropicModel(BaseModelBackend):
         Returns:
             int: The number of tokens in the prompt.
         """
+        from anthropic.types.beta import BetaMessageParam
+
         return self.client.beta.messages.count_tokens(
             messages=[BetaMessageParam(content=prompt, role=role)],
             model=self.model_type,

--- a/camel/utils/token_counting.py
+++ b/camel/utils/token_counting.py
@@ -20,8 +20,9 @@ from io import BytesIO
 from math import ceil
 from typing import TYPE_CHECKING, List, Optional
 
-from camel.logger import get_logger
 from PIL import Image
+
+from camel.logger import get_logger
 from camel.types import (
     ModelType,
     OpenAIImageType,

--- a/camel/utils/token_counting.py
+++ b/camel/utils/token_counting.py
@@ -21,6 +21,7 @@ from math import ceil
 from typing import TYPE_CHECKING, List, Optional
 
 from camel.logger import get_logger
+from PIL import Image
 from camel.types import (
     ModelType,
     OpenAIImageType,

--- a/camel/utils/token_counting.py
+++ b/camel/utils/token_counting.py
@@ -20,9 +20,6 @@ from io import BytesIO
 from math import ceil
 from typing import TYPE_CHECKING, List, Optional
 
-from anthropic.types.beta import BetaMessageParam
-from PIL import Image
-
 from camel.logger import get_logger
 from camel.types import (
     ModelType,
@@ -234,6 +231,7 @@ class AnthropicTokenCounter(BaseTokenCounter):
         self.client = Anthropic()
         self.model = model
 
+    @dependencies_required('anthropic')
     def count_tokens_from_messages(self, messages: List[OpenAIMessage]) -> int:
         r"""Count number of tokens in the provided message list using
         loaded tokenizer specific for this type of model.
@@ -245,6 +243,8 @@ class AnthropicTokenCounter(BaseTokenCounter):
         Returns:
             int: Number of tokens in the messages.
         """
+        from anthropic.types.beta import BetaMessageParam
+
         return self.client.beta.messages.count_tokens(
             messages=[
                 BetaMessageParam(


### PR DESCRIPTION
## Description

Fixes issue when anthropic package isn't installed

## Motivation and Context
There was an error where the anthropic package not being present would cause an error to be thrown from commons.py

- [ ] I have raised an issue to propose this change ([required](https://github.com/camel-ai/camel/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of example)

