### PR TITLE
fix: stream prop for groq

### DIFF
--- a/camel/models/groq_model.py
+++ b/camel/models/groq_model.py
@@ -195,7 +195,10 @@ class GroqModel(BaseModelBackend):
 
     @property
     def stream(self) -> bool:
-        r"""Returns whether the model supports streaming. But Groq API does
-        not support streaming.
+        r"""Returns whether the model is in stream mode, which sends partial
+        results each time.
+
+        Returns:
+            bool: Whether the model is in stream mode.
         """
-        return False
+        return self.model_config_dict.get("stream", False)


### PR DESCRIPTION
This PR addresses the stream flag turned off in groq.

I noticed that the docs for it mentioned it can stream - https://console.groq.com/docs/text-chat