### PR TITLE
feat: Pass timeout to MCP session

### DIFF
--- a/camel/toolkits/mcp_toolkit.py
+++ b/camel/toolkits/mcp_toolkit.py
@@ -61,7 +61,7 @@ class MCPClient(BaseToolkit):
         env (Dict[str, str]): Environment variables for the stdio mode command.
             (default: :obj:`'None'`)
         timeout (Optional[float]): Connection timeout seconds.
-            (default: :obj:`'None'`)
+            (default: 30)
         headers (Dict[str, str]): Headers for the HTTP request.
             (default: :obj:`'None'`)
         strict (Optional[bool]): Whether to enforce strict mode for the
@@ -73,7 +73,7 @@ class MCPClient(BaseToolkit):
         command_or_url: str,
         args: Optional[List[str]] = None,
         env: Optional[Dict[str, str]] = None,
-        timeout: Optional[float] = None,
+        timeout: float = 30,
         headers: Optional[Dict[str, str]] = None,
         strict: Optional[bool] = False,
     ):

--- a/camel/toolkits/mcp_toolkit.py
+++ b/camel/toolkits/mcp_toolkit.py
@@ -60,7 +60,8 @@ class MCPClient(BaseToolkit):
             (default: :obj:`'None'`)
         env (Dict[str, str]): Environment variables for the stdio mode command.
             (default: :obj:`'None'`)
-        timeout (Optional[float]): Connection timeout. (default: :obj:`'None'`)
+        timeout (Optional[float]): Connection timeout seconds.
+            (default: :obj:`'None'`)
         headers (Dict[str, str]): Headers for the HTTP request.
             (default: :obj:`'None'`)
         strict (Optional[bool]): Whether to enforce strict mode for the
@@ -114,6 +115,7 @@ class MCPClient(BaseToolkit):
                     sse_client(
                         self.command_or_url,
                         headers=self.headers,
+                        timeout=self.timeout
                     )
                 )
             else:

--- a/camel/toolkits/mcp_toolkit.py
+++ b/camel/toolkits/mcp_toolkit.py
@@ -11,14 +11,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
-from datetime import timedelta
-
-
 import inspect
 import json
 import os
 import shlex
 from contextlib import AsyncExitStack, asynccontextmanager
+from datetime import timedelta
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -55,15 +53,15 @@ class MCPClient(BaseToolkit):
 
     Attributes:
         command_or_url (str): URL for SSE mode or command executable for stdio
-            mode. (default: :obj:`'None'`)
+            mode. (default: :obj:`None`)
         args (List[str]): List of command-line arguments if stdio mode is used.
-            (default: :obj:`'None'`)
+            (default: :obj:`None`)
         env (Dict[str, str]): Environment variables for the stdio mode command.
-            (default: :obj:`'None'`)
-        timeout (float): Connection timeout seconds.
-            (default: 30)
+            (default: :obj:`None`)
+        timeout (Optional[float]): Connection timeout.
+            (default: :obj:`None`)
         headers (Dict[str, str]): Headers for the HTTP request.
-            (default: :obj:`'None'`)
+            (default: :obj:`None`)
         strict (Optional[bool]): Whether to enforce strict mode for the
             function call. (default: :obj:`False`)
     """
@@ -115,7 +113,7 @@ class MCPClient(BaseToolkit):
                     sse_client(
                         self.command_or_url,
                         headers=self.headers,
-                        timeout=self.timeout
+                        timeout=self.timeout,
                     )
                 )
             else:
@@ -143,8 +141,9 @@ class MCPClient(BaseToolkit):
                 )
 
             self._session = await self._exit_stack.enter_async_context(
-                ClientSession(read_stream, write_stream,
-                              timedelta(seconds=self.timeout))
+                ClientSession(
+                    read_stream, write_stream, timedelta(seconds=self.timeout)
+                )
             )
             await self._session.initialize()
             list_tools_result = await self.list_mcp_tools()

--- a/camel/toolkits/mcp_toolkit.py
+++ b/camel/toolkits/mcp_toolkit.py
@@ -11,6 +11,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
+from datetime import timedelta
+
+
 import inspect
 import json
 import os
@@ -138,7 +141,8 @@ class MCPClient(BaseToolkit):
                 )
 
             self._session = await self._exit_stack.enter_async_context(
-                ClientSession(read_stream, write_stream)
+                ClientSession(read_stream, write_stream,
+                              timedelta(seconds=self.timeout))
             )
             await self._session.initialize()
             list_tools_result = await self.list_mcp_tools()

--- a/camel/toolkits/mcp_toolkit.py
+++ b/camel/toolkits/mcp_toolkit.py
@@ -60,7 +60,7 @@ class MCPClient(BaseToolkit):
             (default: :obj:`'None'`)
         env (Dict[str, str]): Environment variables for the stdio mode command.
             (default: :obj:`'None'`)
-        timeout (Optional[float]): Connection timeout seconds.
+        timeout (float): Connection timeout seconds.
             (default: 30)
         headers (Dict[str, str]): Headers for the HTTP request.
             (default: :obj:`'None'`)


### PR DESCRIPTION
## Description

Pass the timeout seconds to the MCP session. Without this, it will use the default which is 5 currently.

I make timeout non-optional, since one will be set regardless by mcp. It could be desirable to accept a None-able timeout where `None` means to defer to whichever default timeout the underlying library has set, though I don't expect this to be frequently desired and people will be happy with a reasonable default, and many unaware of the underlying library could expect `None` to mean "no timeout" which would lead to greater surprise.

## Context
Timeouts beyond 5 seconds are useful for long-running MCP tools. Excessively long timeouts are also useful for enabling event-based systems (this is my need for this)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide (**required**)
- [ ] I have linked this PR to an issue using the Development section on the right sidebar or by adding `Fixes #issue-number` in the PR description (**required**)
- [x] I have checked if any dependencies need to be added or updated in `pyproject.toml` and `uv lock`
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [x] I have updated the documentation if needed:
- [X] I have added examples if this is a new feature
