### PR TITLE
feat：add zhipu_tookit

### DIFF
--- a/camel/toolkits/__init__.py
+++ b/camel/toolkits/__init__.py
@@ -65,7 +65,7 @@ from .data_commons_toolkit import DataCommonsToolkit
 from .thinking_toolkit import ThinkingToolkit
 from .openai_agent_toolkit import OpenAIAgentToolkit
 from .searxng_toolkit import SearxNGToolkit
-
+from .zhipu_toolkit import ZhiPuToolkit
 
 __all__ = [
     'BaseToolkit',
@@ -118,4 +118,5 @@ __all__ = [
     'ThinkingToolkit',
     'OpenAIAgentToolkit',
     'SearxNGToolkit',
+    'ZhiPuToolkit',
 ]

--- a/camel/toolkits/zhipu_toolkit.py
+++ b/camel/toolkits/zhipu_toolkit.py
@@ -1,0 +1,264 @@
+# ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
+
+from typing import List, Optional
+
+import os
+from zhipuai import ZhipuAI
+
+from camel.logger import get_logger
+from camel.toolkits import FunctionTool
+from camel.toolkits.base import BaseToolkit
+from camel.utils import MCPServer, api_keys_required
+
+logger = get_logger(__name__)
+
+
+@MCPServer()
+class ZhiPuToolkit(BaseToolkit):
+    r"""A toolkit using  the agent on Zhipu AI platform.
+    """
+
+    @api_keys_required(
+        [
+            ("api_key", 'ZHIPUAI_API_KEY'),
+        ]
+    )
+    def __init__(
+            self, 
+            api_key: Optional[str] = None,
+            url: Optional[str] = None,
+    ):
+        r"""Initialize the ZhiPuToolkit.
+
+        Args:
+            api_key (Optional[str]): The api key to use for the Zhipu AI platform.
+                (default: :obj:`None`)
+            url (Optional[str]): The url to use for the Zhipu AI platform.
+                (default: :obj:`None`)
+        """
+        api_key = api_key or os.environ.get("ZHIPUAI_API_KEY")
+        url = url or os.environ.get(
+            "ZHIPUAI_API_BASE_URL", "https://open.bigmodel.cn/api/paas/v4/"
+        )
+        self.client = ZhipuAI(api_key=api_key, base_url=url)
+        self.file_ids = []
+
+    def _call_the_agent(
+            self, 
+            prompt: str ,
+            assistant_id: str ,
+            file_path: Optional[str] = None,
+            conversation_id: Optional[str] = None
+        ) -> str:
+        r"""Call the agent to get the result.
+
+        Args:
+            prompt (str): The prompt to call the agent.
+            assistant_id (str): The assistant id to call the agent.
+            file_path (Optional[str]): The path of the file to upload.
+                (default: :obj:`None`)
+            conversation_id (Optional[str]): The conversation id to call the agent.
+                (default: :obj:`None`)
+        Returns:
+            str: The result of the agent.
+        """
+        if file_path:
+            try:
+                resp = self.client.files.create(
+                    file=open(file_path, 'rb'),
+                    purpose='assistant'
+                )
+                file_id = resp.id
+                self.file_ids.append(file_id)
+                attachments = [
+                    {"file_id": file_id} for file_id in self.file_ids
+                    ]
+            except Exception as e:
+                logger.error(f"Upload file failed: {e}")
+                return f"Upload file failed: {e!s}"
+        else:
+            attachments = None
+        try:
+            response = self.client.assistant.conversation(
+                assistant_id=assistant_id,
+                conversation_id=conversation_id,
+                model="glm-4-assistant",
+                messages=[
+                    {
+                        "role": "user",
+                        "content": [{
+                            "type": "text",
+                            "text": prompt
+                        }]
+                    }
+                ],
+                stream=True,
+                attachments=attachments,
+                metadata=None
+            )
+            ressult = ""
+            # Parse according to the Zhipu message format
+            for resp in response:
+                if hasattr(resp, 'choices') and resp.choices:
+                    choice = resp.choices[0]
+                    if hasattr(choice, 'delta'):
+                        if hasattr(choice.delta, 'tool_calls') and choice.delta.tool_calls:
+                            for tool_call in choice.delta.tool_calls:
+                                for attr in dir(tool_call):
+                                    if not attr.startswith('_'):
+                                        attr_value = getattr(tool_call, attr)
+                                        if hasattr(attr_value, 'outputs') and attr_value.outputs:
+                                            for output_item in attr_value.outputs:
+                                                ressult += str(output_item)
+                        if hasattr(choice.delta, 'content'):
+                            ressult += (str(choice.delta.content))
+                        self.conversation_id = resp.conversation_id
+        except Exception as e:
+            logger.error(f"Unexpected error: {e}")
+            return f"Call the agent failed: {e!s}"
+
+        return ressult
+
+    def draw_mindmap(
+        self, prompt: str = None, file_path: Optional[str] = None
+    ) -> str:
+        r"""Generates mindmap with prompt.
+
+        Args:
+            prompt (str): The prompt to write the mindmap.
+            file_path (Optional[str]): The path of the reference file.
+                (default: :obj:`None`)
+        Returns:
+            str: The result of the agent.
+        """
+        return self._call_the_agent(
+            prompt=prompt,
+            assistant_id="664dd7bd5bb3a13ba0f81668",
+            file_path=file_path
+        )
+
+    def draw_flowchart(
+        self, prompt: str = None, file_path: Optional[str] = None
+    ) -> str:
+        r"""Draw a flowchart with a prompt.
+
+        Args:
+            prompt (str): The prompt for drawing the flowchart.
+            file_path (Optional[str]): The path of the reference file.
+                (default: :obj:`None`)
+        Returns:
+            str: The result of the agent.
+        """
+        return self._call_the_agent(
+            prompt=prompt,
+            assistant_id="664dd7bd5bb3a13ba0f81668",
+            file_path=file_path
+        )
+
+    def data_analysis(
+        self, prompt: str = None, file_path: Optional[str] = None
+    ) -> str:
+        r"""Analyze data and provide charting capabilities. Also,
+        it can complete file processing tasks through simple coding.
+
+        Args:
+            prompt (str): The prompt for data analysis.
+            file_path (Optional[str]): The path of the reference file.
+                (default: :obj:`None`)
+        Returns:
+            str: The result of the agent.
+        """
+        return self._call_the_agent(
+            prompt=prompt,
+            assistant_id="65a265419d72d299a9230616",
+            file_path=file_path
+        )
+    
+    def ai_drawing(
+        self, prompt: str = None, file_path: Optional[str] = None
+    ) -> str:
+        r"""Draw a picture with a prompt.
+
+        Args:
+            prompt (str): The prompt for drawing.
+            file_path (Optional[str]): The path of the reference file.
+                (default: :obj:`None`)
+        Returns:
+            str: The result of the agent.
+        """
+        return self._call_the_agent(
+            prompt=prompt,
+            assistant_id="66437ef3d920bdc5c60f338e",
+            file_path=file_path
+        )
+    
+    def ai_search(
+        self, prompt: str = None, file_path: Optional[str] = None
+    ) -> str:
+        r"""Search the internet for information and answer questions.
+
+        Args:
+            prompt (str): The prompt for searching the internet.
+            file_path (Optional[str]): The path of the reference file.
+                (default: :obj:`None`)
+        Returns:
+            str: The result of the agent.
+        """
+        return self._call_the_agent(
+            prompt=prompt,
+            assistant_id="659e54b1b8006379b4b2abd6",
+            file_path=file_path
+        )
+
+    def ppt_generation(
+        self, prompt: str = None, file_path: Optional[str] = None
+    ) -> str:
+        r"""Generate a ppt with a prompt.
+        
+        Args:
+            prompt (str): The prompt for generating the ppt.
+            file_path (Optional[str]): The path of the reference file.
+                (default: :obj:`None`)
+        Returns:
+            str: The result of the agent.
+        """
+        self._call_the_agent(
+            prompt=prompt,
+            assistant_id="65d2f07bb2c10188f885bd89",
+            file_path=file_path
+        )
+        return self._call_the_agent(
+            prompt='生成PPT',
+            assistant_id="65d2f07bb2c10188f885bd89",
+            file_path=file_path,
+            conversation_id=self.conversation_id
+        )
+
+    def get_tools(self) -> List[FunctionTool]:
+        r"""Returns a list of FunctionTool objects representing the functions
+            in the toolkit.
+
+        Returns:
+            List[FunctionTool]: A list of FunctionTool objects representing the
+                functions in the toolkit.
+        """
+        return [
+            FunctionTool(self.draw_mindmap),
+            FunctionTool(self.draw_flowchart),
+            FunctionTool(self.data_analysis),
+            FunctionTool(self.ai_drawing),
+            FunctionTool(self.ai_search),
+            FunctionTool(self.ppt_generation),
+        ]

--- a/examples/toolkits/zhipu_toolkit.py
+++ b/examples/toolkits/zhipu_toolkit.py
@@ -1,0 +1,180 @@
+# ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
+
+from camel.agents import ChatAgent
+from camel.configs import ChatGPTConfig
+from camel.models import ModelFactory
+from camel.toolkits import ZhiPuToolkit, FunctionTool
+from camel.types import ModelPlatformType, ModelType
+
+# Create a Model
+model_config_dict = ChatGPTConfig(temperature=0.0).as_dict()
+model = ModelFactory.create(
+    model_platform=ModelPlatformType.DEFAULT,
+    model_type=ModelType.DEFAULT,
+    model_config_dict=model_config_dict,
+)
+
+# Initialize the ZhiPuToolkit
+zhipu_toolkit = ZhiPuToolkit().ai_drawing
+tools = [FunctionTool(zhipu_toolkit)]
+
+# Set up the ChatAgent with thinking capabilities
+sys_msg = (
+    "You are an assistant that can use other agents to complete tasks."
+)
+
+agent = ChatAgent(
+    system_message=sys_msg,
+    model=model,
+    tools=tools,
+)
+
+usr_msg = """
+Help me draw a picture of a cat.
+"""
+
+response = agent.step(usr_msg)
+print(response.msgs[0].content)
+print("\nTool calls:")
+print(response.info['tool_calls'])
+
+# ruff: noqa: E501
+"""
+===============================================================================
+Here is the drawing of a cute and playful cat sitting on a windowsill:
+
+![Cat Drawing](https://sfile.chatglm.cn/testpath/gen-1744186721453265884_0.png)
+
+You can choose one of the following options to continue:
+
+1. 🎨 **Transform Style** - Change this drawing to a Van Gogh style, adding vibrant colors and dynamic brush strokes.
+2. 🌟 **Add Elements** - Include a small bird in the scene, making it look like the cat is interacting with the bird.
+3. 📚 **Comic Strip** - Generate another image showing the cat jumping down from the windowsill to chase a butterfly.
+4. 💡 **Enhance Tips** - Suggest making the flowers on the windowsill more vibrant and adding details like small decorations to enrich the scene.
+
+Please let me know your choice!
+
+Tool calls:
+[ToolCallingRecord(tool_name='ai_drawing', args={'prompt': 'A cute and playful cat sitting on a windowsill, looking outside with bright green eyes. The background shows a sunny day with blue skies and fluffy clouds.', 'file_path': None}, result="DrawingToolOutput(image='https://sfile.chatglm.cn/testpath/gen-1744186721453265884_0.png')这是一幅描绘一只可爱、活泼的猫咪坐在窗台上的画。它用明亮的绿色眼睛望着窗外，背景是晴朗的一天，蓝天上飘着蓬松的云朵。\n\n接下来，您可以选择以下四个选项之一来继续生成图片：\n\n1. 🎨 选项1 **转变风格** —— 将这幅画转变为梵高风格的画作，增加梵高特有的鲜艳色彩和动感笔触。\n2. 🌟 选项2 **增加元素** —— 在画面中增加一只小鸟，让猫咪看起来像是在和小鸟互动。\n3. 📚 选项3 **连环画** —— 继续生成一张图，展示猫咪从窗台跳下，开始追逐一只蝴蝶的情景。\n4. 💡 选项4 **提升 tips** —— 建议将窗台上的花朵画得更鲜艳一些，并增加一些细节，如窗台上摆放的小饰品，来丰富画面内容。\n\n请告诉我您的选择！", tool_call_id='call_XW4NuDb54ejFH5zBlkdokClZ')]
+===============================================================================
+"""
+
+zhipu_toolkit = ZhiPuToolkit().data_analysis
+tools = [FunctionTool(zhipu_toolkit)]
+
+usr_msg = """
+Make a line chart of Beijing's temperature in the next seven days.
+"""
+
+agent = ChatAgent(
+    system_message=sys_msg,
+    model=model,
+    tools=tools,
+)
+
+response = agent.step(usr_msg)
+print(response.msgs[0].content)
+print("\nTool calls:")
+print(response.info['tool_calls'])
+
+# ruff: noqa: E501
+"""
+===============================================================================
+Here is the line chart showing the temperature forecast for Beijing over the next seven days:
+
+![Beijing Temperature Forecast](https://sfile.chatglm.cn/img2text/be415fe4-c41d-4ea3-8614-1a49c9becde3.jpg)
+
+The chart displays the dates on the x-axis and the corresponding temperatures in degrees Celsius on the y-axis. Each point represents the forecasted temperature for a specific day.
+
+Tool calls:
+[ToolCallingRecord(tool_name='data_analysis', args={'prompt': 'Create a line chart showing the temperature forecast for Beijing over the next seven days.', 'file_path': None}, result="CodeInterpreterToolOutput(type='logs', logs='https://sfile.chatglm.cn/img2text/be415fe4-c41d-4ea3-8614-1a49c9becde3.jpg', error_msg=None)Here is a line chart showing the temperature forecast for Beijing over the next seven days. The chart displays the dates on the x-axis and the corresponding temperatures in degrees Celsius on the y-axis. The data points are connected by a blue line, and each point represents the forecasted temperature for a specific day.", tool_call_id='call_22lrsWel28CV43qxojME2bGY')]
+===============================================================================
+"""
+
+zhipu_toolkit = ZhiPuToolkit().draw_flowchart
+tools = [FunctionTool(zhipu_toolkit)]
+
+input_file = "/Users/suntao/Documents/GitHub/camel/CONTRIBUTING.md"
+
+usr_msg = f"""
+tell me if want to contribute to camel, how to do it. 
+here is the reference file: {input_file},draw a flowchart of the file.
+"""
+
+agent = ChatAgent(
+    system_message=sys_msg,
+    model=model,
+    tools=tools,
+)
+
+response = agent.step(usr_msg)
+print(response.msgs[0].content)
+print("\nTool calls:")
+print(response.info['tool_calls'])
+
+
+# ruff: noqa: E501
+"""
+===============================================================================
+I have created a flowchart based on the contents of the `CONTRIBUTING.md` file for the Camel project. The flowchart outlines the steps and guidelines for contributing. You can view it below:
+
+![Camel Project Contribution Flowchart](https://sfile.chatglm.cn/mermaid/bcbdc7cb-52be-4aee-9f3d-3612184728af.png)
+
+This visual representation summarizes the various steps involved in contributing to the Camel project. If you have any specific questions or need further details, feel free to ask!
+
+Tool calls:
+[ToolCallingRecord(tool_name='draw_flowchart', args={'prompt': 'Create a flowchart based on the contents of the CONTRIBUTING.md file for the Camel project, outlining the steps and guidelines for contributing.', 'file_path': '/Users/suntao/Documents/GitHub/camel/CONTRIBUTING.md'}, result='To create a flowchart based on the contents of the `CONTRIBUTING.md` file for the Camel project, I will first analyze the document to identify the key steps and guidelines for contributing. Then, I will use this information to generate a Mermaid code, which will be used to create the flowchart.\n\n### Analysis of `CONTRIBUTING.md`\n\n1. **Welcome and Introduction**: The document starts with a welcome message and an overview of the project.\n\n2. **Join Our Community**: This section provides information on how to join the community, including scheduling introduction calls and joining communication channels like Discord and WeChat.\n\n3. **Guidelines for Contributing**:\n   - **Contributing to the Code**: This includes following specific workflows for opening pull requests, ensuring code quality, and adhering to coding standards.\n   - **Contributing to the Cookbook Writing**: Guidelines for writing and reviewing cookbooks, including using a specific template and following a review process.\n   - **Contributing to Code Reviews**: This part outlines the guidelines and best practices for conducting code reviews.\n\n4. **Principles**: This section discusses naming principles and the use of `logger` instead of `print` for output.\n\n5. **Board Item Create Workflow**: Describes the workflow for creating and managing issues and pull requests.\n\n6. **Sprint Planning & Review**: Information on the sprint duration, planning, and review process.\n\n7. **Getting Help**: Provides guidance on how to get help with the developer setup and other aspects of contributing.\n\n8. **Quick Start**: Steps for cloning the repository, setting up a virtual environment, and installing dependencies.\n\n9. **Common Actions**: This includes instructions for updating dependencies, running tests, and generating coverage reports.\n\n10. **Documentation**: Guidelines for contributing to the documentation and building it locally.\n\n11. **Versioning and Release**: Information on the versioning standard and release process.\n\n12. **License**: Details about the Apache 2.0 license and how to add it to your code.\n\n13. **Giving Credit**: Instructions on how to receive credit for your contributions.\n\n### Creating the Mermaid Code\n\nBased on the analysis, I will create a Mermaid code that outlines the steps and guidelines for contributing to the Camel project. This code will be used to generate the flowchart.FunctionToolOutput(content=\'{"url":"https://sfile.chatglm.cn/mermaid/bcbdc7cb-52be-4aee-9f3d-3612184728af.png"}\')Here is the flowchart based on the contents of the `CONTRIBUTING.md` file for the Camel project, outlining the steps and guidelines for contributing:\n\n![Camel Project Contribution Flowchart](https://sfile.chatglm.cn/mermaid/bcbdc7cb-52be-4aee-9f3d-3612184728af.png)\n\nThis flowchart provides a visual representation of the various steps and guidelines involved in contributing to the Camel project. If you have any specific requests or need further details, please let me know!', tool_call_id='call_JUfuqgDxh3Dtwdxc23kTcNyC')]
+===============================================================================
+"""
+
+zhipu_toolkit = ZhiPuToolkit().ppt_generation
+tools = [FunctionTool(zhipu_toolkit)]
+
+input_file = "/Users/suntao/Documents/GitHub/camel/CONTRIBUTING.md"
+
+usr_msg = f"""
+tell me if want to contribute to camel, how to do it. 
+here is the reference file: {input_file},generate a ppt of the file.
+"""
+
+agent = ChatAgent(
+    system_message=sys_msg,
+    model=model,
+    tools=tools,
+)
+
+response = agent.step(usr_msg)
+print(response.msgs[0].content)
+print("\nTool calls:")
+print(response.info['tool_calls'])
+
+# ruff: noqa: E501
+"""
+===============================================================================
+The PowerPoint presentation based on the CONTRIBUTING.md file for Apache Camel has been generated. 
+
+### Cover Image:
+![Cover](https://static.islide.cc/site/content/thumbnail/2025-04-09/190319/QVqpryBpum29z2II.thumbnail-0.jpg)
+
+### Links:
+- **[Online Preview](https://fc.chatglm.cn/islide/get_pure_link?history_id=7f1070dc-3c73-4a34-a93f-7241a64c97b0&uid=ef6589cf-1aa5-4871-bf66-0c9b1ff1adf2#glmiframe)**
+- **[Download PPT](https://sfile.chatglm.cn/islide/625d10f0-d54e-4c0c-b7f4-fbc97dcb75f6.pptx)**
+
+Feel free to check it out!
+
+Tool calls:
+[ToolCallingRecord(tool_name='ppt_generation', args={'prompt': 'Generate a PowerPoint presentation based on the contents of the CONTRIBUTING.md file for Apache Camel, detailing how to contribute to the project.', 'file_path': '/Users/suntao/Documents/GitHub/camel/CONTRIBUTING.md'}, result='FunctionToolOutput(content=\'{"pages":[{"index":0,"slideLayout":"title","thumbnail":"https://static.islide.cc/site/content/thumbnail/2025-04-09/190319/QVqpryBpum29z2II.thumbnail-0.jpg"},{"diagramId":652349,"diagramMagnitude":8,"index":1,"slideLayout":"object","thumbnail":"https://static.islide.cc/site/content/thumbnail/2025-04-09/190319/QVqpryBpum29z2II.thumbnail-1.jpg"},{"index":2,"slideLayout":"sectionHeader","thumbnail":"https://static.islide.cc/site/content/thumbnail/2025-04-09/190319/QVqpryBpum29z2II.thumbnail-2.jpg"},{"diagramId":null,"diagramMagnitude":0,"index":3,"slideLayout":"object","thumbnail":"https://static.islide.cc/site/content/thumbnail/2025-04-09/190319/QVqpryBpum29z2II.thumbnail-3.jpg"},{"diagramId":null,"diagramMagnitude":0,"index":4,"slideLayout":"object","thumbnail":"https://static.islide.cc/site/content/thumbnail/2025-04-09/190319/QVqpryBpum29z2II.thumbnail-4.jpg"},{"diagramId":null,"diagramMagnitude":0,"index":5,"slideLayout":"object","thumbnail":"https://static.islide.cc/site/content/thumbnail/2025-04-09/190319/QVqpryBpum29z2II.thumbnail-5.jpg"},{"index":6,"slideLayout":"sectionHeader","thumbnail":"https://static.islide.cc/site/content/thumbnail/2025-04-09/190319/QVqpryBpum29z2II.thumbnail-6.jpg"},{"diagramId":null,"diagramMagnitude":0,"index":7,"slideLayout":"object","thumbnail":"https://static.islide.cc/site/content/thumbnail/2025-04-09/190319/QVqpryBpum29z2II.thumbnail-7.jpg"},{"diagramId":null,"diagramMagnitude":0,"index":8,"slideLayout":"object","thumbnail":"https://static.islide.cc/site/content/thumbnail/2025-04-09/190319/QVqpryBpum29z2II.thumbnail-8.jpg"},{"diagramId":null,"diagramMagnitude":0,"index":9,"slideLayout":"object","thumbnail":"https://static.islide.cc/site/content/thumbnail/2025-04-09/190319/QVqpryBpum29z2II.thumbnail-9.jpg"},{"diagramId":null,"diagramMagnitude":0,"index":10,"slideLayout":"object","thumbnail":"https://static.islide.cc/site/content/thumbnail/2025-04-09/190319/QVqpryBpum29z2II.thumbnail-10.jpg"},{"diagramId":null,"diagramMagnitude":0,"index":11,"slideLayout":"object","thumbnail":"https://static.islide.cc/site/content/thumbnail/2025-04-09/190319/QVqpryBpum29z2II.thumbnail-11.jpg"},{"diagramId":null,"diagramMagnitude":0,"index":12,"slideLayout":"object","thumbnail":"https://static.islide.cc/site/content/thumbnail/2025-04-09/190319/QVqpryBpum29z2II.thumbnail-12.jpg"},{"diagramId":null,"diagramMagnitude":0,"index":13,"slideLayout":"object","thumbnail":"https://static.islide.cc/site/content/thumbnail/2025-04-09/190319/QVqpryBpum29z2II.thumbnail-13.jpg"},{"diagramId":null,"diagramMagnitude":0,"index":14,"slideLayout":"object","thumbnail":"https://static.islide.cc/site/content/thumbnail/2025-04-09/190319/QVqpryBpum29z2II.thumbnail-14.jpg"},{"index":15,"slideLayout":"sectionHeader","thumbnail":"https://static.islide.cc/site/content/thumbnail/2025-04-09/190319/QVqpryBpum29z2II.thumbnail-15.jpg"},{"index":16,"slideLayout":"sectionHeader","thumbnail":"https://static.islide.cc/site/content/thumbnail/2025-04-09/190319/QVqpryBpum29z2II.thumbnail-16.jpg"},{"index":17,"slideLayout":"sectionHeader","thumbnail":"https://static.islide.cc/site/content/thumbnail/2025-04-09/190319/QVqpryBpum29z2II.thumbnail-17.jpg"},{"index":18,"slideLayout":"sectionHeader","thumbnail":"https://static.islide.cc/site/content/thumbnail/2025-04-09/190319/QVqpryBpum29z2II.thumbnail-18.jpg"},{"index":19,"slideLayout":"sectionHeader","thumbnail":"https://static.islide.cc/site/content/thumbnail/2025-04-09/190319/QVqpryBpum29z2II.thumbnail-19.jpg"},{"index":20,"slideLayout":"sectionHeader","thumbnail":"https://static.islide.cc/site/content/thumbnail/2025-04-09/190319/QVqpryBpum29z2II.thumbnail-20.jpg"},{"index":21,"slideLayout":"closing","thumbnail":"https://static.islide.cc/site/content/thumbnail/2025-04-09/190319/QVqpryBpum29z2II.thumbnail-21.jpg"}],"ppt_download_link":"https://sfile.chatglm.cn/islide/625d10f0-d54e-4c0c-b7f4-fbc97dcb75f6.pptx","ppt_preview_link":"https://fc.chatglm.cn/islide/get_pure_link?history_id=7f1070dc-3c73-4a34-a93f-7241a64c97b0&uid=ef6589cf-1aa5-4871-bf66-0c9b1ff1adf2#glmiframe"}\\n\')PPT已经生成，以下是封面图片：\n![封面](https://static.islide.cc/site/content/thumbnail/2025-04-09/190319/QVqpryBpum29z2II.thumbnail-0.jpg)  \n\n您可以点击以下链接在线预览：[在线预览](https://fc.chatglm.cn/islide/get_pure_link?history_id=7f1070dc-3c73-4a34-a93f-7241a64c97b0&uid=ef6589cf-1aa5-4871-bf66-0c9b1ff1adf2#glmiframe)\n\n如果您需要下载PPT，请点击此链接：[下载PPT](https://sfile.chatglm.cn/islide/625d10f0-d54e-4c0c-b7f4-fbc97dcb75f6.pptx)', tool_call_id='call_LshMh6c5EA6tiDcfAXWA6vGa')]
+===============================================================================
+"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,6 +164,7 @@ model_platforms = [
     "anthropic>=0.47.0,<0.50.0",
     "cohere>=5.11.0,<6",
     "fish-audio-sdk>=2024.12.5,<2025",
+    "zhipuai",
 ]
 huggingface = [
     "transformers>=4,<5",
@@ -335,7 +336,8 @@ all = [
     "typer>=0.15.2",
     "mem0ai>=0.1.67",
     "math-verify>=0.7.0,<0.8",
-    "exa-py>=1.10.0,<2"
+    "exa-py>=1.10.0,<2",
+    "zhipuai"
 ]
 
 [project.urls]

--- a/test/toolkits/test_zhipu_toolkit.py
+++ b/test/toolkits/test_zhipu_toolkit.py
@@ -1,0 +1,313 @@
+# ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
+from unittest.mock import MagicMock, patch
+
+import pytest
+import os
+from zhipuai import ZhipuAI
+
+from camel.toolkits.zhipu_toolkit import ZhiPuToolkit
+from camel.toolkits import FunctionTool
+
+
+# Fixture for mock ZhipuAI client
+@pytest.fixture
+def mock_zhipu_client():
+    mock_client = MagicMock(spec=ZhipuAI)
+    mock_client.files = MagicMock()
+    mock_client.assistant = MagicMock()
+    return mock_client
+
+
+# Fixture for mock environment variables
+@pytest.fixture
+def mock_env_vars():
+    with patch.dict(os.environ, {"ZHIPUAI_API_KEY": "test_api_key"}):
+        yield
+
+
+# Fixture for ZhiPuToolkit with mocked client
+@pytest.fixture
+def zhipu_toolkit(mock_zhipu_client, mock_env_vars):
+    return ZhiPuToolkit(api_key="test_api_key")
+
+
+def test_init_with_api_key():
+    """Test initialization with provided API key."""
+    toolkit = ZhiPuToolkit(api_key="test_api_key")
+    assert toolkit.client.api_key == "test_api_key"
+    assert toolkit.client.base_url == "https://open.bigmodel.cn/api/paas/v4/"
+
+
+def test_init_with_api_key_and_url():
+    """Test initialization with provided API key and URL."""
+    toolkit = ZhiPuToolkit(api_key="test_api_key", url="http://test_url")
+    assert toolkit.client.api_key == "test_api_key"
+    assert toolkit.client.base_url == "http://test_url"
+
+
+def test_init_from_env_vars(mock_zhipu_client, mock_env_vars):
+    """Test initialization using environment variables."""
+    toolkit = ZhiPuToolkit()
+    assert toolkit.client.api_key == "test_api_key"
+    assert toolkit.client.base_url == "https://open.bigmodel.cn/api/paas/v4/"
+
+
+def test_init_no_api_key():
+    """Test initialization without API key raises an error."""
+    with pytest.raises(ValueError, match="ZHIPUAI_API_KEY is required."):
+        ZhiPuToolkit()
+
+
+@patch("camel.toolkits.zhipu_toolkit.ZhipuAI.files.create")
+@patch("camel.toolkits.zhipu_toolkit.ZhipuAI.assistant.conversation")
+def test_call_the_agent_success(
+    mock_conversation, mock_file_create, zhipu_toolkit
+):
+    """Test successful call to the agent."""
+    mock_file_create.return_value.id = "test_file_id"
+    mock_conversation.return_value = [
+        MagicMock(
+            choices=[
+                MagicMock(
+                    delta=MagicMock(
+                        content="Test response part 1", tool_calls=None
+                    )
+                )
+            ],
+            conversation_id="test_conversation_id",
+        ),
+        MagicMock(
+            choices=[
+                MagicMock(
+                    delta=MagicMock(
+                        content="Test response part 2", tool_calls=None
+                    )
+                )
+            ],
+            conversation_id="test_conversation_id",
+        ),
+    ]
+    result = zhipu_toolkit._call_the_agent(
+        prompt="Test prompt", assistant_id="test_assistant_id"
+    )
+    assert result == "Test response part 1Test response part 2"
+    mock_conversation.assert_called_once()
+    assert zhipu_toolkit.conversation_id == "test_conversation_id"
+    assert not mock_file_create.called
+
+
+@patch("camel.toolkits.zhipu_toolkit.ZhipuAI.files.create")
+@patch("camel.toolkits.zhipu_toolkit.ZhipuAI.assistant.conversation")
+def test_call_the_agent_with_file(
+    mock_conversation, mock_file_create, zhipu_toolkit
+):
+    """Test calling the agent with a file."""
+    mock_file_create.return_value.id = "test_file_id"
+    mock_conversation.return_value = [
+        MagicMock(
+            choices=[
+                MagicMock(
+                    delta=MagicMock(
+                        content="Test response", tool_calls=None
+                    )
+                )
+            ],
+            conversation_id="test_conversation_id",
+        )
+    ]
+    with patch("builtins.open", MagicMock(), create=True):
+        result = zhipu_toolkit._call_the_agent(
+            prompt="Test prompt",
+            assistant_id="test_assistant_id",
+            file_path="test_file.txt",
+        )
+    assert result == "Test response"
+    mock_file_create.assert_called_once()
+    mock_conversation.assert_called_once()
+    assert "test_file_id" in zhipu_toolkit.file_ids
+
+
+@patch("camel.toolkits.zhipu_toolkit.ZhipuAI.files.create")
+@patch("camel.toolkits.zhipu_toolkit.ZhipuAI.assistant.conversation")
+def test_call_the_agent_file_upload_fails(
+    mock_conversation, mock_file_create, zhipu_toolkit
+):
+    """Test handling of file upload failure."""
+    mock_file_create.side_effect = Exception("File upload error")
+    with patch("builtins.open", MagicMock(), create=True):
+        result = zhipu_toolkit._call_the_agent(
+            prompt="Test prompt",
+            assistant_id="test_assistant_id",
+            file_path="test_file.txt",
+        )
+    assert "Upload file failed: File upload error" in result
+    assert not mock_conversation.called
+
+
+@patch("camel.toolkits.zhipu_toolkit.ZhipuAI.files.create")
+@patch("camel.toolkits.zhipu_toolkit.ZhipuAI.assistant.conversation")
+def test_call_the_agent_api_call_fails(
+    mock_conversation, mock_file_create, zhipu_toolkit
+):
+    """Test handling of API call failure."""
+    mock_conversation.side_effect = Exception("API call error")
+    result = zhipu_toolkit._call_the_agent(
+        prompt="Test prompt", assistant_id="test_assistant_id"
+    )
+    assert "Call the agent failed: API call error" in result
+    assert not mock_file_create.called
+
+
+@patch("camel.toolkits.zhipu_toolkit.ZhipuAI.assistant.conversation")
+def test_call_the_agent_with_tool_calls(mock_conversation, zhipu_toolkit):
+    """Test parsing response with tool calls."""
+    mock_conversation.return_value = [
+        MagicMock(
+            choices=[
+                MagicMock(
+                    delta=MagicMock(
+                        content=None,
+                        tool_calls=[
+                            MagicMock(
+                                id="call_123",
+                                type="function",
+                                function=MagicMock(
+                                    name="get_current_weather",
+                                    arguments='{"location": "Beijing"}',
+                                ),
+                            )
+                        ],
+                    )
+                )
+            ],
+            conversation_id="test_conversation_id",
+        ),
+        MagicMock(
+            choices=[
+                MagicMock(
+                    delta=MagicMock(
+                        content=None,
+                        tool_calls=[
+                            MagicMock(
+                                id="call_123",
+                                type="function",
+                                function=MagicMock(
+                                    outputs=[{"name": "temperature", "value": "25"}]
+                                ),
+                            )
+                        ],
+                    )
+                )
+            ],
+            conversation_id="test_conversation_id",
+        ),
+    ]
+    result = zhipu_toolkit._call_the_agent(
+        prompt="Test prompt", assistant_id="test_assistant_id"
+    )
+    assert "{'name': 'temperature', 'value': '25'}" in result
+
+
+@patch("camel.toolkits.zhipu_toolkit.ZhiPuToolkit._call_the_agent")
+def test_draw_mindmap(mock_call_agent, zhipu_toolkit):
+    """Test draw_mindmap method."""
+    zhipu_toolkit.draw_mindmap(prompt="Test mindmap prompt")
+    mock_call_agent.assert_called_once_with(
+        prompt="Test mindmap prompt",
+        assistant_id="664dd7bd5bb3a13ba0f81668",
+        file_path=None,
+    )
+
+
+@patch("camel.toolkits.zhipu_toolkit.ZhiPuToolkit._call_the_agent")
+def test_draw_flowchart(mock_call_agent, zhipu_toolkit):
+    """Test draw_flowchart method."""
+    zhipu_toolkit.draw_flowchart(prompt="Test flowchart prompt", file_path="test.txt")
+    mock_call_agent.assert_called_once_with(
+        prompt="Test flowchart prompt",
+        assistant_id="664dd7bd5bb3a13ba0f81668",
+        file_path="test.txt",
+    )
+
+
+@patch("camel.toolkits.zhipu_toolkit.ZhiPuToolkit._call_the_agent")
+def test_data_analysis(mock_call_agent, zhipu_toolkit):
+    """Test data_analysis method."""
+    zhipu_toolkit.data_analysis(prompt="Test data analysis prompt")
+    mock_call_agent.assert_called_once_with(
+        prompt="Test data analysis prompt",
+        assistant_id="65a265419d72d299a9230616",
+        file_path=None,
+    )
+
+
+@patch("camel.toolkits.zhipu_toolkit.ZhiPuToolkit._call_the_agent")
+def test_ai_drawing(mock_call_agent, zhipu_toolkit):
+    """Test ai_drawing method."""
+    zhipu_toolkit.ai_drawing(prompt="Test drawing prompt", file_path="image.png")
+    mock_call_agent.assert_called_once_with(
+        prompt="Test drawing prompt",
+        assistant_id="66437ef3d920bdc5c60f338e",
+        file_path="image.png",
+    )
+
+
+@patch("camel.toolkits.zhipu_toolkit.ZhiPuToolkit._call_the_agent")
+def test_ai_search(mock_call_agent, zhipu_toolkit):
+    """Test ai_search method."""
+    zhipu_toolkit.ai_search(prompt="Test search prompt")
+    mock_call_agent.assert_called_once_with(
+        prompt="Test search prompt",
+        assistant_id="659e54b1b8006379b4b2abd6",
+        file_path=None,
+    )
+
+
+@patch("camel.toolkits.zhipu_toolkit.ZhiPuToolkit._call_the_agent")
+def test_ppt_generation(mock_call_agent, zhipu_toolkit):
+    """Test ppt_generation method."""
+    zhipu_toolkit.ppt_generation(prompt="Test PPT prompt", file_path="report.pdf")
+    assert mock_call_agent.call_count == 2
+    mock_call_agent.assert_any_call(
+        prompt="Test PPT prompt",
+        assistant_id="65d2f07bb2c10188f885bd89",
+        file_path="report.pdf",
+    )
+    mock_call_agent.assert_any_call(
+        prompt="生成PPT",
+        assistant_id="65d2f07bb2c10188f885bd89",
+        file_path="report.pdf",
+        conversation_id=zhipu_toolkit.conversation_id,
+    )
+
+
+def test_get_tools(zhipu_toolkit):
+    """Test get_tools method."""
+    tools = zhipu_toolkit.get_tools()
+    assert isinstance(tools, list)
+    assert len(tools) == 6
+    tool_names = [tool.name for tool in tools]
+    assert "draw_mindmap" in tool_names
+    assert "draw_flowchart" in tool_names
+    assert "data_analysis" in tool_names
+    assert "ai_drawing" in tool_names
+    assert "ai_search" in tool_names
+    assert "ppt_generation" in tool_names
+    assert any(tool.func == zhipu_toolkit.draw_mindmap for tool in tools)
+    assert any(tool.func == zhipu_toolkit.draw_flowchart for tool in tools)
+    assert any(tool.func == zhipu_toolkit.data_analysis for tool in tools)
+    assert any(tool.func == zhipu_toolkit.ai_drawing for tool in tools)
+    assert any(tool.func == zhipu_toolkit.ai_search for tool in tools)
+    assert any(tool.func == zhipu_toolkit.ppt_generation for tool in tools)


### PR DESCRIPTION
## Description

ntegrate GLM-4-Assistant as a toolkit into CAMEL, introducing some tools that are not well-supported by the current CAMEL, such as drawing mind maps, creating PPTs, etc.

Current points that may need discussion are:

Whether to include the tool message from GLM-4-Assistant when calling tools in the returned results (currently included). The advantage is that users can more clearly understand what the agent has done, while the downside is that it may significantly lengthen the message.

Whether to introduce a multi-turn dialogue mode. During testing, it was observed that after some tools are executed, GLM-4-Assistant may provide additional options and ask which direction you'd like to improve in. Introducing this would require providing a conversation_id, similar to the PPT generation method.

Whether to introduce a method for autonomously selecting an assistant_id. The official documentation provides a query command, but unofficial services may be unstable.

reference:https://www.bigmodel.cn/dev/api/intelligent-agent-model/assistantapi

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

- [ ] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide (**required**)
- [ ] I have linked this PR to an issue using the Development section on the right sidebar or by adding `Fixes #issue-number` in the PR description (**required**)
- [ ] I have checked if any dependencies need to be added or updated in `pyproject.toml` and `uv lock`
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed:
- [ ] I have added examples if this is a new feature

If you are unsure about any of these, don't hesitate to ask. We are here to help!
