### PR TITLE
fix: pre-commit mypy hook to use project dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,8 +12,8 @@ repos:
     hooks:
       - id: mypy
         name: Check mypy
-        entry: mypy --namespace-packages -p camel -p test -p apps
-        language: python
+        entry: uv run mypy --namespace-packages -p camel -p test -p apps
+        language: system
         types: [python]
         pass_filenames: false
         require_serial: true


### PR DESCRIPTION
## Description

Updates the pre-commit configuration to ensure mypy runs using the project's virtual environment rather than the system installation.

## Problem

The current pre-commit hook configuration uses language: python, which causes pre-commit to look for mypy in the system environment (e.g., pyenv global installation) instead of using the project's virtual environment managed by uv.

Fixes #2854 

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have linked this PR to an issue using the Development section on the right sidebar or by adding `Fixes #issue-number` in the PR description (**required**)
- [ ] I have checked if any dependencies need to be added or updated in `pyproject.toml` and `uv lock`
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed:
- [ ] I have added examples if this is a new feature

If you are unsure about any of these, don't hesitate to ask. We are here to help!
