### PR TITLE
fix: Enable extractor to handle single boxed backslashes

### DIFF
--- a/camel/extractors/python_strategies.py
+++ b/camel/extractors/python_strategies.py
@@ -22,21 +22,27 @@ logger = get_logger(__name__)
 
 
 class BoxedStrategy(BaseExtractorStrategy):
-    r"""Extracts content from \\boxed{} environments."""
+    r"""Extracts content from \\boxed{} and \boxed{} environments."""
 
     async def extract(self, text: str) -> Optional[str]:
-        r"""Extract content from \\boxed{} environments.
+        r"""Extract content from \\boxed{} and \boxed{} environments.
 
         Args:
             text (str): The input text to process.
 
         Returns:
-            Optional[str]: Content inside \\boxed{} if found, else None.
+            Optional[str]: Content inside \\boxed{} or \boxed{} if found, else
+                None.
         """
         # Find the start of the boxed content
         boxed_pattern = "\\boxed{"
-        if boxed_pattern not in text:
-            logger.debug("No \\boxed{} content found in the response")
+        single_backslash_boxed_pattern = "\boxed{"
+
+        if (
+            boxed_pattern not in text
+            and single_backslash_boxed_pattern not in text
+        ):
+            logger.debug("Neither of the accepted boxed patterns found")
             return None
 
         start_idx = text.find(boxed_pattern) + len(boxed_pattern)

--- a/camel/extractors/python_strategies.py
+++ b/camel/extractors/python_strategies.py
@@ -42,7 +42,10 @@ class BoxedStrategy(BaseExtractorStrategy):
             boxed_pattern not in text
             and single_backslash_boxed_pattern not in text
         ):
-            logger.debug("Neither of the accepted boxed patterns found")
+            logger.debug(
+                f"Patterns '{boxed_pattern}' or "
+                f"'{single_backslash_boxed_pattern}' not found in text: {text}"
+            )
             return None
 
         start_idx = text.find(boxed_pattern) + len(boxed_pattern)

--- a/test/extractors/test_python_strategies.py
+++ b/test/extractors/test_python_strategies.py
@@ -31,6 +31,16 @@ async def test_boxed_strategy():
     result = await strategy.extract(text)
     assert result == "test content"
 
+    # Test not so basic boxed content
+    text = r"\boxed{\dfrac{9}{7}}"
+    result = await strategy.extract(text)
+    assert result == r"\dfrac{9}{7}"
+
+    # Test not so basic boxed content with double backslash
+    text = r"\\boxed{\dfrac{9}{7}}"
+    result = await strategy.extract(text)
+    assert result == r"\dfrac{9}{7}"
+
     # Test nested braces
     text = r"\boxed{nested {braces} test}"
     result = await strategy.extract(text)


### PR DESCRIPTION
## Description

The extractor was not working correctly with single boxed statements.

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide (**required**)
- [ ] I have linked this PR to an issue using the Development section on the right sidebar or by adding `Fixes #issue-number` in the PR description (**required**)
- [ ] I have checked if any dependencies need to be added or updated in `pyproject.toml` and `uv lock`
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed:
- [ ] I have added examples if this is a new feature

If you are unsure about any of these, don't hesitate to ask. We are here to help!
