### PR TITLE
chore: make the default selection for sanbox to subprocess in the Code_execution Toolkit.

### DIFF
--- a/camel/toolkits/code_execution.py
+++ b/camel/toolkits/code_execution.py
@@ -29,6 +29,7 @@ class CodeExecutionToolkit(BaseToolkit):
 
     Args:
         sandbox (str): The environment type used to execute code.
+            (default: `subprocess`)
         verbose (bool): Whether to print the output of the code execution.
             (default: :obj:`False`)
         unsafe_mode (bool):  If `True`, the interpreter runs the code
@@ -43,7 +44,7 @@ class CodeExecutionToolkit(BaseToolkit):
         self,
         sandbox: Literal[
             "internal_python", "jupyter", "docker", "subprocess", "e2b"
-        ] = "internal_python",
+        ] = "subprocess",
         verbose: bool = False,
         unsafe_mode: bool = False,
         import_white_list: Optional[List[str]] = None,


### PR DESCRIPTION
This PR make the default selection for sanbox to subprocess in the Code_execution Toolkit.

Links #1920 