### PR TITLE
fix: migrate Pydantic to new interface

### DIFF
--- a/camel/datasets/models.py
+++ b/camel/datasets/models.py
@@ -46,7 +46,7 @@ class DataPoint(BaseModel):
         Returns:
             Dict[str, Any]: Dictionary representation of the DataPoint.
         """
-        return self.dict()
+        return self.model_dump()
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> 'DataPoint':


### PR DESCRIPTION
## Description
This PR addresses a `PydanticDeprecatedSince20` warning by updating the `DataPoint.to_dict()` method to use the Pydantic V2 API. Changes:
- Replaced `self.dict()` with `self.model_dump()` in `camel/datasets/models.py`.

This change ensures compatibility with Pydantic V2 and resolves deprecation warnings previously observed in [CI log](https://github.com/camel-ai/camel/actions/runs/15509708129/job/43669032243#step:4:410).

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide (**required**)
- [ ] I have linked this PR to an issue using the Development section on the right sidebar or by adding `Fixes #issue-number` in the PR description (**required**)
- [x] I have checked if any dependencies need to be added or updated in `pyproject.toml` and `uv lock`
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed:
- [ ] I have added examples if this is a new feature

If you are unsure about any of these, don't hesitate to ask. We are here to help!
