### PR TITLE
fix: postprocessing error for yt-dlp by sanitizing file names in FileWriteToolkit

### DIFF
--- a/camel/toolkits/file_write_toolkit.py
+++ b/camel/toolkits/file_write_toolkit.py
@@ -85,7 +85,7 @@ class FileWriteToolkit(BaseToolkit):
             path_obj = self.output_dir / path_obj
 
         sanitized_filename = self._sanitize_filename(path_obj.name)
-        path_obj = path_obj.parent/sanitized_filename
+        path_obj = path_obj.parent / sanitized_filename
         return path_obj.resolve()
 
     def _write_text_file(
@@ -375,16 +375,19 @@ class FileWriteToolkit(BaseToolkit):
         return [
             FunctionTool(self.write_to_file),
         ]
-        
-    def _sanitize_filename(self,filename: str)-> str:
-        r"""Sanitize a filename by replacing any character that is not alphanumeric,
-        a dot (.), hyphen (-), or underscore (_) with an underscore (_).
+
+    def _sanitize_filename(self, filename: str) -> str:
+        r"""Sanitize a filename by replacing any character that is not
+        alphanumeric, a dot (.), hyphen (-), or underscore (_) with an
+        underscore (_).
 
         Args:
-            filename (str): The original filename which may contain spaces or special characters.
+            filename (str): The original filename which may contain spaces or
+                special characters.
 
         Returns:
-            str: The sanitized filename with disallowed characters replaced by underscores.
+            str: The sanitized filename with disallowed characters replaced by
+                underscores.
         """
         safe = re.sub(r'[^\w\-.]', '_', filename)
         return safe

--- a/camel/toolkits/file_write_toolkit.py
+++ b/camel/toolkits/file_write_toolkit.py
@@ -13,6 +13,7 @@
 # ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
 
 
+import re
 from datetime import datetime
 from pathlib import Path
 from typing import List, Optional, Union
@@ -69,17 +70,22 @@ class FileWriteToolkit(BaseToolkit):
         r"""Convert the given string path to a Path object.
 
         If the provided path is not absolute, it is made relative to the
-        default output directory.
+        default output directory. The filename part is sanitized to replace
+        spaces and special characters with underscores, ensuring safe usage
+        in downstream processing.
 
         Args:
             file_path (str): The file path to resolve.
 
         Returns:
-            Path: A fully resolved (absolute) Path object.
+            Path: A fully resolved (absolute) and sanitized Path object.
         """
         path_obj = Path(file_path)
         if not path_obj.is_absolute():
             path_obj = self.output_dir / path_obj
+
+        sanitized_filename = self._sanitize_filename(path_obj.name)
+        path_obj = path_obj.parent/sanitized_filename
         return path_obj.resolve()
 
     def _write_text_file(
@@ -369,3 +375,16 @@ class FileWriteToolkit(BaseToolkit):
         return [
             FunctionTool(self.write_to_file),
         ]
+        
+    def _sanitize_filename(self,filename: str)-> str:
+        r"""Sanitize a filename by replacing any character that is not alphanumeric,
+        a dot (.), hyphen (-), or underscore (_) with an underscore (_).
+
+        Args:
+            filename (str): The original filename which may contain spaces or special characters.
+
+        Returns:
+            str: The sanitized filename with disallowed characters replaced by underscores.
+        """
+        safe = re.sub(r'[^\w\-.]', '_', filename)
+        return safe

--- a/test/toolkits/test_file_write_toolkit.py
+++ b/test/toolkits/test_file_write_toolkit.py
@@ -308,21 +308,23 @@ def test_get_tools(file_write_toolkit):
     # Check that the tool has the correct function name
     assert tools[0].get_function_name() == "write_to_file"
 
+
 def test_sanitize_and_resolve_filepath(file_write_toolkit):
-    r"""Test that _resolve_filepath sanitizes filenames 
+    r"""Test that _resolve_filepath sanitizes filenames
     with spaces and special characters.
     """
     # Filename with spaces and special characters
     unsafe_filename = "My Video: How to Fix! File @ Name?.md"
-    # Expected sanitized filename (all disallowed characters replaced by underscores)
+    # Expected sanitized filename (all disallowed characters replaced by
+    # underscores)
     expected_sanitized = file_write_toolkit._sanitize_filename(unsafe_filename)
-    
+
     # Resolve the filepath using the toolkit
     resolved_path = file_write_toolkit._resolve_filepath(unsafe_filename)
     # Expected path is in the toolkit's output_dir with the sanitized filename
     expected_path = file_write_toolkit.output_dir / expected_sanitized
 
     # Check that the resolved path matches the expected path
-    assert resolved_path == expected_path.resolve(), (
-        "The resolved file path does not match the expected sanitized path."
-    )
+    assert (
+        resolved_path == expected_path.resolve()
+    ), "The resolved file path does not match the expected sanitized path."

--- a/test/toolkits/test_file_write_toolkit.py
+++ b/test/toolkits/test_file_write_toolkit.py
@@ -307,3 +307,22 @@ def test_get_tools(file_write_toolkit):
 
     # Check that the tool has the correct function name
     assert tools[0].get_function_name() == "write_to_file"
+
+def test_sanitize_and_resolve_filepath(file_write_toolkit):
+    r"""Test that _resolve_filepath sanitizes filenames 
+    with spaces and special characters.
+    """
+    # Filename with spaces and special characters
+    unsafe_filename = "My Video: How to Fix! File @ Name?.md"
+    # Expected sanitized filename (all disallowed characters replaced by underscores)
+    expected_sanitized = file_write_toolkit._sanitize_filename(unsafe_filename)
+    
+    # Resolve the filepath using the toolkit
+    resolved_path = file_write_toolkit._resolve_filepath(unsafe_filename)
+    # Expected path is in the toolkit's output_dir with the sanitized filename
+    expected_path = file_write_toolkit.output_dir / expected_sanitized
+
+    # Check that the resolved path matches the expected path
+    assert resolved_path == expected_path.resolve(), (
+        "The resolved file path does not match the expected sanitized path."
+    )


### PR DESCRIPTION
## Description

Solves issue in OWL - https://github.com/camel-ai/owl/issues/346

file names generated from video titles (or other metadata) often include spaces and special characters

when calls ytdlp it passes these strings directly 

need to sanitize the way `file_write_toolkit` works - removes dot(.) dash(-) with underscore(_)

added a test function for the same 


## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have linked this PR to an issue using the Development section on the right sidebar or by adding `Fixes #issue-number` in the PR description (**required**)
- [x] I have checked if any dependencies need to be added or updated in `pyproject.toml` and `uv lock`
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed:
- [ ] I have added examples if this is a new feature

If you are unsure about any of these, don't hesitate to ask. We are here to help!
