### PR TITLE
feat(embeddings): allow optional output dimension in OpenAI compatible embedding

### DIFF
--- a/camel/embeddings/openai_compatible_embedding.py
+++ b/camel/embeddings/openai_compatible_embedding.py
@@ -93,12 +93,12 @@ class OpenAICompatibleEmbedding(BaseEmbedding[str]):
             int: The dimensionality of the embedding for the current model.
 
         Raises:
-            RuntimeError: If the embedding dimension cannot be determined.
+            ValueError: If the embedding dimension cannot be determined.
         """
         if self.output_dim is None:
             self.embed_list(["test"])
 
         if self.output_dim is None:
-            raise RuntimeError("Failed to determine embedding dimension")
+            raise ValueError("Failed to determine embedding dimension")
 
         return self.output_dim

--- a/test/embeddings/test_openai_compatible_embedding.py
+++ b/test/embeddings/test_openai_compatible_embedding.py
@@ -85,15 +85,24 @@ class TestOpenAICompatibleEmbedding(unittest.TestCase):
 
     def test_get_output_dim_without_embeddings(self):
         # Test if ValueError is raised when get_output_dim is called before
-        # embed_list
+        # embed_list and embed_list fails to set output_dim
         embedding = OpenAICompatibleEmbedding(
             "text-embedding-model", "test_api_key", "http://test-url.com"
         )
 
-        with self.assertRaises(ValueError) as context:
-            embedding.get_output_dim()
+        # Mock the embed_list method to simulate a failed embedding attempt
+        with patch.object(embedding, 'embed_list') as mock_embed_list:
+            # Configure the mock to not change output_dim (simulating failure)
+            mock_embed_list.return_value = []
 
-        self.assertEqual(
-            str(context.exception),
-            "Output dimension is not yet determined. Call 'embed_list' first.",
-        )
+            with self.assertRaises(ValueError) as context:
+                embedding.get_output_dim()
+
+            # Verify that embed_list was called
+            mock_embed_list.assert_called_once_with(["test"])
+
+            # Check the error message
+            self.assertEqual(
+                str(context.exception),
+                "Failed to determine embedding dimension",
+            )


### PR DESCRIPTION
## Description

- Add a construction parameter called `output_dim` to `OpenAICompatibleEmbedding`. 
- In the `get_output_dim` method, the `self.output_dim` is automatically determined by invoking `embed_list(["test"])`.

Fixes #2071

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have linked this PR to an issue using the Development section on the right sidebar or by adding `Fixes #issue-number` in the PR description (**required**)
- [ ] I have checked if any dependencies need to be added or updated in `pyproject.toml` and `uv lock`
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed:
- [ ] I have added examples if this is a new feature

If you are unsure about any of these, don't hesitate to ask. We are here to help!
