### PR TITLE
feat: adding timeout for basemodel backend

### DIFF
--- a/camel/models/aiml_model.py
+++ b/camel/models/aiml_model.py
@@ -52,6 +52,10 @@ class AIMLModel(BaseModelBackend):
             use for the model. If not provided, :obj:`OpenAITokenCounter(
             ModelType.GPT_4O_MINI)` will be used.
             (default: :obj:`None`)
+        timeout (Optional[float], optional): The timeout value in seconds for
+            API calls. If not provided, will fall back to the MODEL_TIMEOUT
+            environment variable or default to 180 seconds.
+            (default: :obj:`None`)
     """
 
     @api_keys_required([("api_key", "AIML_API_KEY")])
@@ -62,6 +66,7 @@ class AIMLModel(BaseModelBackend):
         api_key: Optional[str] = None,
         url: Optional[str] = None,
         token_counter: Optional[BaseTokenCounter] = None,
+        timeout: Optional[float] = None,
     ) -> None:
         if model_config_dict is None:
             model_config_dict = AIMLConfig().as_dict()
@@ -70,17 +75,18 @@ class AIMLModel(BaseModelBackend):
             "AIML_API_BASE_URL",
             "https://api.aimlapi.com/v1",
         )
+        timeout = timeout or float(os.environ.get("MODEL_TIMEOUT", 180))
         super().__init__(
-            model_type, model_config_dict, api_key, url, token_counter
+            model_type, model_config_dict, api_key, url, token_counter, timeout
         )
         self._client = OpenAI(
-            timeout=180,
+            timeout=self._timeout,
             max_retries=3,
             api_key=self._api_key,
             base_url=self._url,
         )
         self._async_client = AsyncOpenAI(
-            timeout=180,
+            timeout=self._timeout,
             max_retries=3,
             api_key=self._api_key,
             base_url=self._url,

--- a/camel/models/anthropic_model.py
+++ b/camel/models/anthropic_model.py
@@ -45,6 +45,10 @@ class AnthropicModel(BaseModelBackend):
         token_counter (Optional[BaseTokenCounter], optional): Token counter to
             use for the model. If not provided, :obj:`AnthropicTokenCounter`
             will be used. (default: :obj:`None`)
+        timeout (Optional[float], optional): The timeout value in seconds for
+            API calls. If not provided, will fall back to the MODEL_TIMEOUT
+            environment variable or default to 180 seconds.
+            (default: :obj:`None`)
     """
 
     @api_keys_required(
@@ -60,6 +64,7 @@ class AnthropicModel(BaseModelBackend):
         api_key: Optional[str] = None,
         url: Optional[str] = None,
         token_counter: Optional[BaseTokenCounter] = None,
+        timeout: Optional[float] = None,
     ) -> None:
         from openai import AsyncOpenAI, OpenAI
 
@@ -71,13 +76,16 @@ class AnthropicModel(BaseModelBackend):
             or os.environ.get("ANTHROPIC_API_BASE_URL")
             or "https://api.anthropic.com/v1/"
         )
+        timeout = timeout or float(os.environ.get("MODEL_TIMEOUT", 180))
         super().__init__(
-            model_type, model_config_dict, api_key, url, token_counter
+            model_type, model_config_dict, api_key, url, token_counter, timeout
         )
-        self.client = OpenAI(base_url=self._url, api_key=self._api_key)
+        self.client = OpenAI(
+            base_url=self._url, api_key=self._api_key, timeout=self._timeout
+        )
 
         self.async_client = AsyncOpenAI(
-            api_key=self._api_key, base_url=self._url
+            api_key=self._api_key, base_url=self._url, timeout=self._timeout
         )
 
     @property

--- a/camel/models/azure_openai_model.py
+++ b/camel/models/azure_openai_model.py
@@ -49,6 +49,10 @@ class AzureOpenAIModel(BaseModelBackend):
         token_counter (Optional[BaseTokenCounter], optional): Token counter to
             use for the model. If not provided, :obj:`OpenAITokenCounter`
             will be used. (default: :obj:`None`)
+        timeout (Optional[float], optional): The timeout value in seconds for
+            API calls. If not provided, will fall back to the MODEL_TIMEOUT
+            environment variable or default to 180 seconds.
+            (default: :obj:`None`)
 
     References:
         https://learn.microsoft.com/en-us/azure/ai-services/openai/
@@ -60,6 +64,7 @@ class AzureOpenAIModel(BaseModelBackend):
         model_config_dict: Optional[Dict[str, Any]] = None,
         api_key: Optional[str] = None,
         url: Optional[str] = None,
+        timeout: Optional[float] = None,
         token_counter: Optional[BaseTokenCounter] = None,
         api_version: Optional[str] = None,
         azure_deployment_name: Optional[str] = None,
@@ -68,8 +73,9 @@ class AzureOpenAIModel(BaseModelBackend):
             model_config_dict = ChatGPTConfig().as_dict()
         api_key = api_key or os.environ.get("AZURE_OPENAI_API_KEY")
         url = url or os.environ.get("AZURE_OPENAI_BASE_URL")
+        timeout = timeout or float(os.environ.get("MODEL_TIMEOUT", 180))
         super().__init__(
-            model_type, model_config_dict, api_key, url, token_counter
+            model_type, model_config_dict, api_key, url, token_counter, timeout
         )
 
         self.api_version = api_version or os.environ.get("AZURE_API_VERSION")
@@ -92,7 +98,7 @@ class AzureOpenAIModel(BaseModelBackend):
             azure_deployment=self.azure_deployment_name,
             api_version=self.api_version,
             api_key=self._api_key,
-            timeout=180,
+            timeout=self._timeout,
             max_retries=3,
         )
 
