### PR TITLE
fix: await bug in Workforce logic

### DIFF
--- a/camel/societies/workforce/role_playing_worker.py
+++ b/camel/societies/workforce/role_playing_worker.py
@@ -116,7 +116,7 @@ class RolePlayingWorker(Worker):
                 input_msg
             )
 
-            if assistant_response.terminated:git commit -am '
+            if assistant_response.terminated:
                 reason = assistant_response.info['termination_reasons']
                 print(
                     f"{Fore.GREEN}AI Assistant terminated. Reason: "

--- a/camel/societies/workforce/role_playing_worker.py
+++ b/camel/societies/workforce/role_playing_worker.py
@@ -112,11 +112,11 @@ class RolePlayingWorker(Worker):
         chat_history = []
         while n < self.chat_turn_limit:
             n += 1
-            assistant_response, user_response = role_play_session.step(
+            assistant_response, user_response = await role_play_session.step(
                 input_msg
             )
 
-            if assistant_response.terminated:
+            if assistant_response.terminated:git commit -am '
                 reason = assistant_response.info['termination_reasons']
                 print(
                     f"{Fore.GREEN}AI Assistant terminated. Reason: "

--- a/camel/societies/workforce/single_agent_worker.py
+++ b/camel/societies/workforce/single_agent_worker.py
@@ -72,7 +72,7 @@ class SingleAgentWorker(Worker):
             additional_info=task.additional_info,
         )
         try:
-            response = self.worker.step(prompt, response_format=TaskResult)
+            response = await self.worker.step(prompt, response_format=TaskResult)
         except Exception as e:
             print(
                 f"{Fore.RED}Error occurred while processing task {task.id}:"


### PR DESCRIPTION
This pull request fixes two cases where coroutine functions were not properly awaited within async task processing methods.

### Changes:
- In `role_playing_worker.py`, the `role_play_session.step()` call is now awaited.
- In `single_agent_worker.py`, the `worker.step()` call is now awaited.

### Why:
Without `await`, coroutine objects are returned instead of their execution results, which can lead to unexpected behavior and errors like:
- `cannot pickle coroutine object`
- silent failures in task processing

This fix ensures that tasks are correctly executed within the async framework.