### PR TITLE
fix: Remove 'camel' from '__all__' list in 'camel/__init__.py'

### DIFF
--- a/camel/__init__.py
+++ b/camel/__init__.py
@@ -18,7 +18,6 @@ __version__ = '0.2.57'
 
 __all__ = [
     '__version__',
-    'camel',
     'disable_logging',
     'enable_logging',
     'set_log_level',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -367,7 +367,7 @@ all = [
     "ibm-watsonx-ai>=1.3.11",
     "google-genai>=1.13.0",
     "aci-sdk>=1.0.0b1",
-    "markitdown==0.1.1",
+    
 ]
 
 [project.urls]

--- a/test/test_all_exports.py
+++ b/test/test_all_exports.py
@@ -1,0 +1,24 @@
+# ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
+
+
+def test_all_exports_from_camel():
+    # Simulate `from camel import *` and capture the resulting namespace
+    ns = {}
+    exec("from camel import *", ns)
+
+    assert 'set_log_level' in ns
+    assert 'enable_logging' in ns
+    assert 'disable_logging' in ns
+    assert 'camel' not in ns

--- a/test/test_all_exports.py
+++ b/test/test_all_exports.py
@@ -23,8 +23,11 @@ def test_all_exports_from_camel():
     assert 'disable_logging' in ns
     assert 'camel' not in ns
 
+
 def test_all_exports_type():
     import camel
+
     assert isinstance(camel.__all__, list)
+
     for item in camel.__all__:
         assert isinstance(item, str)

--- a/test/test_all_exports.py
+++ b/test/test_all_exports.py
@@ -22,3 +22,9 @@ def test_all_exports_from_camel():
     assert 'enable_logging' in ns
     assert 'disable_logging' in ns
     assert 'camel' not in ns
+
+def test_all_exports_type():
+    import camel
+    assert isinstance(camel.__all__, list)
+    for item in camel.__all__:
+        assert isinstance(item, str)


### PR DESCRIPTION
## Description

Fixes #2367, a small bug

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have linked this PR to an issue using the Development section on the right sidebar or by adding `Fixes #issue-number` in the PR description (**required**)
- [x] I have checked if any dependencies need to be added or updated in `pyproject.toml` and `uv lock`
- [] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [] I have updated the documentation if needed:
- [] I have added examples if this is a new feature

If you are unsure about any of these, don't hesitate to ask. We are here to help!