@@ -101,7 +107,7 @@ class AzureOpenAIModel(BaseModelBackend):
             azure_deployment=self.azure_deployment_name,
             api_version=self.api_version,
             api_key=self._api_key,
-            timeout=180,
+            timeout=self._timeout,
             max_retries=3,
         )
 

--- a/camel/models/base_audio_model.py
+++ b/camel/models/base_audio_model.py
@@ -26,6 +26,7 @@ class BaseAudioModel(ABC):
         self,
         api_key: Optional[str] = None,
         url: Optional[str] = None,
+        timeout: Optional[float] = None,
     ) -> None:
         r"""Initialize an instance of BaseAudioModel.
 
@@ -36,9 +37,14 @@ class BaseAudioModel(ABC):
             url (Optional[str]): Base URL for the audio API. If not provided,
                 will use a default URL or look for an environment variable
                 specific to the implementation.
+            timeout (Optional[float], optional): The timeout value in seconds
+            for API calls. If not provided, will fall back to the
+            MODEL_TIMEOUT environment variable or default to 180 seconds.
+            (default: :obj:`None`)
         """
         self._api_key = api_key
         self._url = url
+        self._timeout = timeout
 
     @abstractmethod
     def text_to_speech(

--- a/camel/models/base_audio_model.py
+++ b/camel/models/base_audio_model.py
@@ -38,9 +38,9 @@ class BaseAudioModel(ABC):
                 will use a default URL or look for an environment variable
                 specific to the implementation.
             timeout (Optional[float], optional): The timeout value in seconds
-            for API calls. If not provided, will fall back to the
-            MODEL_TIMEOUT environment variable or default to 180 seconds.
-            (default: :obj:`None`)
+                for API calls. If not provided, will fall back to the
+                MODEL_TIMEOUT environment variable or default to 180 seconds.
+                (default: :obj:`None`)
         """
         self._api_key = api_key
         self._url = url

--- a/camel/models/base_model.py
+++ b/camel/models/base_model.py
@@ -69,6 +69,8 @@ class BaseModelBackend(ABC, metaclass=ModelBackendMeta):
         token_counter (Optional[BaseTokenCounter], optional): Token
             counter to use for the model. If not provided,
             :obj:`OpenAITokenCounter` will be used. (default: :obj:`None`)
+        timeout (Optional[float], optional): The timeout value in seconds for
+        API calls. (default: :obj:`None`)
     """
 
     def __init__(
@@ -78,6 +80,7 @@ class BaseModelBackend(ABC, metaclass=ModelBackendMeta):
         api_key: Optional[str] = None,
         url: Optional[str] = None,
         token_counter: Optional[BaseTokenCounter] = None,
+        timeout: Optional[float] = None,
     ) -> None:
         self.model_type: UnifiedModelType = UnifiedModelType(model_type)
         if model_config_dict is None:
@@ -86,6 +89,7 @@ class BaseModelBackend(ABC, metaclass=ModelBackendMeta):
         self._api_key = api_key
         self._url = url
         self._token_counter = token_counter
+        self._timeout = timeout
         self.check_model_config()
 
     @property

--- a/camel/models/base_model.py
+++ b/camel/models/base_model.py
@@ -70,7 +70,7 @@ class BaseModelBackend(ABC, metaclass=ModelBackendMeta):
             counter to use for the model. If not provided,
             :obj:`OpenAITokenCounter` will be used. (default: :obj:`None`)
         timeout (Optional[float], optional): The timeout value in seconds for
-        API calls. (default: :obj:`None`)
+            API calls. (default: :obj:`None`)
     """
 
     def __init__(

--- a/camel/models/deepseek_model.py
+++ b/camel/models/deepseek_model.py
@@ -60,6 +60,10 @@ class DeepSeekModel(BaseModelBackend):
         token_counter (Optional[BaseTokenCounter], optional): Token counter to
             use for the model. If not provided, :obj:`OpenAITokenCounter`
             will be used. (default: :obj:`None`)
+        timeout (Optional[float], optional): The timeout value in seconds for
+            API calls. If not provided, will fall back to the MODEL_TIMEOUT
+            environment variable or default to 180 seconds.
+            (default: :obj:`None`)
 
     References:
         https://api-docs.deepseek.com/
@@ -77,6 +81,7 @@ class DeepSeekModel(BaseModelBackend):
         api_key: Optional[str] = None,
         url: Optional[str] = None,
         token_counter: Optional[BaseTokenCounter] = None,
+        timeout: Optional[float] = None,
     ) -> None:
         if model_config_dict is None:
             model_config_dict = DeepSeekConfig().as_dict()
@@ -85,19 +90,20 @@ class DeepSeekModel(BaseModelBackend):
             "DEEPSEEK_API_BASE_URL",
             "https://api.deepseek.com",
         )
+        timeout = timeout or float(os.environ.get("MODEL_TIMEOUT", 180))
         super().__init__(
-            model_type, model_config_dict, api_key, url, token_counter
+            model_type, model_config_dict, api_key, url, token_counter, timeout
         )
 
         self._client = OpenAI(
-            timeout=180,
+            timeout=self._timeout,
             max_retries=3,
             api_key=self._api_key,
             base_url=self._url,
         )
 
         self._async_client = AsyncOpenAI(
-            timeout=180,
+            timeout=self._timeout,
             max_retries=3,
             api_key=self._api_key,
             base_url=self._url,

--- a/camel/models/gemini_model.py
+++ b/camel/models/gemini_model.py
@@ -51,6 +51,10 @@ class GeminiModel(BaseModelBackend):
             use for the model. If not provided, :obj:`OpenAITokenCounter(
             ModelType.GPT_4O_MINI)` will be used.
             (default: :obj:`None`)
+        timeout (Optional[float], optional): The timeout value in seconds for
+            API calls. If not provided, will fall back to the MODEL_TIMEOUT
+            environment variable or default to 180 seconds.
+            (default: :obj:`None`)
     """
 
     @api_keys_required(
@@ -65,6 +69,7 @@ class GeminiModel(BaseModelBackend):
         api_key: Optional[str] = None,
         url: Optional[str] = None,
         token_counter: Optional[BaseTokenCounter] = None,
+        timeout: Optional[float] = None,
     ) -> None:
         if model_config_dict is None:
             model_config_dict = GeminiConfig().as_dict()
@@ -73,17 +78,18 @@ class GeminiModel(BaseModelBackend):
             "GEMINI_API_BASE_URL",
             "https://generativelanguage.googleapis.com/v1beta/openai/",
         )
