### PR TITLE
chore: explicit model usage warnings for workforce

### DIFF
--- a/camel/agents/chat_agent.py
+++ b/camel/agents/chat_agent.py
@@ -526,6 +526,10 @@ class ChatAgent(BaseAgent):
             message.content = response.output_messages[0].content
             if not self._try_format_message(message, response_format):
                 logger.warning(f"Failed to parse response: {message.content}")
+                logger.warning(
+                    "To improve reliability, consider using models "
+                    "that are better equipped to handle structured output"
+                )
 
     async def _aformat_response_if_needed(
         self,
@@ -785,6 +789,11 @@ class ChatAgent(BaseAgent):
                 exc_info=exc,
             )
             error_info = str(exc)
+
+            logger.warning(
+                "To improve reliability, consider using models "
+                "that are better equipped to handle structured output"
+            )
 
         if not response and self.model_backend.num_models > 1:
             raise ModelProcessingError(

--- a/camel/agents/chat_agent.py
+++ b/camel/agents/chat_agent.py
@@ -790,11 +790,6 @@ class ChatAgent(BaseAgent):
             )
             error_info = str(exc)
 
-            logger.warning(
-                "To improve reliability, consider using models "
-                "that are better equipped to handle structured output"
-            )
-
         if not response and self.model_backend.num_models > 1:
             raise ModelProcessingError(
                 "Unable to process messages: none of the provided models "


### PR DESCRIPTION
This PR adds an explicit warning to users to use more suited models in case of structured output failure in Workforce.

Fixes #2054 