### PR TITLE
fix: Make datapoint compatible with openai API

### DIFF
--- a/camel/datasets/models.py
+++ b/camel/datasets/models.py
@@ -40,6 +40,9 @@ class DataPoint(BaseModel):
         default=None, description="Additional metadata about the data point."
     )
 
+    class Config:
+        extra = "forbid"
+
     def to_dict(self) -> Dict[str, Any]:
         r"""Convert DataPoint to a dictionary.
 


### PR DESCRIPTION
## Description

The current pydantic model for DataPoints is not compatible with the OpenAI API. A small fix solves this.

Also, FewShotGenerator currently uses an outdated pydantic model that leads to it wasting API tokens that are not needed.

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide (**required**)
- [ ] I have linked this PR to an issue using the Development section on the right sidebar or by adding `Fixes #issue-number` in the PR description (**required**)
- [ ] I have checked if any dependencies need to be added or updated in `pyproject.toml` and `uv lock`
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed:
- [ ] I have added examples if this is a new feature

If you are unsure about any of these, don't hesitate to ask. We are here to help!
