### PR TITLE
fix cookbook link + missing import for tools section

### DIFF
--- a/docs/cookbooks/basic_concepts/create_your_first_agent.ipynb
+++ b/docs/cookbooks/basic_concepts/create_your_first_agent.ipynb
@@ -250,7 +250,7 @@
       },
       "source": [
         "### 🔧 Tool Usage\n",
-        "For more detailed tool settings, please go to our [tools cookbook](https://docs.camel-ai.org/cookbooks/agents_with_tools.html)."
+        "For more detailed tool settings, please go to our [tools cookbook](https://docs.camel-ai.org/cookbooks/advanced_features/agents_with_tools.html)."
       ]
     },
     {

--- a/docs/get_started/installation.md
+++ b/docs/get_started/installation.md
@@ -162,7 +162,7 @@ import os
 load_dotenv()
 ```
 For more details about the key names in project and how to apply key, 
-you can refer to [here](https://github.com/camel-ai/camel/.env).
+you can refer to [here](./setup.md).
 
 > [!TIP]
 > By default, the load_dotenv() function does not overwrite existing environment variables that are already set in your system. It only populates variables that are missing.

--- a/docs/key_modules/memory.md
+++ b/docs/key_modules/memory.md
@@ -1,6 +1,6 @@
 # Memory
 
-For more detailed usage information, please refer to our cookbook: [Memory Cookbook](../cookbooks/agents_with_memory.ipynb)
+For more detailed usage information, please refer to our cookbook: [Memory Cookbook](../cookbooks/advanced_features/agents_with_memory.ipynb)
 
 ## 1. Concept
 The Memory module in CAMEL provides a flexible and powerful system for storing, retrieving, and managing information for AI agents. It enables agents to maintain context across conversations and retrieve relevant information from past interactions, enhancing the coherence and relevance of AI responses.

--- a/docs/key_modules/retrievers.md
+++ b/docs/key_modules/retrievers.md
@@ -1,6 +1,6 @@
 # Retrievers
 
-For more detailed usage information, please refer to our cookbook: [RAG Cookbook](../cookbooks/agents_with_rag.ipynb)
+For more detailed usage information, please refer to our cookbook: [RAG Cookbook](../cookbooks/advanced_features/agents_with_rag.ipynb)
 
 ## 1. Concept
 The Retrievers module is essentially a search engine. It's designed to help you find specific pieces of information by searching through large volumes of text. Imagine you have a huge library of books and you want to find where certain topics or keywords are mentioned, this module is like a librarian that helps you do just that.

--- a/docs/key_modules/tasks.md
+++ b/docs/key_modules/tasks.md
@@ -1,6 +1,6 @@
 # Task
 
-For more detailed usage information, please refer to our cookbook: [Task Generation Cookbook](../cookbooks/task_generation.ipynb)
+For more detailed usage information, please refer to our cookbook: [Task Generation Cookbook](../cookbooks/multi_agent_society/task_generation.ipynb)
 
 ## 1. Concept
 > In the CAMEL framework, a task is a specific assignment that can be delegated to an agent and resolved by that agent. Tasks represent a higher-level concept than prompts and should be managed by other modules such as the Planner and Workforce. There are two key characteristics of a task: 

--- a/docs/key_modules/tools.md
+++ b/docs/key_modules/tools.md
@@ -1,6 +1,6 @@
 # Tools
 
-For more detailed usage information, please refer to our cookbook: [Tools Cookbook](../cookbooks/agents_with_tools.ipynb)
+For more detailed usage information, please refer to our cookbook: [Tools Cookbook](../cookbooks/advanced_features/agents_with_tools.ipynb)
 
 ## 1. Concept
 Tools serve as interfaces that allow LLMs and Agents to interact with the world. A tool is essentially a function that has a name, a description, input parameters, and an output type. In this section, we will introduce the tools currently supported by CAMEL and explain how to define your own tools and Toolkits.
@@ -122,7 +122,7 @@ tools = toolkit.get_tools()
 To utilize specific tools from the toolkits, you can implement code like the following:
 
 ```python
-from camel.toolkits import SearchToolkit
+from camel.toolkits import FunctionTool, SearchToolkit
 
 google_tool = FunctionTool(SearchToolkit().search_google)
 wiki_tool = FunctionTool(SearchToolkit().search_wiki)


### PR DESCRIPTION
The cookbook link was outdated in the docs and added a missing import.
