### PR TITLE
feat(datagen): Enhance JSON Dump in SelfInstructPipeline for Non-ASCII Character Readability

### DIFF
--- a/camel/datagen/self_instruct/self_instruct.py
+++ b/camel/datagen/self_instruct/self_instruct.py
@@ -361,7 +361,7 @@ class SelfInstructPipeline:
         in JSON format.
         """
         with open(self.data_output_path, 'w') as f:
-            json.dump(self.machine_tasks, f, indent=4)
+            json.dump(self.machine_tasks, f, indent=4, ensure_ascii=False)
 
     def generate(self):
         r"""Execute the entire pipeline to generate machine instructions


### PR DESCRIPTION
## Description

Improve the SelfInstructPipeline by setting the ensure_ascii parameter to False in the json.dump function. This change allows non-ASCII characters to be written directly, significantly enhancing the human readability of the output JSON file.

Fixes #1611 

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have linked this PR to an issue using the Development section on the right sidebar or by adding `Fixes #issue-number` in the PR description (**required**)
- [ ] I have checked if any dependencies need to be added or updated in `pyproject.toml` and `poetry.lock`
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed:
- [ ] I have added examples if this is a new feature

If you are unsure about any of these, don't hesitate to ask. We are here to help!
