### PR TITLE
fix: unstable tool_calling_math_async test

### DIFF
--- a/test/agents/test_chat_agent.py
+++ b/test/agents/test_chat_agent.py
@@ -16,7 +16,7 @@ import json
 from copy import deepcopy
 from io import BytesIO
 from typing import List
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from openai.types.chat.chat_completion import Choice
@@ -1076,7 +1076,7 @@ async def test_tool_calling_math_async(step_call_count=3):
         ),
     )
 
-    model.run = MagicMock(
+    model.arun = AsyncMock(
         side_effect=[
             model_backend_rsp_tool,
             model_backend_rsp_tool1,


### PR DESCRIPTION
## Description
This PR fixes one minor issue in a great unit test  `test_tool_calling_math_async` by @lllllyh01.

While this test often works, sometimes it is unstable, with error info below. (See recently merged PRs #2413, #2348, #2347, #2333, #2319, and #2310) @JINO-ROHIT also recently mentioned this issue in their PR https://github.com/camel-ai/camel/pull/2258#issuecomment-2880695358. I think we should make the test more stable to avoid contributors from being confused.

**Root Cause**: This **async** test mocks `model.run`, but `agent.astep()` actually calls `model.arun()`, which was not mocked. As a result, the tool calling process is actually not mocked, and sometimes the model chooses to answer the question without calling the tool.

**Error info copied from CI/CD result of recent PRs:**
```
=================================== FAILURES ===================================
_________________________ test_tool_calling_math_async _________________________

step_call_count = 3

    @pytest.mark.model_backend
    @pytest.mark.asyncio
    async def test_tool_calling_math_async(step_call_count=3):
        system_message = BaseMessage(
            role_name="assistant",
            role_type=RoleType.ASSISTANT,
            meta_dict=None,
            content="You are a help assistant.",
        )
        model_config = ChatGPTConfig(temperature=0)
        math_funcs = sync_funcs_to_async([FunctionTool(MathToolkit().multiply)])
        model = ModelFactory.create(
            model_platform=ModelPlatformType.OPENAI,
            model_type=ModelType.GPT_4O_MINI,
            model_config_dict=model_config.as_dict(),
        )
        agent = ChatAgent(
            usage=CompletionUsage(
                completion_tokens=50, prompt_tokens=152, total_tokens=202
            ),
        )
        model_backend_rsp_tool1 = ChatCompletion(
            id='***_id_123456',
            choices=[
                Choice(
                    finish_reason='tool_calls',
                    inde***=0,
                    logprobs=None,
                    message=ChatCompletionMessage(
                        content='The result of ( 2 times 8 ) is ( 16 ).',
                        refusal=None,
                        role='assistant',
                        audio=None,
                        function_call=None,
                        tool_calls=None,
                    ),
                )
            ],
            created=1730752528,
            model='gpt-4o-mini-2024-07-18',
            object='chat.completion',
            service_tier=None,
            usage=CompletionUsage(
                completion_tokens=50, prompt_tokens=152, total_tokens=202
            ),
        )
    
        model.run = MagicMock(
            side_effect=[
                model_backend_rsp_tool,
                model_backend_rsp_tool1,
            ]
            * step_call_count
        )
    
        for i in range(step_call_count):
            agent_response = await agent.astep(user_msg)
    
            tool_calls = agent_response.info['tool_calls']
    
>           assert (
                tool_calls[0].tool_name == "multiply"
            ), f"Error in calling round {i+1}"
E           Inde***Error: list inde*** out of range

test/agents/test_chat_agent.py:1092: Inde***Error
=============================== warnings summary ===============================
```



## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

- [ ] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide (**required**)
- [ ] I have linked this PR to an issue using the Development section on the right sidebar or by adding `Fixes #issue-number` in the PR description (**required**)
- [ ] I have checked if any dependencies need to be added or updated in `pyproject.toml` and `uv lock`
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed:
- [ ] I have added examples if this is a new feature

If you are unsure about any of these, don't hesitate to ask. We are here to help!
