### PR TITLE
docs: Correct hyperlink for Hackathon Judge Committee

### DIFF
--- a/docs/key_modules/workforce.md
+++ b/docs/key_modules/workforce.md
@@ -6,7 +6,7 @@
 > brief view on the architecture of workforce, and how you can configure
 > and utilize it to solve tasks.
 
-For more detailed usage information, please refer to our cookbook: [Create A Hackathon Judge Committee with Workforce](../cookbooks/workforce_judge_committee.ipynb)
+For more detailed usage information, please refer to our cookbook: [Create A Hackathon Judge Committee with Workforce](https://colab.research.google.com/drive/18ajYUMfwDx3WyrjHow3EvUMpKQDcrLtr?usp=sharing)
 
 ## System Design
 


### PR DESCRIPTION
## Description

This PR fixes the incorrect hyperlink in the Workforce documentation. The previous link was redirecting to the same page instead of the relevant cookbook.

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide (**required**)
- [ ] I have linked this PR to an issue using the Development section on the right sidebar or by adding `Fixes #issue-number` in the PR description (**required**)
- [ ] I have checked if any dependencies need to be added or updated in `pyproject.toml` and `poetry.lock`
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed:
- [ ] I have added examples if this is a new feature

If you are unsure about any of these, don't hesitate to ask. We are here to help!
