### PR TITLE
feat: Set tool schema follow strict mode

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -26,7 +26,7 @@ body:
     attributes:
       label: What version of camel are you using?
       description: Run command `python3 -c 'print(__import__("camel").__version__)'` in your shell and paste the output here.
-      placeholder: E.g., 0.2.65
+      placeholder: E.g., 0.2.66
     validations:
       required: true
 

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -141,7 +141,20 @@ jobs:
           CRYNUX_API_KEY: "${{ secrets.CRYNUX_API_KEY }}"
         run: |
           source test_venv/bin/activate
-          pytest --fast-test-mode ./test
+          pytest --fast-test-mode -m "not heavy_dependency" \
+            --ignore=test/datagen/test_evol_instruct.py \
+            --ignore=test/datagen/test_self_improving_cot_pipeline.py \
+            --ignore=test/datasets/test_base_dataset.py \
+            --ignore=test/datasets/test_self_instruct_generator.py \
+            --ignore=test/embeddings/test_open_source_embeddings.py \
+            --ignore=test/environments/test_multi_step_env.py \
+            --ignore=test/environments/test_single_step_env.py \
+            --ignore=test/environments/test_tictactoe_env.py \
+            --ignore=test/interpreters/test_python_interpreter.py \
+            --ignore=test/models/reward/test_nemotron_model.py \
+            --ignore=test/toolkits/test_video_analysis_toolkit.py \
+            --ignore=test/toolkits/test_jina_reranker_toolkit.py \
+            ./test
 
       - name: Clean up after build
         if: always()

--- a/camel/__init__.py
+++ b/camel/__init__.py
@@ -14,7 +14,7 @@
 
 from camel.logger import disable_logging, enable_logging, set_log_level
 
-__version__ = '0.2.65'
+__version__ = '0.2.66'
 
 __all__ = [
     '__version__',

--- a/camel/agents/mcp_agent.py
+++ b/camel/agents/mcp_agent.py
@@ -125,7 +125,6 @@ class MCPAgent(ChatAgent):
         local_config_path: Optional[str] = None,
         tools: Optional[List[Union[FunctionTool, Callable]]] = None,
         function_calling_available: bool = True,
-        strict: bool = False,
         **kwargs,
     ):
         if model is None:
@@ -145,7 +144,6 @@ class MCPAgent(ChatAgent):
 
         self.local_config = local_config
         self.function_calling_available = function_calling_available
-        self.strict = strict
 
         if function_calling_available:
             sys_msg_content = "You are a helpful assistant, and you prefer "
@@ -179,7 +177,7 @@ class MCPAgent(ChatAgent):
         if self.local_config:
             config_dict.update(self.local_config)
 
-        return MCPToolkit(config_dict=config_dict, strict=self.strict)
+        return MCPToolkit(config_dict=config_dict)
 
     def add_registry(self, registry_config: BaseMCPRegistryConfig) -> None:
         r"""Add a new registry configuration to the agent.
@@ -213,7 +211,6 @@ class MCPAgent(ChatAgent):
         ] = None,
         model: Optional[BaseModelBackend] = None,
         function_calling_available: bool = False,
-        strict: bool = False,
         **kwargs,
     ) -> "MCPAgent":
         r"""Create and connect an MCPAgent instance.
@@ -279,7 +276,6 @@ class MCPAgent(ChatAgent):
             registry_configs=final_registry_configs,
             model=model,
             function_calling_available=function_calling_available,
-            strict=strict,
             **kwargs,
         )
 

--- a/camel/toolkits/function_tool.py
+++ b/camel/toolkits/function_tool.py
@@ -190,7 +190,9 @@ def sanitize_and_enforce_required(parameters_dict):
     r"""Cleans and updates the function schema to conform with OpenAI's
     requirements:
     - Removes invalid 'default' fields from the parameters schema.
-    - Ensures all fields or function parameters are marked as required.
+    - Ensures all fields are marked as required or have null type for optional
+    fields.
+    - Recursively adds additionalProperties: false to all nested objects.
 
     Args:
         parameters_dict (dict): The dictionary representing the function
@@ -198,8 +200,38 @@ def sanitize_and_enforce_required(parameters_dict):
 
     Returns:
         dict: The updated dictionary with invalid defaults removed and all
-            fields set as required.
+            fields properly configured for strict mode.
     """
