### PR TITLE
fix: api_key and base_url set in environment is not effective for OpenAICompatibleModel

### DIFF
--- a/camel/models/openai_compatible_model.py
+++ b/camel/models/openai_compatible_model.py
@@ -56,10 +56,8 @@ class OpenAICompatibleModel(BaseModelBackend):
         url: Optional[str] = None,
         token_counter: Optional[BaseTokenCounter] = None,
     ) -> None:
-        self.api_key = api_key or os.environ.get(
-            "OPENAI_COMPATIBILITY_API_KEY"
-        )
-        self.url = url or os.environ.get("OPENAI_COMPATIBILITY_API_BASE_URL")
+        api_key = api_key or os.environ.get("OPENAI_COMPATIBILITY_API_KEY")
+        url = url or os.environ.get("OPENAI_COMPATIBILITY_API_BASE_URL")
         super().__init__(
             model_type, model_config_dict, api_key, url, token_counter
         )

--- a/test/models/test_openai_compatible_model.py
+++ b/test/models/test_openai_compatible_model.py
@@ -1,0 +1,62 @@
+# ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
+import pytest
+from httpx import URL
+from pytest import MonkeyPatch
+
+from camel.models import OpenAICompatibleModel
+from camel.types import ModelType
+from camel.utils import OpenAITokenCounter
+
+
+@pytest.mark.model_backend
+@pytest.mark.parametrize(
+    "model_type",
+    [
+        ModelType.GPT_3_5_TURBO,
+        ModelType.GPT_4,
+        ModelType.GPT_4_TURBO,
+        ModelType.GPT_4O,
+        ModelType.GPT_4O_MINI,
+        ModelType.O1,
+        ModelType.O1_PREVIEW,
+        ModelType.O1_MINI,
+        ModelType.GPT_4_5_PREVIEW,
+    ],
+)
+def test_openai_compatible_model(model_type: ModelType):
+    model = OpenAICompatibleModel(model_type)
+    assert model.model_type == model_type
+    assert model.model_config_dict == {}
+    assert isinstance(model.token_counter, OpenAITokenCounter)
+    assert isinstance(model.model_type.value_for_tiktoken, str)
+    assert isinstance(model.model_type.token_limit, int)
+
+
+@pytest.mark.model_backend
+def test_openai_compatible_model_apikey_from_env(monkeypatch: MonkeyPatch):
+    model_type = ModelType.GPT_4O
+    api_key = "api_key_from_env_for_testing"
+    url = "https://api.url_from_env_for_testing.com/v1/"
+
+    monkeypatch.setenv("OPENAI_COMPATIBILITY_API_KEY", api_key)
+    monkeypatch.setenv("OPENAI_COMPATIBILITY_API_BASE_URL", url)
+
+    model = OpenAICompatibleModel(model_type, api_key=None, url=None)
+    assert model._api_key == api_key
+    assert model._url == URL(url)
+    assert model._client.api_key == api_key
+    assert model._client.base_url == URL(url)
+    assert model._async_client.api_key == api_key
+    assert model._async_client.base_url == URL(url)


### PR DESCRIPTION
## Description

This PR fixes an issue in the `OpenAICompatibleModel` initializer. Previously, the API key and URL retrieved from the environment variables were assigned to member variables `self.api_key` and `self.url`, but the parent class constructor was still using the original parameters `api_key` and `url` instead of the updated ones. This bug makes the environment variables ineffective.

I fixed this and wrote a simple test for `OpenAICompatibleModel`.

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide (**required**)
- [ ] I have linked this PR to an issue using the Development section on the right sidebar or by adding `Fixes #issue-number` in the PR description (**required**)
- [x] I have checked if any dependencies need to be added or updated in `pyproject.toml` and `uv lock`
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed:
- [ ] I have added examples if this is a new feature

Note: Seems that there's no such an issue mentioning this.
