### PR TITLE
fix(config): Update the as_dict method in ChatGPTConfig to set tool_choice to NOT_GIVEN

### DIFF
--- a/camel/configs/openai_config.py
+++ b/camel/configs/openai_config.py
@@ -133,6 +133,7 @@ class ChatGPTConfig(BaseConfig):
                     )
                 tools_schema.append(tool.get_openai_tool_schema())
         config_dict["tools"] = NOT_GIVEN
+        config_dict["tool_choice"] = NOT_GIVEN
         return config_dict
 
 


### PR DESCRIPTION
## Description

Fixed the compatibility of parameter validation when using the vllm OAI interface. Currently, if the `tools` parameter is not provided and `tool_choice` is null, the API will throw a `BadRequestError`. The error message indicates that tools must be set when using `tool_choice`.

Fixes #1585 

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have linked this PR to an issue using the Development section on the right sidebar or by adding `Fixes #issue-number` in the PR description (**required**)
- [ ] I have checked if any dependencies need to be added or updated in `pyproject.toml` and `poetry.lock`
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed:
- [ ] I have added examples if this is a new feature

If you are unsure about any of these, don't hesitate to ask. We are here to help!
