### PR TITLE
docs(cookbooks): Fix the DeprecationWarning from Composio (issue-1575)

### DIFF
--- a/docs/cookbooks/advanced_features/agents_with_tools_from_Composio.ipynb
+++ b/docs/cookbooks/advanced_features/agents_with_tools_from_Composio.ipynb
@@ -289,7 +289,7 @@
     "composio_toolset = ComposioToolSet()\n",
     "\n",
     "tools = composio_toolset.get_actions(\n",
-    "    actions=[Action.GITHUB_ACTIVITY_STAR_REPO_FOR_AUTHENTICATED_USER]\n",
+    "    actions=[Action.GITHUB_STAR_A_REPOSITORY_FOR_THE_AUTHENTICATED_USER]\n",
     ")"
    ]
   },


### PR DESCRIPTION
## Description

Fix the DeprecationWarning from Composio.

> UserWarning: Action.GITHUB_ACTIVITY_STAR_REPO_FOR_AUTHENTICATED_USER is deprecated and will be removed. Use Action.GITHUB_STAR_A_REPOSITORY_FOR_THE_AUTHENTICATED_USER instead.

Fixes #1575 

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have linked this PR to an issue using the Development section on the right sidebar or by adding `Fixes #issue-number` in the PR description (**required**)
- [ ] I have checked if any dependencies need to be added or updated in `pyproject.toml` and `poetry.lock`
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed:
- [ ] I have added examples if this is a new feature

If you are unsure about any of these, don't hesitate to ask. We are here to help!
