### PR TITLE
docs(cookbooks): Fix incorrect URL in self_instruct_data_generation.ipynb

### DIFF
--- a/docs/cookbooks/data_generation/self_instruct_data_generation.ipynb
+++ b/docs/cookbooks/data_generation/self_instruct_data_generation.ipynb
@@ -211,7 +211,7 @@
     "os.makedirs('local_data', exist_ok=True)\n",
     "\n",
     "# Update the URL to the raw file content\n",
-    "url = \"https://raw.githubusercontent.com/camel-ai/camel/master/examples/synthetic_datagen/self_instruct/seed_tasks.jsonl\"\n",
+    "url = \"https://raw.githubusercontent.com/camel-ai/camel/master/examples/datagen/self_instruct/seed_tasks.jsonl\"\n",
     "\n",
     "# Fetch the raw file\n",
     "response = requests.get(url)\n",


### PR DESCRIPTION
## Description

The incorrect link is: `https://raw.githubusercontent.com/camel-ai/camel/master/examples/synthetic_datagen/self_instruct/seed_tasks.jsonl`  

Fixes #1609 

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have linked this PR to an issue using the Development section on the right sidebar or by adding `Fixes #issue-number` in the PR description (**required**)
- [ ] I have checked if any dependencies need to be added or updated in `pyproject.toml` and `poetry.lock`
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed:
- [ ] I have added examples if this is a new feature

If you are unsure about any of these, don't hesitate to ask. We are here to help!
