### PR TITLE
refactor: rename generic function names and add aliases for compatibility (#2907)

### DIFF
--- a/camel/toolkits/hybrid_browser_toolkit/hybrid_browser_toolkit.py
+++ b/camel/toolkits/hybrid_browser_toolkit/hybrid_browser_toolkit.py
@@ -1488,7 +1488,7 @@ class HybridBrowserToolkit(BaseToolkit):
 
         return ToolResult(text=text_result, images=[img_data_url])
 
-    async def click(self, *, ref: str) -> Dict[str, Any]:
+    async def hybrid_browser_click(self, *, ref: str) -> Dict[str, Any]:
         r"""Performs a click on an element on the page.
 
         Args:
@@ -1531,8 +1531,10 @@ class HybridBrowserToolkit(BaseToolkit):
         result.update(tab_info)
 
         return result
+    # Alias for backward compatibility
+    click = hybrid_browser_click
 
-    async def type(self, *, ref: str, text: str) -> Dict[str, Any]:
+    async def hybrid_browser_type(self, *, ref: str, text: str) -> Dict[str, Any]:
         r"""Types text into an input element on the page.
 
         Args:
@@ -1559,8 +1561,10 @@ class HybridBrowserToolkit(BaseToolkit):
         result.update(tab_info)
 
         return result
-
-    async def select(self, *, ref: str, value: str) -> Dict[str, Any]:
+        # Alias for backward compatibility
+        type = hybrid_browser_type
+        
+    async def hybrid_browser_select(self, *, ref: str, value: str) -> Dict[str, Any]:
         r"""Selects an option in a dropdown (`<select>`) element.
 
         Args:
@@ -1588,8 +1592,10 @@ class HybridBrowserToolkit(BaseToolkit):
         result.update(tab_info)
 
         return result
-
-    async def scroll(self, *, direction: str, amount: int) -> Dict[str, Any]:
+        # Alias for backward compatibility
+        select = hybrid_browser_select
+        
+    async def hybrid_browser_scroll(self, *, direction: str, amount: int) -> Dict[str, Any]:
         r"""Scrolls the current page window.
 
         Args:
@@ -1620,8 +1626,10 @@ class HybridBrowserToolkit(BaseToolkit):
         result.update(tab_info)
 
         return result
-
-    async def enter(self) -> Dict[str, Any]:
+        # Alias for backward compatibility
+        scroll = hybrid_browser_scroll
+        
+    async def hybrid_browser_enter(self) -> Dict[str, Any]:
         r"""Simulates pressing the Enter key on the currently focused element.
 
         This is useful for submitting forms or search queries after using the
@@ -1646,7 +1654,9 @@ class HybridBrowserToolkit(BaseToolkit):
         result.update(tab_info)
 
         return result
-
+        # Alias for backward compatibility
+        enter = hybrid_browser_enter
+        
     @action_logger
     async def wait_user(
         self, timeout_sec: Optional[float] = None


### PR DESCRIPTION
## Description

This PR addresses issue #2907 by changing some general function names in the `hybrid browser module` to more clear and meaningful ones. 

To make sure nothing breaks, the old function names still work as aliases for the new ones

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have linked this PR to an issue using the Development section on the right sidebar or by adding `Fixes #issue-number` in the PR description (**required**)
- [ ] I have checked if any dependencies need to be added or updated in `pyproject.toml` and `uv lock`
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed:
- [ ] I have added examples if this is a new feature

If you are unsure about any of these, don't hesitate to ask. We are here to help!
