### PR TITLE
feat: update Gemini model types, fix Gemini-2.0-Flash matching issue

### DIFF
--- a/camel/types/enums.py
+++ b/camel/types/enums.py
@@ -180,10 +180,13 @@ class ModelType(UnifiedModelType, Enum):
     NVIDIA_LLAMA3_3_70B_INSTRUCT = "meta/llama-3.3-70b-instruct"
 
     # Gemini models
+    GEMINI_2_5_FLASH_PREVIEW = "gemini-2.5-flash-preview-04-17"
     GEMINI_2_5_PRO_PREVIEW = "gemini-2.5-pro-preview-05-06"
-    GEMINI_2_0_FLASH = "gemini-2.0-flash-exp"
+    GEMINI_2_0_FLASH = "gemini-2.0-flash"
+    GEMINI_2_0_FLASH_EXP = "gemini-2.0-flash-exp"
     GEMINI_2_0_FLASH_THINKING = "gemini-2.0-flash-thinking-exp"
     GEMINI_2_0_PRO_EXP = "gemini-2.0-pro-exp-02-05"
+    GEMINI_2_0_FLASH_LITE = "gemini-2.0-flash-lite"
     GEMINI_2_0_FLASH_LITE_PREVIEW = "gemini-2.0-flash-lite-preview-02-05"
     GEMINI_1_5_FLASH = "gemini-1.5-flash"
     GEMINI_1_5_PRO = "gemini-1.5-pro"
