### PR TITLE
fix: missing-fields-when-converting-mcp-toolkit-inputschema-to-openai-schema

### DIFF
--- a/camel/toolkits/mcp_toolkit.py
+++ b/camel/toolkits/mcp_toolkit.py
@@ -314,6 +314,7 @@ class MCPClient(BaseToolkit):
             "type": "object",
             "properties": properties,
             "required": required,
+            "additionalProperties": False,
         }
 
         return {
@@ -322,6 +323,7 @@ class MCPClient(BaseToolkit):
                 "name": mcp_tool.name,
                 "description": mcp_tool.description
                 or "No description provided.",
+                "strict": True,
                 "parameters": parameters,
             },
         }

--- a/test/toolkits/test_mcp_toolkit.py
+++ b/test/toolkits/test_mcp_toolkit.py
@@ -264,6 +264,7 @@ class TestMCPClient:
             "function": {
                 "name": "test_function",
                 "description": "Test function description",
+                "strict": True,
                 "parameters": {
                     "type": "object",
                     "properties": {
@@ -271,6 +272,7 @@ class TestMCPClient:
                         "param2": {"type": "integer"},
                     },
                     "required": ["param1", "param2"],
+                    "additionalProperties": False,
                 },
             },
         }
@@ -284,6 +286,7 @@ class TestMCPClient:
             "function": {
                 "name": "test_function",
                 "description": "No description provided.",
+                "strict": True,
                 "parameters": {
                     "type": "object",
                     "properties": {
@@ -291,6 +294,7 @@ class TestMCPClient:
                         "param2": {"type": "integer"},
                     },
                     "required": ["param1", "param2"],
+                    "additionalProperties": False,
                 },
             },
         }


### PR DESCRIPTION
## Description

Describe your changes in detail (optional if the linked issue already contains a detailed description of the changes).

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

- [ ] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide (**required**)
- [ ] I have linked this PR to an issue using the Development section on the right sidebar or by adding `Fixes #issue-number` in the PR description (**required**)
- [ ] I have checked if any dependencies need to be added or updated in `pyproject.toml` and `uv lock`
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed:
- [ ] I have added examples if this is a new feature

If you are unsure about any of these, don't hesitate to ask. We are here to help!
