### PR TITLE
chore: add api_keys_required decorator to Firecrawl Loader

### DIFF
--- a/camel/loaders/firecrawl_reader.py
+++ b/camel/loaders/firecrawl_reader.py
@@ -28,6 +28,11 @@ class Firecrawl:
 
     References:
         https://docs.firecrawl.dev/introduction
+
+    Notes:
+        - When using Firecrawl SDKs with a self-hosted instance, API keys are
+        optional. API keys are only required when connecting to the cloud
+        service (api.firecrawl.dev).
     """
 
     def __init__(


### PR DESCRIPTION
## Description

Add api_keys_required decorator to Firecrawl Loader, instead of relying on catching the error lateron.

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide (**required**)
- [ ] I have linked this PR to an issue using the Development section on the right sidebar or by adding `Fixes #issue-number` in the PR description (**required**)
- [x] I have checked if any dependencies need to be added or updated in `pyproject.toml` and `uv lock`
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed:
- [ ] I have added examples if this is a new feature

If you are unsure about any of these, don't hesitate to ask. We are here to help!
