### PR TITLE
fix: migrate to `logger.warning`

### DIFF
--- a/apps/agents/agents.py
+++ b/apps/agents/agents.py
@@ -138,7 +138,7 @@ def load_roles(path: str) -> List[str]:
                 role = match.group(1)
                 roles.append(role)
             else:
-                logger.warn("No match")
+                logger.warning("No match")
     return roles
 
 

--- a/apps/data_explorer/data_explorer.py
+++ b/apps/data_explorer/data_explorer.py
@@ -73,7 +73,7 @@ def parse_arguments():
     )
     args, unknown = parser.parse_known_args()
     if len(unknown) > 0:
-        logger.warn("Unknown args: %s", unknown)
+        logger.warning("Unknown args: %s", unknown)
     return args
 
 

--- a/apps/dilemma/dilemma.py
+++ b/apps/dilemma/dilemma.py
@@ -77,7 +77,7 @@ def parse_arguments():
     )
     args, unknown = parser.parse_known_args()
     if len(unknown) > 0:
-        logger.warn("Unknown args: ", unknown)
+        logger.warning("Unknown args: ", unknown)
     return args
 
 


### PR DESCRIPTION
## Description
This small PR resolves the `logger.warn` deprecation warnings:
```python
/home/runner/work/camel/camel/apps/data_explorer/data_explorer.py:76: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide (**required**)
- [ ] I have linked this PR to an issue using the Development section on the right sidebar or by adding `Fixes #issue-number` in the PR description (**required**)
- [ ] I have checked if any dependencies need to be added or updated in `pyproject.toml` and `uv lock`
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed:
- [ ] I have added examples if this is a new feature

If you are unsure about any of these, don't hesitate to ask. We are here to help!
