### PR TITLE
feat: reasoning_parameter integration

### DIFF
--- a/camel/configs/openai_config.py
+++ b/camel/configs/openai_config.py
@@ -94,6 +94,13 @@ class ChatGPTConfig(BaseConfig):
             forces the model to call that tool. :obj:`"none"` is the default
             when no tools are present. :obj:`"auto"` is the default if tools
             are present.
+        reasoning_effort(str, optional): A parameter specifying the level of
+            reasoning used by certain model types. Valid values are :obj:
+            `"low"`, :obj:`"medium"`, or :obj:`"high"`. If set, it is only
+            applied to the model types that support it (e.g., :obj:`o1`,
+            :obj:`o1mini`, :obj:`o1preview`, :obj:`o3mini`). If not provided
+            or if the model type does not support it, this parameter is
+            ignored. (default: :obj:`None`)
     """
 
     temperature: float = 0.2  # openai default: 1.0
@@ -108,6 +115,7 @@ class ChatGPTConfig(BaseConfig):
     logit_bias: Dict = Field(default_factory=dict)
     user: str = ""
     tool_choice: Optional[Union[Dict[str, str], str]] = None
+    reasoning_effort: Optional[str] = None
 
 
 OPENAI_API_PARAMS = {param for param in ChatGPTConfig.model_fields.keys()}


### PR DESCRIPTION
## Description

Added the reasoning_effort parameter into the Openai_config for reasoning model support 

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

- [X ] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide (**required**)
- [X ] I have linked this PR to an issue using the Development section on the right sidebar or by adding `Fixes #issue-number` in the PR description (**required**)
- [ X] I have checked if any dependencies need to be added or updated in `pyproject.toml` and `poetry.lock`
- [ X] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [X ] I have updated the documentation if needed:
- [ X] I have added examples if this is a new feature

If you are unsure about any of these, don't hesitate to ask. We are here to help!
