### PR TITLE
fix : ACI Windows MCPToolkit fix

### DIFF
--- a/camel/utils/mcp_client.py
+++ b/camel/utils/mcp_client.py
@@ -357,6 +357,7 @@ class MCPClient:
             # This prevents "Event loop is closed" errors during shutdown
             import asyncio
             import sys
+
             if sys.platform == "win32":
                 await asyncio.sleep(0.01)
 

--- a/camel/utils/mcp_client.py
+++ b/camel/utils/mcp_client.py
@@ -353,6 +353,13 @@ class MCPClient:
                 finally:
                     self._connection_context = None
 
+            # Add a small delay to allow subprocess cleanup on Windows
+            # This prevents "Event loop is closed" errors during shutdown
+            import asyncio
+            import sys
+            if sys.platform == "win32":
+                await asyncio.sleep(0.01)
+
         finally:
             # Ensure state is reset
             self._tools = []


### PR DESCRIPTION
## Description

https://github.com/camel-ai/camel/issues/2859

Fixes Windows subprocess cleanup issue in MCPClient that causes "ValueError: I/O operation on closed pipe" errors during program shutdown.
Problem: When using MCPToolkit on Windows, users experience warnings about closed pipes and event loop errors during program termination. This occurs because the asyncio event loop closes before subprocess cleanup can complete properly.

Solution: Added a small delay (0.01 seconds) specifically for Windows in the _cleanup_connection method of MCPClient. This allows sufficient time for subprocess resources to be properly released before the event loop shuts down.


## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

- [ ] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide (**required**)
- [ ] I have linked this PR to an issue using the Development section on the right sidebar or by adding `Fixes #issue-number` in the PR description (**required**)
- [ ] I have checked if any dependencies need to be added or updated in `pyproject.toml` and `uv lock`
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed:
- [ ] I have added examples if this is a new feature

If you are unsure about any of these, don't hesitate to ask. We are here to help!
