### PR TITLE
chore: _create_file_in_container method bug in Docker interpreter 

### DIFF
--- a/camel/interpreters/docker_interpreter.py
+++ b/camel/interpreters/docker_interpreter.py
@@ -146,7 +146,7 @@ class DockerInterpreter(BaseInterpreter):
         tar_stream = io.BytesIO()
         with tarfile.open(fileobj=tar_stream, mode='w') as tar:
             tarinfo = tarfile.TarInfo(name=filename)
-            tarinfo.size = len(content)
+            tarinfo.size = len(content.encode('utf-8'))
             tar.addfile(tarinfo, io.BytesIO(content.encode('utf-8')))
         tar_stream.seek(0)
 

--- a/camel/interpreters/docker_interpreter.py
+++ b/camel/interpreters/docker_interpreter.py
@@ -146,8 +146,9 @@ class DockerInterpreter(BaseInterpreter):
         tar_stream = io.BytesIO()
         with tarfile.open(fileobj=tar_stream, mode='w') as tar:
             tarinfo = tarfile.TarInfo(name=filename)
-            tarinfo.size = len(content.encode('utf-8'))
-            tar.addfile(tarinfo, io.BytesIO(content.encode('utf-8')))
+            encoded_content = content.encode('utf-8')
+            tarinfo.size = len(encoded_content)
+            tar.addfile(tarinfo, io.BytesIO(encoded_content))
         tar_stream.seek(0)
 
         # copy the tar into the container


### PR DESCRIPTION
## Description

The `_create_file_in_container` function in `camel/interpreters/docker_interpreter.py` is used for executing the code in  and copying it into docker, the encoded data is transmitted, but the calculated binary length is the unencoded data.

## Result after code improvement
![image](https://github.com/user-attachments/assets/21b165ef-5b29-4d9f-b9de-d0be88ba0744)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide (**required**)
- [ ] I have linked this PR to an issue using the Development section on the right sidebar or by adding `Fixes #issue-number` in the PR description (**required**)
- [ ] I have checked if any dependencies need to be added or updated in `pyproject.toml` and `uv lock`
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [x] I have updated the documentation if needed:
- [x] I have added examples if this is a new feature

If you are unsure about any of these, don't hesitate to ask. We are here to help!
