### PR TITLE
refactor: Simplify usage of Verifier

### DIFF
--- a/camel/datasets/few_shot_generator.py
+++ b/camel/datasets/few_shot_generator.py
@@ -22,7 +22,6 @@ from camel.agents import ChatAgent
 from camel.logger import get_logger
 from camel.models.base_model import BaseModelBackend
 from camel.verifiers import BaseVerifier
-from camel.verifiers.models import VerifierInput
 
 from .base_generator import BaseGenerator
 from .models import DataPoint
@@ -203,10 +202,8 @@ class FewShotGenerator(BaseGenerator):
 
                 try:
                     verifier_response = await self.verifier.verify(
-                        VerifierInput(
-                            llm_response=rationale,
-                            ground_truth=None,
-                        )
+                        solution=rationale,
+                        ground_truth=None,
                     )
                     if not verifier_response or not verifier_response.result:
                         raise ValueError(

--- a/camel/environments/single_step.py
+++ b/camel/environments/single_step.py
@@ -23,9 +23,6 @@ from camel.verifiers.base import (
     BaseVerifier,
     VerificationResult,
 )
-from camel.verifiers.models import (
-    VerifierInput,
-)
 
 from .models import Action, Observation, StepResult
 
@@ -189,10 +186,7 @@ class SingleStepEnv:
 
         # verify the extracted
         verification_result = await self.verifier.verify(
-            VerifierInput(
-                llm_response=extraction_result,
-                ground_truth=self._state.final_answer,
-            )
+            solution=extraction_result, ground_truth=self._state.final_answer
         )
 
         # compute rewards

--- a/camel/verifiers/__init__.py
+++ b/camel/verifiers/__init__.py
@@ -12,12 +12,11 @@
 # limitations under the License.
 # ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
 from .base import BaseVerifier
-from .models import VerificationOutcome, VerifierInput
+from .models import VerificationOutcome
 from .python_verifier import PythonVerifier
 
 __all__ = [
     "BaseVerifier",
     "VerificationOutcome",
-    "VerifierInput",
     "PythonVerifier",
 ]

--- a/camel/verifiers/models.py
+++ b/camel/verifiers/models.py
@@ -18,18 +18,6 @@ from typing import Any, Dict, Optional
 from pydantic import BaseModel, Field
 
 
-class VerifierInput(BaseModel):
-    r"""Structured input to the verifier"""
-
-    llm_response: str = Field(
-        description="The LLM response to be verified."
-        "Needs to be in a format that the verifier can handle."
-    )
-    ground_truth: Optional[str] = Field(
-        None, description="The ground truth data, if available."
-    )
-
-
 class VerificationOutcome(Enum):
     r"""Enum representing the status of a verification."""
 

--- a/examples/verifier/python_verifier_example.py
+++ b/examples/verifier/python_verifier_example.py
@@ -13,7 +13,7 @@
 # ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
 import asyncio
 
-from camel.verifiers import PythonVerifier, VerifierInput
+from camel.verifiers import PythonVerifier
 
 verifier = PythonVerifier(required_packages=["numpy"])
 asyncio.run(verifier.setup())
@@ -29,12 +29,14 @@ print(result)
 
 # Since the output of the above numpy code evaluates to 32,
 # we expect the verification outcome to be a success.
-response = VerifierInput(llm_response=numpy_test_code, ground_truth="32")
-result = asyncio.run(verifier.verify(response))
+result = asyncio.run(
+    verifier.verify(solution=numpy_test_code, ground_truth="32")
+)
 print(f"Result: {result.status}")
 
-response = VerifierInput(llm_response=numpy_test_code, ground_truth="40")
-result = asyncio.run(verifier.verify(response))
+result = asyncio.run(
+    verifier.verify(solution=numpy_test_code, ground_truth="40")
+)
 
 # Now we expect the VerificationOutcome to be a failure,
 # because the answer is wrong.

--- a/test/verifiers/test_base_verifier.py
+++ b/test/verifiers/test_base_verifier.py
@@ -13,16 +13,13 @@
 # ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
 
 import asyncio
+from typing import Optional
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from camel.verifiers.base import BaseVerifier
-from camel.verifiers.models import (
-    VerificationOutcome,
-    VerificationResult,
-    VerifierInput,
-)
+from camel.verifiers.models import VerificationOutcome, VerificationResult
 
 
 class TestVerifier(BaseVerifier):
@@ -35,19 +32,19 @@ class TestVerifier(BaseVerifier):
         self.cleanup_called = True
 
     async def _verify_implementation(
-        self, result: VerifierInput
+        self, solution: str, ground_truth: Optional[str] = None
     ) -> VerificationResult:
         r"""Simple implementation that returns success or failure based on
         input.
         """
-        if "fail" in result.llm_response.lower():
+        if "fail" in solution.lower():
             return VerificationResult(
                 status=VerificationOutcome.FAILURE,
                 result="Verification failed",
             )
-        elif "error" in result.llm_response.lower():
+        elif "error" in solution.lower():
             raise ValueError("Simulated error in verification")
-        elif "timeout" in result.llm_response.lower():
+        elif "timeout" in solution.lower():
             raise asyncio.TimeoutError("Simulated timeout")
         else:
             return VerificationResult(
@@ -140,10 +137,8 @@ async def test_verify_success(test_verifier):
     await test_verifier.setup()
 
     result = await test_verifier.verify(
-        VerifierInput(
-            llm_response="This is a successful response",
-            ground_truth="Expected response",
-        )
+        solution="This is a successful response",
+        ground_truth="Expected response",
     )
 
     assert result.status == VerificationOutcome.SUCCESS
@@ -160,10 +155,8 @@ async def test_verify_failure(test_verifier):
     await test_verifier.setup()
 
     result = await test_verifier.verify(
-        VerifierInput(
-            llm_response="This will fail the verification",
-            ground_truth="Expected response",
-        )
+        solution="This will fail the verification",
+        ground_truth="Expected response",
     )
 
     assert result.status == VerificationOutcome.FAILURE
@@ -183,10 +176,8 @@ async def test_verify_error_with_retry(test_verifier):
 
     with patch("asyncio.sleep", new_callable=AsyncMock):
         result = await test_verifier.verify(
-            VerifierInput(
-                llm_response="This will cause an error",
-                ground_truth="Expected response",
-            )
+            solution="This will cause an error",
+            ground_truth="Expected response",
         )
 
         assert result.status == VerificationOutcome.ERROR
@@ -208,10 +199,8 @@ async def test_verify_timeout(test_verifier):
         side_effect=asyncio.TimeoutError("Simulated timeout"),
     ):
         result = await test_verifier.verify(
-            VerifierInput(
-                llm_response="This will timeout",
-                ground_truth="Expected response",
-            )
+            solution="This will timeout",
+            ground_truth="Expected response",
         )
 
         assert result.status == VerificationOutcome.TIMEOUT
@@ -233,9 +222,7 @@ async def test_verify_not_setup():
         )
     )
 
