### PR TITLE
fix: improve error handling and resource cleanup in MCP toolkit

### DIFF
--- a/.env
+++ b/.env
@@ -92,7 +92,7 @@
 # CHUNKR_API_KEY="Fill your API key here"
 
 # Meshy API (https://www.meshy.ai/api)
-# MESHY_API_KEY="Fill your API key h    ere"
+# MESHY_API_KEY="Fill your API key here"
 
 # Dappier API (https://api.dappier.com/)
 # DAPPIER_API_KEY="Fill your API key here"

--- a/camel/toolkits/mcp_toolkit.py
+++ b/camel/toolkits/mcp_toolkit.py
@@ -146,8 +146,6 @@ class MCPClient(BaseToolkit):
             await self.disconnect()
             logger.error(f"Failed to connect to MCP server: {e}")
             raise e
-        finally:
-            await self.disconnect()
 
     async def disconnect(self):
         r"""Explicitly disconnect from the MCP server."""
@@ -432,7 +430,7 @@ class MCPToolkit(BaseToolkit):
                         f"Invalid JSON in config file '{config_path}': {e!s}"
                     )
                     raise e
-        except FileNotFoundError:
+        except FileNotFoundError as e:
             logger.warning(f"Config file not found: '{config_path}'")
             raise e
 


### PR DESCRIPTION
## Description

Raise exceptions instead of catch-to-log or returning them to the agent in MCP tools.

Whether an exception is recoverable and how to recover from one should be the caller's responsibility in these cases.

Per [mcp's guidelines](https://modelcontextprotocol.io/docs/concepts/tools#error-handling), tools should report errors via response objects. So an exception raised via an MCP tool will be related to the protocol itself or another issue outside the agent's responsibility.

If the caller (e.g. an application developer) wants agents to be able to work around issues outside their control, like if an MCP server stops responding, they can wrap the step function with an except and give agents a chance to recover or work around on their own. Developers might want to do this for certain types of exceptions and not others (it can be appropriate to also make our own exception types to better serve those patterns), so by self-catching here we make things more difficult.

The current behaviour that hides some errors and stracktraces even when things are potentially very broken is fail-slow and bad devex. If we want ChatAgents to allow agents to recover by default, then an except should be added to the ChatAgent step function, and we should make sure stacktraces are still being printed in that before the agents are given a chance to recover.

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

- [X] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide (**required**)
- [ ] I have linked this PR to an issue using the Development section on the right sidebar or by adding `Fixes #issue-number` in the PR description (**required**)
- [ ] I have checked if any dependencies need to be added or updated in `pyproject.toml` and `uv lock`
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed:
- [ ] I have added examples if this is a new feature