+
+    def _add_additional_properties_false(obj):
+        r"""Recursively add additionalProperties: false to all objects."""
+        if isinstance(obj, dict):
+            if (
+                obj.get("type") == "object"
+                and "additionalProperties" not in obj
+            ):
+                obj["additionalProperties"] = False
+
+            # Process nested structures
+            for key, value in obj.items():
+                if key == "properties" and isinstance(value, dict):
+                    for prop_value in value.values():
+                        _add_additional_properties_false(prop_value)
+                elif key in [
+                    "items",
+                    "allOf",
+                    "oneOf",
+                    "anyOf",
+                ] and isinstance(value, (dict, list)):
+                    if isinstance(value, dict):
+                        _add_additional_properties_false(value)
+                    elif isinstance(value, list):
+                        for item in value:
+                            _add_additional_properties_false(item)
+                elif key == "$defs" and isinstance(value, dict):
+                    for def_value in value.values():
+                        _add_additional_properties_false(def_value)
+
     # Check if 'function' and 'parameters' exist
     if (
         'function' in parameters_dict
@@ -209,12 +241,46 @@ def sanitize_and_enforce_required(parameters_dict):
         parameters = parameters_dict['function']['parameters']
         properties = parameters.get('properties', {})
 
-        # Remove 'default' key from each property
-        for field in properties.values():
-            field.pop('default', None)
+        # Track which fields should be required vs optional
+        required_fields = []
 
-        # Mark all keys in 'properties' as required
-        parameters['required'] = list(properties.keys())
+        # Process each property
+        for field_name, field_schema in properties.items():
+            # Check if this field had a default value (making it optional)
+            had_default = 'default' in field_schema
+
+            # Remove 'default' key from field schema as required by OpenAI
+            field_schema.pop('default', None)
+
+            if had_default:
+                # This field is optional - add null to its type
+                current_type = field_schema.get('type')
+                if current_type:
+                    if isinstance(current_type, str):
+                        # Single type - convert to array with null
+                        field_schema['type'] = [current_type, 'null']
+                    elif (
+                        isinstance(current_type, list)
+                        and 'null' not in current_type
+                    ):
+                        # Array of types - add null if not present
+                        field_schema['type'] = [*current_type, 'null']
+                else:
+                    # No type specified, add null type
+                    field_schema['type'] = ['null']
+
+                # Optional fields are still marked as required in strict mode
+                # but with null type to indicate they can be omitted
+                required_fields.append(field_name)
+            else:
+                # This field is required
+                required_fields.append(field_name)
+
+        # Set all fields as required (strict mode requirement)
+        parameters['required'] = required_fields
+
+        # Recursively add additionalProperties: false to all objects
+        _add_additional_properties_false(parameters)
 
     return parameters_dict
 

--- a/camel/toolkits/function_tool.py
+++ b/camel/toolkits/function_tool.py
@@ -255,7 +255,13 @@ def sanitize_and_enforce_required(parameters_dict):
             if had_default:
                 # This field is optional - add null to its type
                 current_type = field_schema.get('type')
-                if current_type:
+                has_ref = '$ref' in field_schema
+                
+                if has_ref:
+                    # Fields with $ref shouldn't have additional type field
+                    # The $ref itself defines the type structure
+                    pass
+                elif current_type:
                     if isinstance(current_type, str):
                         # Single type - convert to array with null
                         field_schema['type'] = [current_type, 'null']
@@ -268,7 +274,7 @@ def sanitize_and_enforce_required(parameters_dict):
                 else:
                     # No type specified, add null type
                     field_schema['type'] = ['null']
-
+                
                 # Optional fields are still marked as required in strict mode
                 # but with null type to indicate they can be omitted
                 required_fields.append(field_name)

--- a/camel/utils/mcp_client.py
+++ b/camel/utils/mcp_client.py
@@ -173,8 +173,6 @@ class MCPClient:
             initialization. (default: :obj:`None`)
         timeout (Optional[float], optional): Timeout for waiting for messages
             from the server in seconds. (default: :obj:`10.0`)
-        strict (Optional[bool], optional): Strict mode for generating
-            FunctionTool objects. (default: :obj:`False`)
 
     Examples:
         STDIO server:
@@ -209,20 +207,6 @@ class MCPClient:
             async with MCPClient({"url": "ws://localhost:8080/mcp"}) as client:
                 tools = client.get_tools()
 
-        With strict mode enabled:
-
-        .. code-block:: python
-
-            async with MCPClient({
-                "command": "npx",
-                "args": [
-                    "-y",
-                    "@modelcontextprotocol/server-filesystem",
-                    "/path"
-                ]
-            }, strict=True) as client:
-                tools = client.get_tools()
-
     Attributes:
         config (ServerConfig): The server configuration object.
         client_info (Optional[types.Implementation]): Client implementation
@@ -235,14 +219,12 @@ class MCPClient:
         config: Union[ServerConfig, Dict[str, Any]],
         client_info: Optional[types.Implementation] = None,
         timeout: Optional[float] = 10.0,
-        strict: Optional[bool] = False,
     ):
         # Convert dict config to ServerConfig if needed
         if isinstance(config, dict):
             config = ServerConfig(**config)
 
         self.config = config