-    await verifier.verify(
-        VerifierInput(llm_response="Test", ground_truth="Expected")
-    )
+    await verifier.verify(solution="Test", ground_truth="Expected")
 
     verifier.setup.assert_called_once()
 
@@ -270,15 +257,10 @@ async def test_verify_batch(test_verifier):
             test_verifier, *args, **kwargs
         )
 
-        inputs = [
-            VerifierInput(llm_response="Success 1", ground_truth="Expected 1"),
-            VerifierInput(llm_response="Success 2", ground_truth="Expected 2"),
-            VerifierInput(
-                llm_response="This will fail", ground_truth="Expected 3"
-            ),
-        ]
+        solutions = (["Success 1", "Success 2", "This will fail"],)
+        ground_truthes = (["Expected 1", "Expected 2", "Expected 3"],)
 
-        results = await test_verifier.verify_batch(inputs)
+        results = await test_verifier.verify_batch(solutions, ground_truthes)
 
         assert len(results) == 3
         assert results[0].status == VerificationOutcome.SUCCESS
@@ -315,20 +297,17 @@ async def test_verify_batch_with_error_handling(test_verifier):
             test_verifier, *args, **kwargs
         )
 
-        inputs = [
-            VerifierInput(llm_response="Success", ground_truth="Expected 1"),
-            VerifierInput(
-                llm_response="This will cause an error",
-                ground_truth="Expected 2",
-            ),
-        ]
+        solutions = (["Success", "This will cause an error"],)
+        ground_truthes = ["Expected 1", "Expected 2"]
 
         with pytest.raises(
             RuntimeError, match="One or more verifications failed"
         ):
-            await test_verifier.verify_batch(inputs, raise_on_error=True)
+            await test_verifier.verify_batch(
+                solutions, ground_truthes, raise_on_error=True
+            )
 
-        results = await test_verifier.verify_batch(inputs)
+        results = await test_verifier.verify_batch(solutions, ground_truthes)
         assert len(results) == 2
         assert results[0].status == VerificationOutcome.SUCCESS
         assert results[1].status == VerificationOutcome.ERROR
@@ -354,28 +333,26 @@ async def test_verify_batch_concurrency_limiting(test_verifier):
         async def __aexit__(self, *args):
             self.count -= 1
 
-    inputs = [
-        VerifierInput(
-            llm_response=f"Success {i}", ground_truth=f"Expected {i}"
-        )
-        for i in range(3)
-    ]
+    solutions = (["Success 1", "Success 2", "Success 3"],)
+    ground_truthes = (["Expected 1", "Expected 2", "Expected 3"],)
 
     mock_sem = MockSemaphore(1)
 
-    async def patched_verify_batch(verifier, inputs, raise_on_error=False):
+    async def patched_verify_batch(
+        verifier, solutions, ground_truthes, raise_on_error=False
+    ):
         results = []
-        for input_data in inputs:
+        for solution, ground_truth in zip(solutions, ground_truthes):
             async with mock_sem:
                 await asyncio.sleep(0.01)  # Simulate processing time
