### PR TITLE
fix: when the user does not use huggingface record preset fields, the preset fields will be ignored.

### DIFF
--- a/camel/datahubs/huggingface.py
+++ b/camel/datahubs/huggingface.py
@@ -362,7 +362,13 @@ class HuggingFaceDatasetManager(BaseDatasetManager):
         with tempfile.NamedTemporaryFile(
             delete=False, mode="w", newline="", encoding="utf-8"
         ) as f:
-            json.dump([record.model_dump() for record in records], f)
+            json.dump(
+                [
+                    record.model_dump(exclude_defaults=True)
+                    for record in records
+                ],
+                f,
+            )
             temp_file_path = f.name
 
         try:

--- a/camel/datahubs/models.py
+++ b/camel/datahubs/models.py
@@ -13,7 +13,7 @@
 # ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
 from typing import Any, Dict, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class Record(BaseModel):
@@ -21,5 +21,4 @@ class Record(BaseModel):
     metadata: Optional[Dict[str, Any]] = None
     content: Optional[Dict[str, Any]] = None
 
-    class Config:
-        extra = "allow"  # Allow any additional fields
+    model_config = ConfigDict(extra="allow")


### PR DESCRIPTION
## Description

fix: when the user does not use huggingface record preset fields, the preset fields will be ignored.

## Motivation and Context

close #1324

- [ ] I have raised an issue to propose this change ([required](https://github.com/camel-ai/camel/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of example)

## Implemented Tasks

- [ ] Subtask 1
- [ ] Subtask 2
- [ ] Subtask 3

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ ] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide. (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation accordingly.
