### PR TITLE
fix: Add task content validation to prevent empty content processing

### DIFF
--- a/camel/societies/workforce/workforce.py
+++ b/camel/societies/workforce/workforce.py
@@ -38,6 +38,7 @@ from camel.societies.workforce.utils import (
     TaskAssignResult,
     WorkerConf,
     check_if_running,
+    validate_task_content,
 )
 from camel.societies.workforce.worker import Worker
 from camel.tasks.task import Task, TaskState
@@ -211,6 +212,15 @@ class Workforce(BaseNode):
         Returns:
             Task: The updated task.
         """
+        if not validate_task_content(task.content, task.id):
+            task.state = TaskState.FAILED
+            task.result = "Task failed: Invalid or empty content provided"
+            logger.warning(
+                f"Task {task.id} rejected: Invalid or empty content. "
+                f"Content preview: '{task.content[:50]}...'"
+            )
+            return task
+
         self.reset()
         self._task = task
         task.state = TaskState.FAILED


### PR DESCRIPTION
## Description

Empty/whitespace-only tasks were processed extensively, causing resource waste and meaningless task decomposition. Added validation at two points:
1. Entry point (workforce.py): Reject empty tasks before processing
2. Subtask generation (task.py): Filter invalid subtasks

fixes #2608. 

this fix makes sure we have three levels of validation:
entry point: rejects empty tasks at submission
subtask generation: filters out empty subtasks during decomposition
worker processing: existing result validation (already implemented in #2611)


## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

- [ ] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide (**required**)
- [ ] I have linked this PR to an issue using the Development section on the right sidebar or by adding `Fixes #issue-number` in the PR description (**required**)
- [ ] I have checked if any dependencies need to be added or updated in `pyproject.toml` and `uv lock`
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed:
- [ ] I have added examples if this is a new feature

If you are unsure about any of these, don't hesitate to ask. We are here to help!