+        timeout = timeout or float(os.environ.get("MODEL_TIMEOUT", 180))
         super().__init__(
-            model_type, model_config_dict, api_key, url, token_counter
+            model_type, model_config_dict, api_key, url, token_counter, timeout
         )
         self._client = OpenAI(
-            timeout=180,
+            timeout=self._timeout,
             max_retries=3,
             api_key=self._api_key,
             base_url=self._url,
         )
         self._async_client = AsyncOpenAI(
-            timeout=180,
+            timeout=self._timeout,
             max_retries=3,
             api_key=self._api_key,
             base_url=self._url,

--- a/camel/models/groq_model.py
+++ b/camel/models/groq_model.py
@@ -51,6 +51,10 @@ class GroqModel(BaseModelBackend):
             use for the model. If not provided, :obj:`OpenAITokenCounter(
             ModelType.GPT_4O_MINI)` will be used.
             (default: :obj:`None`)
+        timeout (Optional[float], optional): The timeout value in seconds for
+            API calls. If not provided, will fall back to the MODEL_TIMEOUT
+            environment variable or default to 180 seconds.
+            (default: :obj:`None`)
     """
 
     @api_keys_required([("api_key", "GROQ_API_KEY")])
@@ -61,6 +65,7 @@ class GroqModel(BaseModelBackend):
         api_key: Optional[str] = None,
         url: Optional[str] = None,
         token_counter: Optional[BaseTokenCounter] = None,
+        timeout: Optional[float] = None,
     ) -> None:
         if model_config_dict is None:
             model_config_dict = GroqConfig().as_dict()
@@ -68,17 +73,18 @@ class GroqModel(BaseModelBackend):
         url = url or os.environ.get(
             "GROQ_API_BASE_URL", "https://api.groq.com/openai/v1"
         )
+        timeout = timeout or float(os.environ.get("MODEL_TIMEOUT", 180))
         super().__init__(
-            model_type, model_config_dict, api_key, url, token_counter
+            model_type, model_config_dict, api_key, url, token_counter, timeout
         )
         self._client = OpenAI(
-            timeout=180,
+            timeout=self._timeout,
             max_retries=3,
             api_key=self._api_key,
             base_url=self._url,
         )
         self._async_client = AsyncOpenAI(
-            timeout=180,
+            timeout=self._timeout,
             max_retries=3,
             api_key=self._api_key,
             base_url=self._url,

--- a/camel/models/internlm_model.py
+++ b/camel/models/internlm_model.py
@@ -51,6 +51,10 @@ class InternLMModel(BaseModelBackend):
             use for the model. If not provided, :obj:`OpenAITokenCounter(
             ModelType.GPT_4O_MINI)` will be used.
             (default: :obj:`None`)
+        timeout (Optional[float], optional): The timeout value in seconds for
+            API calls. If not provided, will fall back to the MODEL_TIMEOUT
+            environment variable or default to 180 seconds.
+            (default: :obj:`None`)
     """
 
     @api_keys_required(
@@ -65,6 +69,7 @@ class InternLMModel(BaseModelBackend):
         api_key: Optional[str] = None,
         url: Optional[str] = None,
         token_counter: Optional[BaseTokenCounter] = None,
+        timeout: Optional[float] = None,
     ) -> None:
         if model_config_dict is None:
             model_config_dict = InternLMConfig().as_dict()
@@ -73,11 +78,12 @@ class InternLMModel(BaseModelBackend):
             "INTERNLM_API_BASE_URL",
             "https://internlm-chat.intern-ai.org.cn/puyu/api/v1",
         )
+        timeout = timeout or float(os.environ.get("MODEL_TIMEOUT", 180))
         super().__init__(
-            model_type, model_config_dict, api_key, url, token_counter
+            model_type, model_config_dict, api_key, url, token_counter, timeout
         )
         self._client = OpenAI(
-            timeout=180,
+            timeout=self._timeout,
             max_retries=3,
             api_key=self._api_key,
             base_url=self._url,

--- a/camel/models/model_factory.py
+++ b/camel/models/model_factory.py
@@ -60,6 +60,7 @@ class ModelFactory:
         token_counter: Optional[BaseTokenCounter] = None,
         api_key: Optional[str] = None,
         url: Optional[str] = None,
+        timeout: Optional[int] = None,
     ) -> BaseModelBackend:
         r"""Creates an instance of `BaseModelBackend` of the specified type.
 
@@ -79,6 +80,8 @@ class ModelFactory:
                 with the model service. (default: :obj:`None`)
             url (Optional[str], optional): The url to the model service.
                 (default: :obj:`None`)
+            timeout (Optional[float], optional): The timeout value in seconds
+                for API calls. (default: :obj:`None`)
 
         Returns:
             BaseModelBackend: The initialized backend.
@@ -157,4 +160,5 @@ class ModelFactory:
             api_key=api_key,
             url=url,
             token_counter=token_counter,
+            timeout=timeout,
         )

--- a/camel/models/moonshot_model.py
+++ b/camel/models/moonshot_model.py
@@ -52,6 +52,10 @@ class MoonshotModel(BaseModelBackend):
             use for the model. If not provided, :obj:`OpenAITokenCounter(
             ModelType.GPT_4)` will be used.
             (default: :obj:`None`)
+        timeout (Optional[float], optional): The timeout value in seconds for
+            API calls. If not provided, will fall back to the MODEL_TIMEOUT
+            environment variable or default to 180 seconds.
+            (default: :obj:`None`)
     """
 
     @api_keys_required([("api_key", "MOONSHOT_API_KEY")])
