### PR TITLE
add extra_body in vllm config

### DIFF
--- a/camel/configs/vllm_config.py
+++ b/camel/configs/vllm_config.py
@@ -90,6 +90,7 @@ class VLLMConfig(BaseConfig):
             most likely tokens to return at each token position, each with an
             associated log probability. `logprobs` must be set to `true` if
             this parameter is used. (default: :obj:`None`)
+        extra_body: Add additional JSON properties to the request. (default: :obj:`None`)
     """
 
     temperature: Optional[float] = None  # openai default: 1.0
@@ -105,6 +106,6 @@ class VLLMConfig(BaseConfig):
     user: Optional[str] = None
     logprobs: Optional[bool] = None
     top_logprobs: Optional[int] = None
-
+    extra_body: Optional[dict] = None
 
 VLLM_API_PARAMS = {param for param in VLLMConfig.model_fields.keys()}


### PR DESCRIPTION
vLLM supports some parameters that are not supported by OpenAI, top_k, chat_template_kwargs for example. You can pass these parameters to vLLM using the OpenAI client in the extra_body parameter of your requests.

In this way, you can call Qwen3 model with enable_thinking.

vllm_model = ModelFactory.create(
    model_platform=ModelPlatformType.VLLM,
    model_type=MODEL_NAME,
    model_config_dict={"temperature": 0.0, "extra_body":{
       "chat_template_kwargs": {"enable_thinking": False}
    }},
    url="http://localhost:33949/v1",
    api_key="EMPTY",
)

## Description

Describe your changes in detail (optional if the linked issue already contains a detailed description of the changes).

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide (**required**)
- [ ] I have linked this PR to an issue using the Development section on the right sidebar or by adding `Fixes #issue-number` in the PR description (**required**)
- [ ] I have checked if any dependencies need to be added or updated in `pyproject.toml` and `uv lock`
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed:
- [ ] I have added examples if this is a new feature

If you are unsure about any of these, don't hesitate to ask. We are here to help!