-        self.strict = strict
 
         # Validate transport type early (this will raise ValueError if invalid)
         _ = self.config.transport_type
@@ -766,7 +748,6 @@ class MCPClient:
                 "name": mcp_tool.name,
                 "description": mcp_tool.description
                 or "No description provided.",
-                "strict": self.strict,
                 "parameters": parameters,
             },
         }
@@ -932,8 +913,7 @@ def create_mcp_client(
             dictionary is provided, it will be automatically converted to
             a :obj:`ServerConfig`.
         **kwargs: Additional keyword arguments passed to the :obj:`MCPClient`
-            constructor, such as :obj:`client_info`, :obj:`timeout`, and
-            :obj:`strict`.
+            constructor, such as :obj:`client_info`, :obj:`timeout`.
 
     Returns:
         MCPClient: A configured :obj:`MCPClient` instance ready for use as
@@ -971,20 +951,6 @@ def create_mcp_client(
             async with create_mcp_client({
                 "url": "ws://localhost:8080/mcp"
             }) as client:
-                tools = client.get_tools()
-
-        With strict mode enabled:
-
-        .. code-block:: python
-
-            async with create_mcp_client({
-                "command": "npx",
-                "args": [
-                    "-y",
-                    "@modelcontextprotocol/server-filesystem",
-                    "/path",
-                ],
-            }, strict=True) as client:
                 tools = client.get_tools()
     """
     return MCPClient(config, **kwargs)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ sys.path.insert(0, os.path.abspath('..'))
 project = 'CAMEL'
 copyright = '2024, CAMEL-AI.org'
 author = 'CAMEL-AI.org'
-release = '0.2.65'
+release = '0.2.66'
 
 html_favicon = (
     'https://raw.githubusercontent.com/camel-ai/camel/master/misc/favicon.png'

--- a/examples/toolkits/playwright_mcp_toolkit.py
+++ b/examples/toolkits/playwright_mcp_toolkit.py
@@ -13,6 +13,8 @@
 # ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
 import asyncio
 
+from pydantic import BaseModel, Field
+
 from camel.agents import ChatAgent
 from camel.models import ModelFactory
 from camel.toolkits import PlaywrightMCPToolkit
@@ -30,13 +32,19 @@ async def main():
         model_type=ModelType.DEFAULT,
     )
 
+    # pydantic basemodel as input params format
+    class AgentResponse(BaseModel):
+        url: str = Field(description="Url of the repository")
+        stars: int = Field(description="Stars of the repository")
+
     chat_agent = ChatAgent(
         model=model,
         tools=playwright_mcp_toolkit.get_tools(),
     )
 
     response = await chat_agent.astep(
-        "search for camel-ai using google search, how many stars does it have?"
+        "search for camel-ai using google search, how many stars does it has?",
+        response_format=AgentResponse,
     )
     print(response.msg.content)
 
@@ -50,7 +58,6 @@ if __name__ == "__main__":
 
 """
 ==============================================================================
-The GitHub repository for **camel-ai** has **12,338 stars**. If you need more
-information or details about the project, feel free to ask!
+{"url":"https://github.com/camel-ai/camel","stars":12900}
 ==============================================================================
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "camel-ai"
-version = "0.2.65"
+version = "0.2.66"
 description = "Communicative Agents for AI Society Study"
 authors = [{ name = "CAMEL-AI.org" }]
 requires-python = ">=3.10,<3.13"

--- a/test/toolkits/test_generate_openai_tool_schema.py
+++ b/test/toolkits/test_generate_openai_tool_schema.py
@@ -214,7 +214,7 @@ def test_function_tool_generate_schema_with_retries(
                         'description': 'The integer value to check.',
                     },
                     'b': {
-                        'type': 'string',
+                        'type': ['string', 'null'],
                         'description': (
                             "The string to verify. Default is 'default'."
                         ),

--- a/uv.lock
+++ b/uv.lock
@@ -547,7 +547,7 @@ wheels = [
 
 [[package]]
 name = "camel-ai"
-version = "0.2.65"
+version = "0.2.66"
 source = { editable = "." }
 dependencies = [
     { name = "colorama" },
@@ -4103,11 +4103,11 @@ wheels = [
 
 [[package]]
 name = "narwhals"
-version = "1.42.0"
+version = "1.42.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/7e/9484c2427453bd0024fd36cf7923de4367d749f0b216b9ca56b9dfc3c516/narwhals-1.42.0.tar.gz", hash = "sha256:a5e554782446d1197593312651352cd39b2025e995053d8e6bdfaa01a70a91d3", size = 490671 }
+sdist = { url = "https://files.pythonhosted.org/packages/df/d6/168a787b7800d6c89846b791e4f5ee6b94998a80c8c2838a019d3d71984d/narwhals-1.42.1.tar.gz", hash = "sha256:50a5635b11aeda98cf9c37e839fd34b0a24159f59a4dfae930290ad698320494", size = 492865 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/0f/f9ae7c8c55f9078c852b13ea4a6e92e5f4d6d4c8fc0781ec2882957006bb/narwhals-1.42.0-py3-none-any.whl", hash = "sha256:ef6cedf7700dc22c09d17973b9ede11b53e25331e238b24ac73884a8c5e27c19", size = 359033 },
+    { url = "https://files.pythonhosted.org/packages/79/3f/8d450588206b437dd239a6d44230c63095e71135bd95d5a74347d07adbd5/narwhals-1.42.1-py3-none-any.whl", hash = "sha256:7a270d44b94ccdb277a799ae890c42e8504c537c1849f195eb14717c6184977a", size = 359888 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

strict mode is required when do structured output with tool call, but for MCP toolkits we can't ensure the tool schema would follow strict mode, to support mcp toolkit could run in workforce (which requires structured output), we set all tool schema follow strict mode, this is also suggested by openai

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

- [ ] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide (**required**)
- [ ] I have linked this PR to an issue using the Development section on the right sidebar or by adding `Fixes #issue-number` in the PR description (**required**)
- [ ] I have checked if any dependencies need to be added or updated in `pyproject.toml` and `uv lock`
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed:
- [ ] I have added examples if this is a new feature

If you are unsure about any of these, don't hesitate to ask. We are here to help!
