### PR TITLE
fix: python verifier does not handle string comparison properly

### DIFF
--- a/camel/verifiers/python_verifier.py
+++ b/camel/verifiers/python_verifier.py
@@ -317,19 +317,9 @@ class PythonVerifier(BaseVerifier):
                     sol_val = ast.literal_eval(sol_out)
                 except Exception as e:
                     logger.warning(
-                        f"Direct eval failed: {e}. Trying repr on output."
+                        f"Direct eval failed: {e}."
                     )
-                    try:
-                        # Try to convert sol_out to a literal
-                        # by wrapping it with repr.
-                        # FIXME: may be unnecessary
-                        sol_val = ast.literal_eval(repr(sol_out))
-                    except Exception as e2:
-                        logger.warning(
-                            f"repr eval also failed: {e2}."
-                            "Falling back to string comparison."
-                        )
-                        sol_val = None
+                    sol_val = None
 
                 if sol_val is not None:
                     try:


### PR DESCRIPTION
## Description

The current Python verifier has a bug in the string comparison part. `repr` function was added for the deleted code, but str can be evaluated using `literal_eval` & `repr`. As a result, the line sol_val = None is never actually executed, and the fallback code for string comparison (# Fallback: string comparison) is never reached (it's effectively unreachable).
Currently, string comparison cases cannot be handled properly.

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide (**required**)
- [ ] I have linked this PR to an issue using the Development section on the right sidebar or by adding `Fixes #issue-number` in the PR description (**required**)
- [x] I have checked if any dependencies need to be added or updated in `pyproject.toml` and `uv lock`
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed:
- [ ] I have added examples if this is a new feature
