### PR TITLE
enhance: Enhance #2901, allowing users to exclude domains from SearchToolkit 

### DIFF
--- a/camel/toolkits/search_toolkit.py
+++ b/camel/toolkits/search_toolkit.py
@@ -36,6 +36,7 @@ class SearchToolkit(BaseToolkit):
         self,
         timeout: Optional[float] = None,
         number_of_result_pages: int = 10,
+        exclude_domains: Optional[List[str]] = None,
     ):
         r"""Initializes the RedditToolkit with the specified number of retries
         and delay.
@@ -45,9 +46,14 @@ class SearchToolkit(BaseToolkit):
                 (default: :obj:`None`)
             number_of_result_pages (int): The number of result pages to
                 retrieve. (default: :obj:`10`)
+            exclude_domains (Optional[List[str]]): List of domains to
+                exclude from search results. Currently only supported
+                by the `search_google` function.
+                (default: :obj:`None`)
         """
         super().__init__(timeout=timeout)
         self.number_of_result_pages = number_of_result_pages
+        self.exclude_domains = exclude_domains
 
     @dependencies_required("wikipedia")
     def search_wiki(self, entity: str) -> str:
@@ -438,7 +444,6 @@ class SearchToolkit(BaseToolkit):
         self,
         query: str,
         search_type: str = "web",
-        exclude_domains: Optional[List[str]] = None,
     ) -> List[Dict[str, Any]]:
         r"""Use Google search engine to search information for the given query.
 
@@ -446,9 +451,6 @@ class SearchToolkit(BaseToolkit):
             query (str): The query to be searched.
             search_type (str): The type of search to perform. Either "web" for
                 web pages or "image" for image search. (default: "web")
-            exclude_domains (Optional[List[str]]): A list of domains to exclude
-                from the search results. If provided, the query will be modified.
-                (default: :obj:`None`)
 
         Returns:
             List[Dict[str, Any]]: A list of dictionaries where each dictionary
@@ -507,10 +509,10 @@ class SearchToolkit(BaseToolkit):
         search_language = "en"
 
         modified_query = query
-        if exclude_domains:
+        if self.exclude_domains:
             # Use Google's -site: operator to exclude domains
             exclusion_terms = " ".join(
-                [f"-site:{domain}" for domain in exclude_domains]
+                [f"-site:{domain}" for domain in self.exclude_domains]
             )
             modified_query = f"{query} {exclusion_terms}"
             logger.debug(f"Excluded domains, modified query: {modified_query}")

--- a/camel/toolkits/search_toolkit.py
+++ b/camel/toolkits/search_toolkit.py
@@ -435,7 +435,10 @@ class SearchToolkit(BaseToolkit):
         ]
     )
     def search_google(
-        self, query: str, search_type: str = "web"
+        self,
+        query: str,
+        search_type: str = "web",
+        exclude_domains: Optional[List[str]] = None,
     ) -> List[Dict[str, Any]]:
         r"""Use Google search engine to search information for the given query.
 
@@ -443,6 +446,9 @@ class SearchToolkit(BaseToolkit):
             query (str): The query to be searched.
             search_type (str): The type of search to perform. Either "web" for
                 web pages or "image" for image search. (default: "web")
+            exclude_domains (Optional[List[str]]): A list of domains to exclude
+                from the search results. If provided, the query will be modified.
+                (default: :obj:`None`)
 
         Returns:
             List[Dict[str, Any]]: A list of dictionaries where each dictionary
@@ -499,11 +505,21 @@ class SearchToolkit(BaseToolkit):
         start_page_idx = 1
         # Different language may get different result
         search_language = "en"
+
+        modified_query = query
+        if exclude_domains:
+            # Use Google's -site: operator to exclude domains
+            exclusion_terms = " ".join(
+                [f"-site:{domain}" for domain in exclude_domains]
+            )
+            modified_query = f"{query} {exclusion_terms}"
+            logger.debug(f"Excluded domains, modified query: {modified_query}")
+
         # Constructing the URL
         # Doc: https://developers.google.com/custom-search/v1/using_rest
         base_url = (
             f"https://www.googleapis.com/customsearch/v1?"
-            f"key={GOOGLE_API_KEY}&cx={SEARCH_ENGINE_ID}&q={query}&start="
+            f"key={GOOGLE_API_KEY}&cx={SEARCH_ENGINE_ID}&q={modified_query}&start="
             f"{start_page_idx}&lr={search_language}&num={self.number_of_result_pages}"
         )
 

--- a/examples/toolkits/search_google_with_exclusion.py
+++ b/examples/toolkits/search_google_with_exclusion.py
@@ -1,0 +1,39 @@
+# ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
+from camel.toolkits import SearchToolkit
+
+# This example demonstrates how to use the SearchToolkit to
+# perform a Google search while excluding certain domains from the results.
+
+# Google search API Key and Search Engine ID are required to run this example
+# API Key: https://developers.google.com/custom-search/v1/overview
+# Search Engine ID: https://cse.google.com/cse/all
+
+
+toolkit = SearchToolkit(number_of_result_pages=3)
+search_result = toolkit.search_google(query="Python Wikipedia")
+print("Search results for 'Python Wikipedia':\n")
+for result in search_result:
+    print(result['url'])
+search_result = toolkit.search_google(
+    query="Python Wikipedia",
+    exclude_domains=[
+        "wikipedia.org",
+        "wikipedia-api.readthedocs.io",
+        "wikipedia.readthedocs.io",
+    ],
+)
+print("\nExcluding specified domains related to wikipedia:\n")
+for result in search_result:
+    print(result['url'])

--- a/examples/toolkits/search_google_with_exclusion.py
+++ b/examples/toolkits/search_google_with_exclusion.py
@@ -26,14 +26,27 @@ search_result = toolkit.search_google(query="Python Wikipedia")
 print("Search results for 'Python Wikipedia':\n")
 for result in search_result:
     print(result['url'])
-search_result = toolkit.search_google(
-    query="Python Wikipedia",
+toolkit = SearchToolkit(
+    number_of_result_pages=3,
     exclude_domains=[
         "wikipedia.org",
-        "wikipedia-api.readthedocs.io",
-        "wikipedia.readthedocs.io",
     ],
 )
+search_result = toolkit.search_google(query="Python Wikipedia")
 print("\nExcluding specified domains related to wikipedia:\n")
 for result in search_result:
     print(result['url'])
+
+"""
+Search results for 'Python Wikipedia':
+
+https://en.wikipedia.org/wiki/Python_(programming_language)
+https://wiki.python.org/moin/FrontPage
+https://pypi.org/project/wikipedia/
+
+Excluding specified domains related to wikipedia:
+
+https://pypi.org/project/wikipedia/
+https://wiki.python.org/moin/FrontPage
+https://www.reddit.com/r/Python/comments/3tn216/scraping_wikipedia/
+"""


### PR DESCRIPTION
## Description

After thinking carefully about PR #2901, I think it is better to allow users to set url domains to exclude from SearchToolkit, rather than from the specific `search_google` function. The specific functions are typically called by LLMs rather than used by human users.

The current version only supports excluding domains from `search_google`, and it can be extended to support other search toolkits in the future.

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have linked this PR to an issue using the Development section on the right sidebar or by adding `Fixes #issue-number` in the PR description (**required**)
- [x] I have checked if any dependencies need to be added or updated in `pyproject.toml` and `uv lock`
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed:
- [ ] I have added examples if this is a new feature

If you are unsure about any of these, don't hesitate to ask. We are here to help!