@@ -62,6 +66,7 @@ class MoonshotModel(BaseModelBackend):
         api_key: Optional[str] = None,
         url: Optional[str] = None,
         token_counter: Optional[BaseTokenCounter] = None,
+        timeout: Optional[float] = None,
     ) -> None:
         if model_config_dict is None:
             model_config_dict = MoonshotConfig().as_dict()
@@ -70,12 +75,13 @@ class MoonshotModel(BaseModelBackend):
             "MOONSHOT_API_BASE_URL",
             "https://api.moonshot.cn/v1",
         )
+        timeout = timeout or float(os.environ.get("MODEL_TIMEOUT", 180))
         super().__init__(
-            model_type, model_config_dict, api_key, url, token_counter
+            model_type, model_config_dict, api_key, url, token_counter, timeout
         )
         self._client = OpenAI(
             api_key=self._api_key,
-            timeout=180,
+            timeout=self._timeout,
             max_retries=3,
             base_url=self._url,
         )

--- a/camel/models/nemotron_model.py
+++ b/camel/models/nemotron_model.py
@@ -36,6 +36,10 @@ class NemotronModel(BaseModelBackend):
             the Nvidia service. (default: :obj:`None`)
         url (Optional[str], optional): The url to the Nvidia service.
             (default: :obj:`https://integrate.api.nvidia.com/v1`)
+        timeout (Optional[float], optional): The timeout value in seconds for
+            API calls. If not provided, will fall back to the MODEL_TIMEOUT
+            environment variable or default to 180 seconds.
+            (default: :obj:`None`)
 
     Notes:
         Nemotron model doesn't support additional model config like OpenAI.
@@ -51,20 +55,22 @@ class NemotronModel(BaseModelBackend):
         model_type: Union[ModelType, str],
         api_key: Optional[str] = None,
         url: Optional[str] = None,
+        timeout: Optional[float] = None,
     ) -> None:
         url = url or os.environ.get(
             "NVIDIA_API_BASE_URL", "https://integrate.api.nvidia.com/v1"
         )
         api_key = api_key or os.environ.get("NVIDIA_API_KEY")
