### PR TITLE
add browser_get_page_links tool to hybrid_browser_toolkit_ts

### DIFF
--- a/camel/toolkits/hybrid_browser_toolkit/hybrid_browser_toolkit_ts.py
+++ b/camel/toolkits/hybrid_browser_toolkit/hybrid_browser_toolkit_ts.py
@@ -620,6 +620,32 @@ class HybridBrowserToolkit(BaseToolkit, RegisteredAgentToolkit):
             logger.error(f"Failed to get screenshot: {e}")
             return f"Error capturing screenshot: {e}"
 
+    async def browser_get_page_links(
+        self, *, ref: List[str]
+    ) -> Dict[str, Any]:
+        r"""Gets the destination URLs for a list of link elements.
+
+        This is useful to know where a link goes before clicking it.
+
+        Args:
+            ref (List[str]): A list of `ref` IDs for link elements, obtained
+                from a page snapshot.
+
+        Returns:
+            Dict[str, Any]: A dictionary containing:
+                - "links" (List[Dict]): A list of found links, where each
+                  link has "text", "ref", and "url" keys.
+        """
+        try:
+            ws_wrapper = await self._get_ws_wrapper()
+            result = await ws_wrapper.get_page_links(ref)
+
+            return result
+
+        except Exception as e:
+            logger.error(f"Failed to get page links: {e}")
+            return {"links": []}
+
     async def browser_click(self, *, ref: str) -> Dict[str, Any]:
         r"""Performs a click on an element on the page.
 
@@ -1071,8 +1097,7 @@ class HybridBrowserToolkit(BaseToolkit, RegisteredAgentToolkit):
         except asyncio.TimeoutError:
             wait_time = timeout_sec or 0.0
             logger.info(
-                f"User input timeout reached after {wait_time}s, "
-                f"auto-resuming"
+                f"User input timeout reached after {wait_time}s, auto-resuming"
             )
             result_msg = f"Timeout {timeout_sec}s reached, auto-resumed."
 
@@ -1114,8 +1139,7 @@ class HybridBrowserToolkit(BaseToolkit, RegisteredAgentToolkit):
             user_data_dir=self._user_data_dir,
             stealth=self._stealth,
             web_agent_model=self._web_agent_model,
-            cache_dir=f"{self._cache_dir.rstrip('/')}_clone_"
-            f"{new_session_id}/",
+            cache_dir=f"{self._cache_dir.rstrip('/')}_clone_{new_session_id}/",
             enabled_tools=self.enabled_tools.copy(),
             browser_log_to_file=self._browser_log_to_file,
             session_id=new_session_id,

--- a/camel/toolkits/hybrid_browser_toolkit/ts/src/types.ts
+++ b/camel/toolkits/hybrid_browser_toolkit/ts/src/types.ts
@@ -108,3 +108,12 @@ export interface VisualMarkResult {
   images: string[];
 }
 
+export interface LinkData {
+  text: string;
+  ref: string;
+  url: string;
+}
+export interface LinkResult {
+  links: LinkData[];
+}
+

--- a/camel/toolkits/hybrid_browser_toolkit/ts/websocket-server.js
+++ b/camel/toolkits/hybrid_browser_toolkit/ts/websocket-server.js
@@ -154,6 +154,11 @@ class WebSocketBrowserServer {
         console.log(`Screenshot completed in ${endTime - startTime}ms`);
         return result;
       }
+
+      case 'get_page_links':
+        if (!this.toolkit) throw new Error('Toolkit not initialized');
+        return await this.toolkit.getPageLinks(params.ref);
+
       case 'click':
         if (!this.toolkit) throw new Error('Toolkit not initialized');
         return await this.toolkit.click(params.ref);

--- a/camel/toolkits/hybrid_browser_toolkit/ws_wrapper.py
+++ b/camel/toolkits/hybrid_browser_toolkit/ws_wrapper.py
@@ -504,6 +504,12 @@ class WebSocketBrowserWrapper:
         return ToolResult(text=response['text'], images=response['images'])
 
     @action_logger
+    async def get_page_links(self, ref: List[str]) -> Dict[str, Any]:
+        """Get the destination URLs for a list of link elements."""
+        response = await self._send_command('get_page_links', {'ref': ref})
+        return response
+
+    @action_logger
     async def click(self, ref: str) -> Dict[str, Any]:
         """Click an element."""
         response = await self._send_command('click', {'ref': ref})


### PR DESCRIPTION
## Description

this pr adds the missing tool `browser_get_page_links` in `hybrid_browser_toolkit_ts.py`

the tool was mentioned under the `ALL_TOOLS` class variable and this pr completes the implementation.

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide (**required**)
- [ ] I have linked this PR to an issue using the Development section on the right sidebar or by adding `Fixes #issue-number` in the PR description (**required**)
- [x] I have checked if any dependencies need to be added or updated in `pyproject.toml` and `uv lock`
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed:
- [ ] I have added examples if this is a new feature

If you are unsure about any of these, don't hesitate to ask. We are here to help!
