### PR TITLE
[MCP] Remove MCP client info

### DIFF
--- a/camel/utils/mcp_client.py
+++ b/camel/utils/mcp_client.py
@@ -168,9 +168,6 @@ class MCPClient:
             as either a :obj:`ServerConfig` object or a dictionary that will
             be converted to a :obj:`ServerConfig`. The configuration determines
             the transport type and connection parameters.
-        client_info (Optional[types.Implementation], optional): Client
-            implementation information to send to the server during
-            initialization. (default: :obj:`None`)
         timeout (Optional[float], optional): Timeout for waiting for messages
             from the server in seconds. (default: :obj:`10.0`)
 
@@ -209,15 +206,12 @@ class MCPClient:
 
     Attributes:
         config (ServerConfig): The server configuration object.
-        client_info (Optional[types.Implementation]): Client implementation
-            information.
         read_timeout_seconds (timedelta): Timeout for reading from the server.
     """
 
     def __init__(
         self,
         config: Union[ServerConfig, Dict[str, Any]],
-        client_info: Optional[types.Implementation] = None,
         timeout: Optional[float] = 10.0,
     ):
         # Convert dict config to ServerConfig if needed
@@ -229,7 +223,6 @@ class MCPClient:
         # Validate transport type early (this will raise ValueError if invalid)
         _ = self.config.transport_type
 
-        self.client_info = client_info
         self.read_timeout_seconds = timedelta(seconds=timeout or 10.0)
 
         self._session: Optional[ClientSession] = None
@@ -271,7 +264,6 @@ class MCPClient:
             self._session = ClientSession(
                 read_stream=read_stream,
                 write_stream=write_stream,
-                client_info=self.client_info,
                 read_timeout_seconds=self.read_timeout_seconds,
             )
 
@@ -913,7 +905,7 @@ def create_mcp_client(
             dictionary is provided, it will be automatically converted to
             a :obj:`ServerConfig`.
         **kwargs: Additional keyword arguments passed to the :obj:`MCPClient`
-            constructor, such as :obj:`client_info`, :obj:`timeout`.
+            constructor, such as :obj:`timeout`.
 
     Returns:
         MCPClient: A configured :obj:`MCPClient` instance ready for use as

--- a/test/utils/test_mcp_client.py
+++ b/test/utils/test_mcp_client.py
@@ -154,13 +154,6 @@ class TestMCPClient:
         assert client.config.command == "npx"
         assert client.config.args == ["test"]
 
-    def test_init_with_client_info(self):
-        """Test MCPClient initialization with client info."""
-        config = ServerConfig(command="npx", args=["test"])
-        client_info = types.Implementation(name="test-client", version="1.0.0")
-        client = MCPClient(config, client_info=client_info)
-        assert client.client_info == client_info
-
     def test_init_with_invalid_config(self):
         """Test MCPClient initialization with invalid config."""
         with pytest.raises(ValueError):
@@ -223,13 +216,6 @@ class TestCreateMCPClient:
         client = create_mcp_client(config)
         assert isinstance(client, MCPClient)
         assert client.config == config
-
-    def test_create_with_client_info(self):
-        """Test creating client with client_info parameter."""
-        config_dict = {"command": "npx", "args": ["test"]}
-        client_info = types.Implementation(name="test", version="1.0")
-        client = create_mcp_client(config_dict, client_info=client_info)
-        assert client.client_info == client_info
 
 
 class TestCreateMCPClientFromConfigFile:
@@ -352,11 +338,9 @@ class TestCreateMCPClientFromConfigFile:
             config_path = f.name
 
         try:
-            client_info = types.Implementation(name="test", version="1.0")
-            client = create_mcp_client_from_config_file(
-                config_path, "test", client_info=client_info
+            _ = create_mcp_client_from_config_file(
+                config_path, "test",
             )
-            assert client.client_info == client_info
         finally:
             Path(config_path).unlink()
 
@@ -496,29 +480,6 @@ class TestEdgeCases:
             ValueError, match="Either 'command'.*or 'url'.*must be provided"
         ):
             ServerConfig(url="")
-
-    def test_client_initialization_variations(self):
-        """Test different ways to initialize the client."""
-        # Test with minimal config
-        client1 = MCPClient({"command": "test"})
-        assert client1.config.command == "test"
-
-        # Test with comprehensive config
-        client2 = MCPClient(
-            {
-                "url": "wss://api.example.com/mcp",
-                "timeout": 120.0,
-                "sse_read_timeout": 600.0,
-            }
-        )
-        assert client2.config.url == "wss://api.example.com/mcp"
-        assert client2.config.timeout == 120.0
-
-        # Test with client_info
-        client_info = types.Implementation(name="test", version="2.0")
-        client3 = MCPClient({"command": "test"}, client_info=client_info)
-        assert client3.client_info.name == "test"
-        assert client3.client_info.version == "2.0"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Seems that for current MCP there is no `client_info` args (at least for the uv install with mcp==1.6.0)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide (**required**)
- [ ] I have linked this PR to an issue using the Development section on the right sidebar or by adding `Fixes #issue-number` in the PR description (**required**)
- [ ] I have checked if any dependencies need to be added or updated in `pyproject.toml` and `uv lock`
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed:
- [ ] I have added examples if this is a new feature
