### PR TITLE
fix: pydutogui test

### DIFF
--- a/test/toolkits/test_pyautogui_toolkit.py
+++ b/test/toolkits/test_pyautogui_toolkit.py
@@ -11,19 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
-# =========== Copyright 2023 @ CAMEL-AI.org. All Rights Reserved. ===========
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-# =========== Copyright 2023 @ CAMEL-AI.org. All Rights Reserved. ===========
 
 import os
 from unittest.mock import MagicMock, patch

--- a/test/toolkits/test_pyautogui_toolkit.py
+++ b/test/toolkits/test_pyautogui_toolkit.py
@@ -11,11 +11,42 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
+# =========== Copyright 2023 @ CAMEL-AI.org. All Rights Reserved. ===========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =========== Copyright 2023 @ CAMEL-AI.org. All Rights Reserved. ===========
 
 import os
 from unittest.mock import MagicMock, patch
 
-from camel.toolkits.pyautogui_toolkit import PyAutoGUIToolkit
+import pytest
+
+# Try importing PyAutoGUIToolkit, skip tests if it or its dependencies fail
+# This commonly happens in headless environments where 'DISPLAY' is not set.
+try:
+    import pyautogui  # noqa: F401
+
+    from camel.toolkits import PyAutoGUIToolkit
+
+    pyautogui_functional = True
+except (ImportError, KeyError, RuntimeError):
+    pyautogui_functional = False
+
+# Skip all tests in this module if pyautogui isn't functional
+pytestmark = pytest.mark.skipif(
+    not pyautogui_functional,
+    reason="PyAutoGUI is not installed or not functional in this "
+    "environment (e.g., headless)",
+)
 
 
 def test_initialization():


### PR DESCRIPTION
## Description

These KeyError: 'DISPLAY' failures are happening because pyautogui requires a display environment (like X11 on Linux) to control the mouse/keyboard or take screenshots. When running in headless CI environments (like GitHub Actions), there's no display available, hence the 'DISPLAY' variable is missing.

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

- [ ] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide (**required**)
- [ ] I have linked this PR to an issue using the Development section on the right sidebar or by adding `Fixes #issue-number` in the PR description (**required**)
- [ ] I have checked if any dependencies need to be added or updated in `pyproject.toml` and `uv lock`
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed:
- [ ] I have added examples if this is a new feature

If you are unsure about any of these, don't hesitate to ask. We are here to help!