@@ -629,13 +632,16 @@ class ModelType(UnifiedModelType, Enum):
             bool: Whether this type of models is gemini.
         """
         return self in {
+            ModelType.GEMINI_2_5_FLASH_PREVIEW,
             ModelType.GEMINI_2_5_PRO_PREVIEW,
             ModelType.GEMINI_2_0_FLASH,
-            ModelType.GEMINI_1_5_FLASH,
-            ModelType.GEMINI_1_5_PRO,
+            ModelType.GEMINI_2_0_FLASH_EXP,
             ModelType.GEMINI_2_0_FLASH_THINKING,
             ModelType.GEMINI_2_0_PRO_EXP,
+            ModelType.GEMINI_2_0_FLASH_LITE,
             ModelType.GEMINI_2_0_FLASH_LITE_PREVIEW,
+            ModelType.GEMINI_1_5_FLASH,
+            ModelType.GEMINI_1_5_PRO,
         }
 
     @property
@@ -1181,12 +1187,15 @@ class ModelType(UnifiedModelType, Enum):
         }:
             return 512_000
         elif self in {
+            ModelType.GEMINI_2_5_FLASH_PREVIEW,
             ModelType.GEMINI_2_5_PRO_PREVIEW,
             ModelType.GEMINI_2_0_FLASH,
+            ModelType.GEMINI_2_0_FLASH_EXP,
+            ModelType.GEMINI_2_0_FLASH_THINKING,            
+            ModelType.GEMINI_2_0_FLASH_LITE,
+            ModelType.GEMINI_2_0_FLASH_LITE_PREVIEW,
             ModelType.GEMINI_1_5_FLASH,
             ModelType.GEMINI_1_5_PRO,
-            ModelType.GEMINI_2_0_FLASH_THINKING,
-            ModelType.GEMINI_2_0_FLASH_LITE_PREVIEW,
             ModelType.GEMINI_2_0_PRO_EXP,  # Not given in doc, assume the same
             ModelType.GLM_4_LONG,
             ModelType.TOGETHER_LLAMA_4_MAVERICK,

--- a/camel/types/enums.py
+++ b/camel/types/enums.py
@@ -1191,7 +1191,7 @@ class ModelType(UnifiedModelType, Enum):
             ModelType.GEMINI_2_5_PRO_PREVIEW,
             ModelType.GEMINI_2_0_FLASH,
             ModelType.GEMINI_2_0_FLASH_EXP,
-            ModelType.GEMINI_2_0_FLASH_THINKING,            
+            ModelType.GEMINI_2_0_FLASH_THINKING,
             ModelType.GEMINI_2_0_FLASH_LITE,
             ModelType.GEMINI_2_0_FLASH_LITE_PREVIEW,
             ModelType.GEMINI_1_5_FLASH,

--- a/docs/key_modules/models.md
+++ b/docs/key_modules/models.md
@@ -17,7 +17,7 @@ CAMEL supports a wide range of models, including [OpenAI’s GPT series](https:/
 | **Mistral AI** | mistral-large-latest, pixtral-12b-2409, ministral-8b-latest, ministral-3b-latest, open-mistral-nemo, codestral-latest, open-mistral-7b, open-mixtral-8x7b, open-mixtral-8x22b, open-codestral-mamba |
 | **Moonshot** | moonshot-v1-8k, moonshot-v1-32k, moonshot-v1-128k |
 | **Anthropic** | claude-2.1, claude-2.0, claude-instant-1.2, claude-3-opus-latest, claude-3-sonnet-20240229, claude-3-haiku-20240307, claude-3-5-sonnet-latest, claude-3-5-haiku-latest |
-| **Gemini** | gemini-2.0-flash-exp, gemini-1.5-pro, gemini-1.5-flash, gemini-exp-1114 |
+| **Gemini** | gemini-2.5-flash-preview-04-17, gemini-2.5-pro-preview-05-06, gemini-2.0-flash, gemini-2.0-flash-exp, gemini-2.0-flash-thinking-exp, gemini-2.0-pro-exp-02-05, gemini-2.0-flash-lite, gemini-2.0-flash-lite-preview-02-05, gemini-1.5-flash, gemini-1.5-pro |
 | **Lingyiwanwu** | yi-lightning, yi-large, yi-medium, yi-large-turbo, yi-vision, yi-medium-200k, yi-spark, yi-large-rag, yi-large-fc |
 | **Qwen** | qwq-32b-preview, qwen-max, qwen-plus, qwen-turbo, qwen-long, qwen-vl-max, qwen-vl-plus, qwen-math-plus, qwen-math-turbo, qwen-coder-turbo, qwen2.5-coder-32b-instruct, qwen2.5-72b-instruct, qwen2.5-32b-instruct, qwen2.5-14b-instruct |
 | **DeepSeek** | deepseek-chat, deepseek-reasoner |

--- a/examples/models/gemini_model_example.py
+++ b/examples/models/gemini_model_example.py
@@ -74,7 +74,7 @@ doing in this area. Keep up the great work! 🤖
 # Example of using the gemini-2.0-flash-exp model
 model_2_0_flash = ModelFactory.create(
     model_platform=ModelPlatformType.GEMINI,
-    model_type=ModelType.GEMINI_2_0_FLASH,
+    model_type=ModelType.GEMINI_2_0_FLASH_EXP,
     model_config_dict=GeminiConfig(temperature=0.2).as_dict(),
 )
 camel_agent_flash = ChatAgent(system_message=sys_msg, model=model_2_0_flash)


### PR DESCRIPTION
## Description

The previously model type Gemini-2.0-Flash listed in `camel/types/enums.py` is linked to the Gemini-2.0-Flash-Experimental model. The latter model has a request limit of 10 RPM for users below Tier 3, which can easily lead to a `RESOURCE_EXHAUSTED` issue when running with more agents simultaneously. 

In addition to correcting the mapping for the two models, I added two model types of Gemini (`GEMINI_2_5_FLASH_PREVIEW` and `GEMINI_2_0_FLASH_LITE`) and updated the corresponding docs.

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide (**required**)
- [ ] I have linked this PR to an issue using the Development section on the right sidebar or by adding `Fixes #issue-number` in the PR description (**required**)
- [x] I have checked if any dependencies need to be added or updated in `pyproject.toml` and `uv lock`
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [x] I have updated the documentation if needed:
- [ ] I have added examples if this is a new feature

If you are unsure about any of these, don't hesitate to ask. We are here to help!