### PR TITLE
fix code block rendering line break bug

### DIFF
--- a/docs/mcp/camel_toolkits_as_an_mcp_server.md
+++ b/docs/mcp/camel_toolkits_as_an_mcp_server.md
@@ -35,7 +35,7 @@ You can turn any CAMEL toolkit into a full-featured MCP server—making its tool
 Below is a minimal script to expose <b>ArxivToolkit</b> as an MCP server.  
 Swap in any other toolkit (e.g., <code>SearchToolkit</code>, <code>MathToolkit</code>), they all work the same way!
 
-<CodeBlock language="python" title="arxiv_toolkit_server.py">
+```python
 from camel.toolkits import ArxivToolkit
 import argparse
 
@@ -52,7 +52,7 @@ args = parser.parse_args()
 
 toolkit = ArxivToolkit()
 toolkit.mcp.run(args.mode)
-</CodeBlock>
+```
 
 - **stdio:** For local IPC (default, fast and secure for single-machine setups)
 - **sse:** Server-Sent Events (good for remote servers and web clients)


### PR DESCRIPTION
During markdown rendering, the code blocks within the <CodeBlock></CodeBlock> tags failed to produce correct line breaks, which impaired readability. Therefore, this bug was fixed using markdown syntax (Note that adding the "white-space: pre-wrap" style declaration did not work).

## Description

Before modification:
from camel.toolkits import ArxivToolkit import argparse

parser = argparse.ArgumentParser( description="Run Arxiv Toolkit as an MCP server." ) parser.add_argument( "--mode", choices=["stdio", "sse", "streamable-http"], default="stdio", help="Select MCP server mode." ) args = parser.parse_args()

toolkit = ArxivToolkit() toolkit.mcp.run(args.mode)

After modification:
```python
from camel.toolkits import ArxivToolkit 
import argparse

parser = argparse.ArgumentParser( 
    description="Run Arxiv Toolkit as an MCP server." 
) 
parser.add_argument( 
    "--mode", 
    choices=["stdio", "sse", "streamable-http"], 
    default="stdio", 
    help="Select MCP server mode." 
) 
args = parser.parse_args()

toolkit = ArxivToolkit() 
toolkit.mcp.run(args.mode) 
```

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

- [ ] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide (**required**)
- [ ] I have linked this PR to an issue using the Development section on the right sidebar or by adding `Fixes #issue-number` in the PR description (**required**)
- [ ] I have checked if any dependencies need to be added or updated in `pyproject.toml` and `uv lock`
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed:
- [ ] I have added examples if this is a new feature

If you are unsure about any of these, don't hesitate to ask. We are here to help!
