### PR TITLE
Skip test_agent_mcp_server.py if DEEPSEEK_API_KEY is not set

### DIFF
--- a/test/services/test_agent_mcp_server.py
+++ b/test/services/test_agent_mcp_server.py
@@ -1,3 +1,13 @@
+import os
+
+import pytest
+
+if not os.getenv("DEEPSEEK_API_KEY"):
+    pytest.skip(
+        "Skipping test_agent_mcp_server.py: DEEPSEEK_API_KEY not set",
+        allow_module_level=True,
+    )
+
 # ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description

This PR updates test/services/test_agent_mcp_server.py to gracefully skip test collection if the required DEEPSEEK_API_KEY environment variable is not set. This avoids test import errors during local development or CI environments where the key may be absent.

This one is particularly important because the error happens during tests collection phase, which means no test could run if the DEEPSEEP_API_KEY is missing.

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

- [X] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide (**required**)
- [X] I have linked this PR to an issue using the Development section on the right sidebar or by adding `Fixes #issue-number` in the PR description (**required**)
- [X] I have checked if any dependencies need to be added or updated in `pyproject.toml` and `uv lock`
- [X] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [X] I have updated the documentation if needed:
- [X] I have added examples if this is a new feature

If you are unsure about any of these, don't hesitate to ask. We are here to help!