-        super().__init__(model_type, {}, api_key, url)
+        timeout = timeout or float(os.environ.get("MODEL_TIMEOUT", 180))
+        super().__init__(model_type, {}, api_key, url, None, timeout)
         self._client = OpenAI(
-            timeout=180,
+            timeout=self._timeout,
             max_retries=3,
             base_url=self._url,
             api_key=self._api_key,
         )
         self._async_client = AsyncOpenAI(
-            timeout=180,
+            timeout=self._timeout,
             max_retries=3,
             base_url=self._url,
             api_key=self._api_key,

--- a/camel/models/nvidia_model.py
+++ b/camel/models/nvidia_model.py
@@ -47,6 +47,10 @@ class NvidiaModel(BaseModelBackend):
             use for the model. If not provided, :obj:`OpenAITokenCounter(
             ModelType.GPT_4)` will be used.
             (default: :obj:`None`)
+        timeout (Optional[float], optional): The timeout value in seconds for
+            API calls. If not provided, will fall back to the MODEL_TIMEOUT
+            environment variable or default to 180 seconds.
+            (default: :obj:`None`)
     """
 
     @api_keys_required(
@@ -61,6 +65,7 @@ class NvidiaModel(BaseModelBackend):
         api_key: Optional[str] = None,
         url: Optional[str] = None,
         token_counter: Optional[BaseTokenCounter] = None,
+        timeout: Optional[float] = None,
     ) -> None:
         if model_config_dict is None:
             model_config_dict = NvidiaConfig().as_dict()
@@ -68,17 +73,18 @@ class NvidiaModel(BaseModelBackend):
         url = url or os.environ.get(
             "NVIDIA_API_BASE_URL", "https://integrate.api.nvidia.com/v1"
         )
+        timeout = timeout or float(os.environ.get("MODEL_TIMEOUT", 180))
         super().__init__(
-            model_type, model_config_dict, api_key, url, token_counter
+            model_type, model_config_dict, api_key, url, token_counter, timeout
         )
         self._client = OpenAI(
-            timeout=180,
+            timeout=self._timeout,
             max_retries=3,
             api_key=self._api_key,
             base_url=self._url,
         )
         self._async_client = AsyncOpenAI(
-            timeout=180,
+            timeout=self._timeout,
             max_retries=3,
             api_key=self._api_key,
             base_url=self._url,

--- a/camel/models/ollama_model.py
+++ b/camel/models/ollama_model.py
@@ -49,6 +49,10 @@ class OllamaModel(BaseModelBackend):
             use for the model. If not provided, :obj:`OpenAITokenCounter(
             ModelType.GPT_4O_MINI)` will be used.
             (default: :obj:`None`)
+        timeout (Optional[float], optional): The timeout value in seconds for
+            API calls. If not provided, will fall back to the MODEL_TIMEOUT
+            environment variable or default to 180 seconds.
+            (default: :obj:`None`)
 
     References:
         https://github.com/ollama/ollama/blob/main/docs/openai.md
@@ -61,24 +65,26 @@ class OllamaModel(BaseModelBackend):
         api_key: Optional[str] = None,
         url: Optional[str] = None,
         token_counter: Optional[BaseTokenCounter] = None,
+        timeout: Optional[float] = None,
     ) -> None:
         if model_config_dict is None:
             model_config_dict = OllamaConfig().as_dict()
         url = url or os.environ.get("OLLAMA_BASE_URL")
+        timeout = timeout or float(os.environ.get("MODEL_TIMEOUT", 180))
         super().__init__(
-            model_type, model_config_dict, api_key, url, token_counter
+            model_type, model_config_dict, api_key, url, token_counter, timeout
         )
         if not self._url:
             self._start_server()
         # Use OpenAI client as interface call Ollama
         self._client = OpenAI(
-            timeout=180,
+            timeout=self._timeout,
             max_retries=3,
             api_key="Set-but-ignored",  # required but ignored
             base_url=self._url,
         )
         self._async_client = AsyncOpenAI(
-            timeout=180,
+            timeout=self._timeout,
             max_retries=3,
             api_key="Set-but-ignored",  # required but ignored
             base_url=self._url,

--- a/camel/models/openai_audio_models.py
+++ b/camel/models/openai_audio_models.py
@@ -29,19 +29,21 @@ class OpenAIAudioModels(BaseAudioModel):
         self,
         api_key: Optional[str] = None,
         url: Optional[str] = None,
+        timeout: Optional[float] = None,
     ) -> None:
         r"""Initialize an instance of OpenAI."""
-        super().__init__(api_key, url)
+        super().__init__(api_key, url, timeout)
         self._url = url or os.environ.get("OPENAI_API_BASE_URL")
         self._api_key = api_key or os.environ.get("OPENAI_API_KEY")
+        self._timeout = timeout or float(os.environ.get("MODEL_TIMEOUT", 180))
         self._client = OpenAI(
-            timeout=120,
+            timeout=self._timeout,
             max_retries=3,
             base_url=self._url,
             api_key=self._api_key,
         )
         self._async_client = AsyncOpenAI(
-            timeout=120,
+            timeout=self._timeout,
             max_retries=3,
             base_url=self._url,
             api_key=self._api_key,

--- a/camel/models/openai_compatible_model.py
+++ b/camel/models/openai_compatible_model.py
@@ -46,6 +46,10 @@ class OpenAICompatibleModel(BaseModelBackend):
             use for the model. If not provided, :obj:`OpenAITokenCounter(
             ModelType.GPT_4O_MINI)` will be used.
             (default: :obj:`None`)
+        timeout (Optional[float], optional): The timeout value in seconds for
+            API calls. If not provided, will fall back to the MODEL_TIMEOUT
+            environment variable or default to 180 seconds.
+            (default: :obj:`None`)
     """
 
     def __init__(
@@ -55,21 +59,23 @@ class OpenAICompatibleModel(BaseModelBackend):
         api_key: Optional[str] = None,
         url: Optional[str] = None,
         token_counter: Optional[BaseTokenCounter] = None,
+        timeout: Optional[float] = None,
     ) -> None:
         api_key = api_key or os.environ.get("OPENAI_COMPATIBILITY_API_KEY")
         url = url or os.environ.get("OPENAI_COMPATIBILITY_API_BASE_URL")
+        timeout = timeout or float(os.environ.get("MODEL_TIMEOUT", 180))
         super().__init__(
-            model_type, model_config_dict, api_key, url, token_counter
+            model_type, model_config_dict, api_key, url, token_counter, timeout
         )
         self._client = OpenAI(
-            timeout=180,
+            timeout=self._timeout,
             max_retries=3,
             api_key=self._api_key,
             base_url=self._url,
         )
 
         self._async_client = AsyncOpenAI(
-            timeout=180,
+            timeout=self._timeout,
             max_retries=3,
             api_key=self._api_key,
             base_url=self._url,

--- a/camel/models/openai_model.py
+++ b/camel/models/openai_model.py
@@ -60,6 +60,10 @@ class OpenAIModel(BaseModelBackend):
         token_counter (Optional[BaseTokenCounter], optional): Token counter to
             use for the model. If not provided, :obj:`OpenAITokenCounter` will
             be used. (default: :obj:`None`)
+        timeout (Optional[float], optional): The timeout value in seconds for
+            API calls. If not provided, will fall back to the MODEL_TIMEOUT
+            environment variable or default to 180 seconds.
+            (default: :obj:`None`)
     """
 
     @api_keys_required(
@@ -74,24 +78,26 @@ class OpenAIModel(BaseModelBackend):
         api_key: Optional[str] = None,
         url: Optional[str] = None,
         token_counter: Optional[BaseTokenCounter] = None,
+        timeout: Optional[float] = None,
     ) -> None:
         if model_config_dict is None:
             model_config_dict = ChatGPTConfig().as_dict()
         api_key = api_key or os.environ.get("OPENAI_API_KEY")
         url = url or os.environ.get("OPENAI_API_BASE_URL")
+        timeout = timeout or float(os.environ.get("MODEL_TIMEOUT", 180))
 
         super().__init__(
-            model_type, model_config_dict, api_key, url, token_counter
+            model_type, model_config_dict, api_key, url, token_counter, timeout
         )
 
         self._client = OpenAI(
-            timeout=180,
+            timeout=self._timeout,
             max_retries=3,
             base_url=self._url,
             api_key=self._api_key,
         )
         self._async_client = AsyncOpenAI(
-            timeout=180,
+            timeout=self._timeout,
             max_retries=3,
             base_url=self._url,
             api_key=self._api_key,

--- a/camel/models/openrouter_model.py
+++ b/camel/models/openrouter_model.py
@@ -51,6 +51,10 @@ class OpenRouterModel(BaseModelBackend):
             use for the model. If not provided, :obj:`OpenAITokenCounter(
             ModelType.GPT_4O_MINI)` will be used.
             (default: :obj:`None`)
+        timeout (Optional[float], optional): The timeout value in seconds for
+            API calls. If not provided, will fall back to the MODEL_TIMEOUT
+            environment variable or default to 180 seconds.
+            (default: :obj:`None`)
     """
 
     @api_keys_required([("api_key", "OPENROUTER_API_KEY")])
@@ -61,6 +65,7 @@ class OpenRouterModel(BaseModelBackend):
         api_key: Optional[str] = None,
         url: Optional[str] = None,
         token_counter: Optional[BaseTokenCounter] = None,
+        timeout: Optional[float] = None,
     ) -> None:
         if model_config_dict is None:
             model_config_dict = OpenRouterConfig().as_dict()
@@ -68,17 +73,18 @@ class OpenRouterModel(BaseModelBackend):
         url = url or os.environ.get(
             "OPENROUTER_API_BASE_URL", "https://openrouter.ai/api/v1"
         )
+        timeout = timeout or float(os.environ.get("MODEL_TIMEOUT", 180))
         super().__init__(
-            model_type, model_config_dict, api_key, url, token_counter
+            model_type, model_config_dict, api_key, url, token_counter, timeout
         )
         self._client = OpenAI(
-            timeout=180,
+            timeout=self._timeout,
             max_retries=3,
             api_key=self._api_key,
             base_url=self._url,
         )
         self._async_client = AsyncOpenAI(
-            timeout=180,
+            timeout=self._timeout,
             max_retries=3,
             api_key=self._api_key,
             base_url=self._url,

--- a/camel/models/qwen_model.py
+++ b/camel/models/qwen_model.py
@@ -52,6 +52,10 @@ class QwenModel(BaseModelBackend):
             use for the model. If not provided, :obj:`OpenAITokenCounter(
             ModelType.GPT_4O_MINI)` will be used.
             (default: :obj:`None`)
+        timeout (Optional[float], optional): The timeout value in seconds for
+            API calls. If not provided, will fall back to the MODEL_TIMEOUT
+            environment variable or default to 180 seconds.
+            (default: :obj:`None`)
     """
 
     @api_keys_required(
@@ -66,6 +70,7 @@ class QwenModel(BaseModelBackend):
         api_key: Optional[str] = None,
         url: Optional[str] = None,
         token_counter: Optional[BaseTokenCounter] = None,
+        timeout: Optional[float] = None,
     ) -> None:
         if model_config_dict is None:
             model_config_dict = QwenConfig().as_dict()
@@ -74,17 +79,18 @@ class QwenModel(BaseModelBackend):
             "QWEN_API_BASE_URL",
             "https://dashscope.aliyuncs.com/compatible-mode/v1",
         )
+        timeout = timeout or float(os.environ.get("MODEL_TIMEOUT", 180))
         super().__init__(
-            model_type, model_config_dict, api_key, url, token_counter
+            model_type, model_config_dict, api_key, url, token_counter, timeout
         )
         self._client = OpenAI(
-            timeout=180,
+            timeout=self._timeout,
             max_retries=3,
             api_key=self._api_key,
             base_url=self._url,
         )
         self._async_client = AsyncOpenAI(
-            timeout=180,
+            timeout=self._timeout,
             max_retries=3,
             api_key=self._api_key,
             base_url=self._url,

--- a/camel/models/samba_model.py
+++ b/camel/models/samba_model.py
@@ -73,6 +73,10 @@ class SambaModel(BaseModelBackend):
         token_counter (Optional[BaseTokenCounter], optional): Token counter to
             use for the model. If not provided, :obj:`OpenAITokenCounter(
             ModelType.GPT_4O_MINI)` will be used.
+        timeout (Optional[float], optional): The timeout value in seconds for
+            API calls. If not provided, will fall back to the MODEL_TIMEOUT
+            environment variable or default to 180 seconds.
+            (default: :obj:`None`)
     """
 
     @api_keys_required(
@@ -87,6 +91,7 @@ class SambaModel(BaseModelBackend):
         api_key: Optional[str] = None,
         url: Optional[str] = None,
         token_counter: Optional[BaseTokenCounter] = None,
+        timeout: Optional[float] = None,
     ) -> None:
         if model_config_dict is None:
             model_config_dict = SambaCloudAPIConfig().as_dict()
@@ -95,19 +100,20 @@ class SambaModel(BaseModelBackend):
             "SAMBA_API_BASE_URL",
             "https://api.sambanova.ai/v1",
         )
+        timeout = timeout or float(os.environ.get("MODEL_TIMEOUT", 180))
         super().__init__(
-            model_type, model_config_dict, api_key, url, token_counter
+            model_type, model_config_dict, api_key, url, token_counter, timeout
         )
 
         if self._url == "https://api.sambanova.ai/v1":
             self._client = OpenAI(
-                timeout=180,
+                timeout=self._timeout,
                 max_retries=3,
                 base_url=self._url,
                 api_key=self._api_key,
             )
             self._async_client = AsyncOpenAI(
-                timeout=180,
+                timeout=self._timeout,
                 max_retries=3,
                 base_url=self._url,
                 api_key=self._api_key,

--- a/camel/models/sglang_model.py
+++ b/camel/models/sglang_model.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
 import logging
+import os
 import subprocess
 import threading
 import time
@@ -51,6 +52,10 @@ class SGLangModel(BaseModelBackend):
             use for the model. If not provided, :obj:`OpenAITokenCounter(
             ModelType.GPT_4O_MINI)` will be used.
             (default: :obj:`None`)
+        timeout (Optional[float], optional): The timeout value in seconds for
+            API calls. If not provided, will fall back to the MODEL_TIMEOUT
+            environment variable or default to 180 seconds.
+            (default: :obj:`None`)
 
     Reference: https://sgl-project.github.io/backend/openai_api_completions.html
     """
@@ -62,6 +67,7 @@ class SGLangModel(BaseModelBackend):
         api_key: Optional[str] = None,
         url: Optional[str] = None,
         token_counter: Optional[BaseTokenCounter] = None,
+        timeout: Optional[float] = None,
     ) -> None:
         if model_config_dict is None:
             model_config_dict = SGLangConfig().as_dict()
@@ -73,8 +79,9 @@ class SGLangModel(BaseModelBackend):
         self._lock = threading.Lock()
         self._inactivity_thread: Optional[threading.Thread] = None
 
+        timeout = timeout or float(os.environ.get("MODEL_TIMEOUT", 180))
         super().__init__(
-            model_type, model_config_dict, api_key, url, token_counter
+            model_type, model_config_dict, api_key, url, token_counter, timeout
         )
 
         self._client = None
@@ -82,13 +89,13 @@ class SGLangModel(BaseModelBackend):
         if self._url:
             # Initialize the client if an existing URL is provided
             self._client = OpenAI(
-                timeout=180,
+                timeout=self._timeout,
                 max_retries=3,
                 api_key="Set-but-ignored",  # required but ignored
                 base_url=self._url,
             )
             self._async_client = AsyncOpenAI(
-                timeout=180,
+                timeout=self._timeout,
                 max_retries=3,
                 api_key="Set-but-ignored",  # required but ignored
                 base_url=self._url,

--- a/camel/models/sglang_model.py
+++ b/camel/models/sglang_model.py
@@ -130,7 +130,7 @@ class SGLangModel(BaseModelBackend):
             self.last_run_time = time.time()
             # Initialize the client after the server starts
             self._client = OpenAI(
-                timeout=180,
+                timeout=self._timeout,
                 max_retries=3,
                 api_key="Set-but-ignored",  # required but ignored
                 base_url=self._url,

--- a/camel/models/siliconflow_model.py
+++ b/camel/models/siliconflow_model.py
@@ -51,6 +51,10 @@ class SiliconFlowModel(BaseModelBackend):
             use for the model. If not provided, :obj:`OpenAITokenCounter(
             ModelType.GPT_4O_MINI)` will be used.
             (default: :obj:`None`)
+        timeout (Optional[float], optional): The timeout value in seconds for
+            API calls. If not provided, will fall back to the MODEL_TIMEOUT
+            environment variable or default to 180 seconds.
+            (default: :obj:`None`)
     """
 
     @api_keys_required(
@@ -65,6 +69,7 @@ class SiliconFlowModel(BaseModelBackend):
         api_key: Optional[str] = None,
         url: Optional[str] = None,
         token_counter: Optional[BaseTokenCounter] = None,
+        timeout: Optional[float] = None,
     ) -> None:
         if model_config_dict is None:
             model_config_dict = SiliconFlowConfig().as_dict()
@@ -73,11 +78,12 @@ class SiliconFlowModel(BaseModelBackend):
             "SILICONFLOW_API_BASE_URL",
             "https://api.siliconflow.cn/v1/",
         )
+        timeout = timeout or float(os.environ.get("MODEL_TIMEOUT", 180))
         super().__init__(
-            model_type, model_config_dict, api_key, url, token_counter
+            model_type, model_config_dict, api_key, url, token_counter, timeout
         )
         self._client = OpenAI(
-            timeout=180,
+            timeout=self._timeout,
             max_retries=3,
             api_key=self._api_key,
             base_url=self._url,

--- a/camel/models/stub_model.py
+++ b/camel/models/stub_model.py
@@ -82,10 +82,11 @@ class StubModel(BaseModelBackend):
         api_key: Optional[str] = None,
         url: Optional[str] = None,
         token_counter: Optional[BaseTokenCounter] = None,
+        timeout: Optional[float] = None,
     ) -> None:
         r"""All arguments are unused for the dummy model."""
         super().__init__(
-            model_type, model_config_dict, api_key, url, token_counter
+            model_type, model_config_dict, api_key, url, token_counter, timeout
         )
 
     @property

--- a/camel/models/togetherai_model.py
+++ b/camel/models/togetherai_model.py
@@ -52,6 +52,10 @@ class TogetherAIModel(BaseModelBackend):
         token_counter (Optional[BaseTokenCounter], optional): Token counter to
             use for the model. If not provided, :obj:`OpenAITokenCounter(
             ModelType.GPT_4O_MINI)` will be used.
+        timeout (Optional[float], optional): The timeout value in seconds for
+            API calls. If not provided, will fall back to the MODEL_TIMEOUT
+            environment variable or default to 180 seconds.
+            (default: :obj:`None`)
     """
 
     @api_keys_required(
@@ -66,6 +70,7 @@ class TogetherAIModel(BaseModelBackend):
         api_key: Optional[str] = None,
         url: Optional[str] = None,
         token_counter: Optional[BaseTokenCounter] = None,
+        timeout: Optional[float] = None,
     ) -> None:
         if model_config_dict is None:
             model_config_dict = TogetherAIConfig().as_dict()
@@ -73,18 +78,19 @@ class TogetherAIModel(BaseModelBackend):
         url = url or os.environ.get(
             "TOGETHER_API_BASE_URL", "https://api.together.xyz/v1"
         )
+        timeout = timeout or float(os.environ.get("MODEL_TIMEOUT", 180))
         super().__init__(
-            model_type, model_config_dict, api_key, url, token_counter
+            model_type, model_config_dict, api_key, url, token_counter, timeout
         )
 
         self._client = OpenAI(
-            timeout=180,
+            timeout=self._timeout,
             max_retries=3,
             api_key=self._api_key,
             base_url=self._url,
         )
         self._async_client = AsyncOpenAI(
-            timeout=180,
+            timeout=self._timeout,
             max_retries=3,
             api_key=self._api_key,
             base_url=self._url,

--- a/camel/models/vllm_model.py
+++ b/camel/models/vllm_model.py
@@ -50,6 +50,10 @@ class VLLMModel(BaseModelBackend):
             use for the model. If not provided, :obj:`OpenAITokenCounter(
             ModelType.GPT_4O_MINI)` will be used.
             (default: :obj:`None`)
+        timeout (Optional[float], optional): The timeout value in seconds for
+            API calls. If not provided, will fall back to the MODEL_TIMEOUT
+            environment variable or default to 180 seconds.
+            (default: :obj:`None`)
 
     References:
         https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html
@@ -62,24 +66,26 @@ class VLLMModel(BaseModelBackend):
         api_key: Optional[str] = None,
         url: Optional[str] = None,
         token_counter: Optional[BaseTokenCounter] = None,
+        timeout: Optional[float] = None,
     ) -> None:
         if model_config_dict is None:
             model_config_dict = VLLMConfig().as_dict()
         url = url or os.environ.get("VLLM_BASE_URL")
+        timeout = timeout or float(os.environ.get("MODEL_TIMEOUT", 180))
         super().__init__(
-            model_type, model_config_dict, api_key, url, token_counter
+            model_type, model_config_dict, api_key, url, token_counter, timeout
         )
         if not self._url:
             self._start_server()
         # Use OpenAI cilent as interface call vLLM
         self._client = OpenAI(
-            timeout=180,
+            timeout=self._timeout,
             max_retries=3,
             api_key="EMPTY",  # required but ignored
             base_url=self._url,
         )
         self._async_client = AsyncOpenAI(
-            timeout=180,
+            timeout=self._timeout,
             max_retries=3,
             api_key="EMPTY",  # required but ignored
             base_url=self._url,

--- a/camel/models/yi_model.py
+++ b/camel/models/yi_model.py
@@ -51,6 +51,10 @@ class YiModel(BaseModelBackend):
             use for the model. If not provided, :obj:`OpenAITokenCounter(
             ModelType.GPT_4O_MINI)` will be used.
             (default: :obj:`None`)
+        timeout (Optional[float], optional): The timeout value in seconds for
+            API calls. If not provided, will fall back to the MODEL_TIMEOUT
+            environment variable or default to 180 seconds.
+            (default: :obj:`None`)
     """
 
     @api_keys_required(
@@ -65,6 +69,7 @@ class YiModel(BaseModelBackend):
         api_key: Optional[str] = None,
         url: Optional[str] = None,
         token_counter: Optional[BaseTokenCounter] = None,
+        timeout: Optional[float] = None,
     ) -> None:
         if model_config_dict is None:
             model_config_dict = YiConfig().as_dict()
@@ -72,17 +77,18 @@ class YiModel(BaseModelBackend):
         url = url or os.environ.get(
             "YI_API_BASE_URL", "https://api.lingyiwanwu.com/v1"
         )
+        timeout = timeout or float(os.environ.get("MODEL_TIMEOUT", 180))
         super().__init__(
-            model_type, model_config_dict, api_key, url, token_counter
+            model_type, model_config_dict, api_key, url, token_counter, timeout
         )
         self._client = OpenAI(
-            timeout=180,
+            timeout=self._timeout,
             max_retries=3,
             api_key=self._api_key,
             base_url=self._url,
         )
         self._async_client = AsyncOpenAI(
-            timeout=180,
+            timeout=self._timeout,
             max_retries=3,
             api_key=self._api_key,
             base_url=self._url,

--- a/camel/models/zhipuai_model.py
+++ b/camel/models/zhipuai_model.py
@@ -51,6 +51,10 @@ class ZhipuAIModel(BaseModelBackend):
             use for the model. If not provided, :obj:`OpenAITokenCounter(
             ModelType.GPT_4O_MINI)` will be used.
             (default: :obj:`None`)
+        timeout (Optional[float], optional): The timeout value in seconds for
+            API calls. If not provided, will fall back to the MODEL_TIMEOUT
+            environment variable or default to 180 seconds.
+            (default: :obj:`None`)
     """
 
     @api_keys_required(
@@ -65,6 +69,7 @@ class ZhipuAIModel(BaseModelBackend):
         api_key: Optional[str] = None,
         url: Optional[str] = None,
         token_counter: Optional[BaseTokenCounter] = None,
+        timeout: Optional[float] = None,
     ) -> None:
         if model_config_dict is None:
             model_config_dict = ZhipuAIConfig().as_dict()
@@ -72,17 +77,18 @@ class ZhipuAIModel(BaseModelBackend):
         url = url or os.environ.get(
             "ZHIPUAI_API_BASE_URL", "https://open.bigmodel.cn/api/paas/v4/"
         )
+        timeout = timeout or float(os.environ.get("MODEL_TIMEOUT", 180))
         super().__init__(
-            model_type, model_config_dict, api_key, url, token_counter
+            model_type, model_config_dict, api_key, url, token_counter, timeout
         )
         self._client = OpenAI(
-            timeout=180,
+            timeout=self._timeout,
             max_retries=3,
             api_key=self._api_key,
             base_url=self._url,
         )
         self._async_client = AsyncOpenAI(
-            timeout=180,
+            timeout=self._timeout,
             max_retries=3,
             api_key=self._api_key,
             base_url=self._url,


### PR DESCRIPTION
This PR adds two ways to add timeout to the models
1. Parameter passing
2. From the env variables

Link #1946 