-                results.append(await verifier.verify(input_data))
+                results.append(await verifier.verify(solution, ground_truth))
         return results
 
     test_verifier.verify_batch = lambda *args, **kwargs: patched_verify_batch(
         test_verifier, *args, **kwargs
     )
 
-    await test_verifier.verify_batch(inputs)
+    await test_verifier.verify_batch(solutions, ground_truthes)
 
     assert mock_sem.max_count == 1
 
@@ -392,25 +369,19 @@ async def test_full_verification_flow():
         assert verifier._is_setup is True
 
         success_result = await verifier.verify(
-            VerifierInput(
-                llm_response="This should succeed", ground_truth="Expected"
-            )
+            solution="This should succeed", ground_truth="Expected"
         )
         assert success_result.status == VerificationOutcome.SUCCESS
 
         failure_result = await verifier.verify(
-            VerifierInput(
-                llm_response="This will fail", ground_truth="Expected"
-            )
+            solution="This will fail", ground_truth="Expected"
         )
         assert failure_result.status == VerificationOutcome.FAILURE
 
         with patch("asyncio.sleep", new_callable=AsyncMock):
             error_result = await verifier.verify(
-                VerifierInput(
-                    llm_response="This will cause an error",
-                    ground_truth="Expected",
-                )
+                solution="This will cause an error",
+                ground_truth="Expected",
             )
             assert error_result.status == VerificationOutcome.ERROR
 

--- a/test/verifiers/test_python_verifier.py
+++ b/test/verifiers/test_python_verifier.py
@@ -17,7 +17,6 @@ import pytest
 
 from camel.verifiers.models import (
     VerificationOutcome,
-    VerifierInput,
 )
 from camel.verifiers.python_verifier import PythonVerifier
 
@@ -48,7 +47,7 @@ async def test_python_verifier_execution_success(python_verifier):
 
     script = 'print("Hello, World!")'
     result = await python_verifier._verify_implementation(
-        VerifierInput(llm_response=script)
+        solution=script, ground_truth=None
     )
 
     assert result.status == VerificationOutcome.SUCCESS
@@ -64,7 +63,7 @@ async def test_python_verifier_execution_failure(python_verifier):
 
     script = 'print("Hello"'  # Syntax error
     result = await python_verifier._verify_implementation(
-        VerifierInput(llm_response=script)
+        solution=script, ground_truth=None
     )
 
     assert result.status == VerificationOutcome.ERROR
@@ -81,7 +80,7 @@ async def test_python_verifier_execution_timeout(python_verifier):
 
     script = 'import time; time.sleep(5)'
     result = await python_verifier._verify_implementation(
-        VerifierInput(llm_response=script)
+        solution=script, ground_truth=None
     )
 
     assert result.status == VerificationOutcome.TIMEOUT
@@ -97,7 +96,7 @@ async def test_python_verifier_output_mismatch(python_verifier):
 
     script = 'print("Wrong output")'
     result = await python_verifier._verify_implementation(
-        VerifierInput(llm_response=script, ground_truth="Expected output")
+        solution=script, ground_truth="Expected output"
     )
 
     assert result.status == VerificationOutcome.FAILURE
@@ -113,7 +112,7 @@ async def test_python_verifier_correct_output_matching(python_verifier):
 
     script = 'print("Expected output")'
     result = await python_verifier._verify_implementation(
-        VerifierInput(llm_response=script, ground_truth="Expected output")
+        solution=script, ground_truth="Expected output"
     )
 
     assert result.status == VerificationOutcome.SUCCESS
@@ -128,7 +127,7 @@ async def test_python_verifier_no_venv_error():
     verifier = PythonVerifier()
     script = 'print("Hello")'
     result = await verifier._verify_implementation(
-        VerifierInput(llm_response=script)
+        solution=script, ground_truth=None
     )
 
     assert result.status == VerificationOutcome.ERROR
@@ -142,7 +141,7 @@ async def test_python_verifier_with_numpy(python_verifier):
 
     script = 'import numpy as np; print(np.array([1, 2, 3]))'
     result = await python_verifier._verify_implementation(
-        VerifierInput(llm_response=script)
+        solution=script, ground_truth=None
     )
 
     assert result.status == VerificationOutcome.SUCCESS


### PR DESCRIPTION
## Description

In this PR, I want to simplify the usage of Verifier, which is currently quite cumbersome.

The user has to define a `VerifierInput` BaseModel, which is defined in `camel.verifiers.models` and contains `llm_response: str` and `ground_truth: Optional[str]`. This naming has also lead to much confusion among contributors and researchers.

To simplify usage, I propose to remove the BaseModel for `VerifierInput` and rename `llm_response` to `solution`, since a solution is what is verified and compared against a ground truth, which does not necessarily have to be an LLM response.

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide (**required**)
- [ ] I have linked this PR to an issue using the Development section on the right sidebar or by adding `Fixes #issue-number` in the PR description (**required**)
- [ ] I have checked if any dependencies need to be added or updated in `pyproject.toml` and `uv lock`
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed:
- [ ] I have added examples if this is a new feature