### PR TITLE
Feat: Add Nebius AI Studio integration

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -140,6 +140,7 @@ jobs:
           ACI_API_KEY: "${{ secrets.ACI_API_KEY }}"
           BOHRIUM_API_KEY: "${{ secrets.BOHRIUM_API_KEY }}"
           CRYNUX_API_KEY: "${{ secrets.CRYNUX_API_KEY }}"
+          NEBIUS_API_KEY: "${{ secrets.NEBIUS_API_KEY }}"
         run: |
           source test_venv/bin/activate
           pytest --fast-test-mode -m "not heavy_dependency" \

--- a/.github/workflows/pytest_package.yml
+++ b/.github/workflows/pytest_package.yml
@@ -79,6 +79,7 @@ jobs:
         ACI_API_KEY: "${{ secrets.ACI_API_KEY }}"
         BOHRIUM_API_KEY: "${{ secrets.BOHRIUM_API_KEY }}"
         CRYNUX_API_KEY: "${{ secrets.CRYNUX_API_KEY }}"
+        NEBIUS_API_KEY: "${{ secrets.NEBIUS_API_KEY }}"
       run: |
         source .venv/bin/activate
         uv pip install -e ".[all, dev, docs]"
@@ -163,6 +164,7 @@ jobs:
         ACI_API_KEY: "${{ secrets.ACI_API_KEY }}"
         BOHRIUM_API_KEY: "${{ secrets.BOHRIUM_API_KEY }}"
         CRYNUX_API_KEY: "${{ secrets.CRYNUX_API_KEY }}"
+        NEBIUS_API_KEY: "${{ secrets.NEBIUS_API_KEY }}"
       run: |
         source .venv/bin/activate
         uv pip install -e ".[all, dev, docs]"
@@ -245,6 +247,7 @@ jobs:
         ACI_API_KEY: "${{ secrets.ACI_API_KEY }}"
         BOHRIUM_API_KEY: "${{ secrets.BOHRIUM_API_KEY }}"
         CRYNUX_API_KEY: "${{ secrets.CRYNUX_API_KEY }}"
+        NEBIUS_API_KEY: "${{ secrets.NEBIUS_API_KEY }}"
       run: |
         source .venv/bin/activate
         uv pip install -e ".[all, dev, docs]"

--- a/camel/configs/__init__.py
+++ b/camel/configs/__init__.py
@@ -21,12 +21,12 @@ from .deepseek_config import DEEPSEEK_API_PARAMS, DeepSeekConfig
 from .gemini_config import Gemini_API_PARAMS, GeminiConfig
 from .groq_config import GROQ_API_PARAMS, GroqConfig
 from .internlm_config import INTERNLM_API_PARAMS, InternLMConfig
-from .nebius_config import NEBIUS_API_PARAMS, NebiusConfig
 from .litellm_config import LITELLM_API_PARAMS, LiteLLMConfig
 from .lmstudio_config import LMSTUDIO_API_PARAMS, LMStudioConfig
 from .mistral_config import MISTRAL_API_PARAMS, MistralConfig
 from .modelscope_config import MODELSCOPE_API_PARAMS, ModelScopeConfig
 from .moonshot_config import MOONSHOT_API_PARAMS, MoonshotConfig
+from .nebius_config import NEBIUS_API_PARAMS, NebiusConfig
 from .netmind_config import NETMIND_API_PARAMS, NetmindConfig
 from .novita_config import NOVITA_API_PARAMS, NovitaConfig
 from .nvidia_config import NVIDIA_API_PARAMS, NvidiaConfig

--- a/camel/configs/__init__.py
+++ b/camel/configs/__init__.py
@@ -21,6 +21,7 @@ from .deepseek_config import DEEPSEEK_API_PARAMS, DeepSeekConfig
 from .gemini_config import Gemini_API_PARAMS, GeminiConfig
 from .groq_config import GROQ_API_PARAMS, GroqConfig
 from .internlm_config import INTERNLM_API_PARAMS, InternLMConfig
+from .nebius_config import NEBIUS_API_PARAMS, NebiusConfig
 from .litellm_config import LITELLM_API_PARAMS, LiteLLMConfig
 from .lmstudio_config import LMSTUDIO_API_PARAMS, LMStudioConfig
 from .mistral_config import MISTRAL_API_PARAMS, MistralConfig
@@ -58,6 +59,8 @@ __all__ = [
     'ANTHROPIC_API_PARAMS',
     'GROQ_API_PARAMS',
     'GroqConfig',
+    'NEBIUS_API_PARAMS',
+    'NebiusConfig',
     'LiteLLMConfig',
     'LITELLM_API_PARAMS',
     'NetmindConfig',

--- a/camel/configs/nebius_config.py
+++ b/camel/configs/nebius_config.py
@@ -1,0 +1,103 @@
+# ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
+from __future__ import annotations
+
+from typing import Optional, Sequence, Union
+
+from camel.configs.base_config import BaseConfig
+
+
+class NebiusConfig(BaseConfig):
+    r"""Defines the parameters for generating chat completions using OpenAI
+    compatibility with Nebius AI Studio.
+
+    Reference: https://nebius.com/docs/ai-studio/api
+
+    Args:
+        temperature (float, optional): Sampling temperature to use, between
+            :obj:`0` and :obj:`2`. Higher values make the output more random,
+            while lower values make it more focused and deterministic.
+            (default: :obj:`None`)
+        top_p (float, optional): An alternative to sampling with temperature,
+            called nucleus sampling, where the model considers the results of
+            the tokens with top_p probability mass. So :obj:`0.1` means only
+            the tokens comprising the top 10% probability mass are considered.
+            (default: :obj:`None`)
+        n (int, optional): How many chat completion choices to generate for
+            each input message. (default: :obj:`None`)
+        response_format (object, optional): An object specifying the format
+            that the model must output. Compatible with GPT-4 Turbo and all
+            GPT-3.5 Turbo models newer than gpt-3.5-turbo-1106. Setting to
+            {"type": "json_object"} enables JSON mode, which guarantees the
+            message the model generates is valid JSON. Important: when using
+            JSON mode, you must also instruct the model to produce JSON
+            yourself via a system or user message. Without this, the model
+            may generate an unending stream of whitespace until the generation
+            reaches the token limit, resulting in a long-running and seemingly
+            "stuck" request. Also note that the message content may be
+            partially cut off if finish_reason="length", which indicates the
+            generation exceeded max_tokens or the conversation exceeded the
+            max context length.
+        stream (bool, optional): If True, partial message deltas will be sent
+            as data-only server-sent events as they become available.
+            (default: :obj:`None`)
+        stop (str or list, optional): Up to :obj:`4` sequences where the API
+            will stop generating further tokens. (default: :obj:`None`)
+        max_tokens (int, optional): The maximum number of tokens to generate
+            in the chat completion. The total length of input tokens and
+            generated tokens is limited by the model's context length.
+            (default: :obj:`None`)
+        presence_penalty (float, optional): Number between :obj:`-2.0` and
+            :obj:`2.0`. Positive values penalize new tokens based on whether
+            they appear in the text so far, increasing the model's likelihood
+            to talk about new topics. See more information about frequency and
+            presence penalties. (default: :obj:`None`)
+        frequency_penalty (float, optional): Number between :obj:`-2.0` and
+            :obj:`2.0`. Positive values penalize new tokens based on their
+            existing frequency in the text so far, decreasing the model's
+            likelihood to repeat the same line verbatim. See more information
+            about frequency and presence penalties. (default: :obj:`None`)
+        user (str, optional): A unique identifier representing your end-user,
+            which can help OpenAI to monitor and detect abuse.
+            (default: :obj:`None`)
+        tools (list[FunctionTool], optional): A list of tools the model may
+            call. Currently, only functions are supported as a tool. Use this
+            to provide a list of functions the model may generate JSON inputs
+            for. A max of 128 functions are supported.
+        tool_choice (Union[dict[str, str], str], optional): Controls which (if
+            any) tool is called by the model. :obj:`"none"` means the model
+            will not call any tool and instead generates a message.
+            :obj:`"auto"` means the model can pick between generating a
+            message or calling one or more tools.  :obj:`"required"` means the
+            model must call one or more tools. Specifying a particular tool
+            via {"type": "function", "function": {"name": "my_function"}}
+            forces the model to call that tool. :obj:`"none"` is the default
+            when no tools are present. :obj:`"auto"` is the default if tools
+            are present.
+    """
+
+    temperature: Optional[float] = None
+    top_p: Optional[float] = None
+    n: Optional[int] = None
+    stream: Optional[bool] = None
+    stop: Optional[Union[str, Sequence[str]]] = None
+    max_tokens: Optional[int] = None
+    presence_penalty: Optional[float] = None
+    response_format: Optional[dict] = None
+    frequency_penalty: Optional[float] = None
+    user: Optional[str] = None
+    tool_choice: Optional[Union[dict[str, str], str]] = None
+
+
+NEBIUS_API_PARAMS = {param for param in NebiusConfig.model_fields.keys()}

--- a/camel/models/__init__.py
+++ b/camel/models/__init__.py
@@ -24,7 +24,6 @@ from .fish_audio_model import FishAudioModel
 from .gemini_model import GeminiModel
 from .groq_model import GroqModel
 from .internlm_model import InternLMModel
-from .nebius_model import NebiusModel
 from .litellm_model import LiteLLMModel
 from .lmstudio_model import LMStudioModel
 from .mistral_model import MistralModel
@@ -32,6 +31,7 @@ from .model_factory import ModelFactory
 from .model_manager import ModelManager, ModelProcessingError
 from .modelscope_model import ModelScopeModel
 from .moonshot_model import MoonshotModel
+from .nebius_model import NebiusModel
 from .nemotron_model import NemotronModel
 from .netmind_model import NetmindModel
 from .novita_model import NovitaModel

--- a/camel/models/__init__.py
+++ b/camel/models/__init__.py
@@ -24,6 +24,7 @@ from .fish_audio_model import FishAudioModel
 from .gemini_model import GeminiModel
 from .groq_model import GroqModel
 from .internlm_model import InternLMModel
+from .nebius_model import NebiusModel
 from .litellm_model import LiteLLMModel
 from .lmstudio_model import LMStudioModel
 from .mistral_model import MistralModel
@@ -87,6 +88,7 @@ __all__ = [
     'QwenModel',
     'AWSBedrockModel',
     'ModelProcessingError',
+    'NebiusModel',
     'DeepSeekModel',
     'FishAudioModel',
     'InternLMModel',

--- a/camel/models/model_factory.py
+++ b/camel/models/model_factory.py
@@ -26,12 +26,12 @@ from camel.models.deepseek_model import DeepSeekModel
 from camel.models.gemini_model import GeminiModel
 from camel.models.groq_model import GroqModel
 from camel.models.internlm_model import InternLMModel
-from camel.models.nebius_model import NebiusModel
 from camel.models.litellm_model import LiteLLMModel
 from camel.models.lmstudio_model import LMStudioModel
 from camel.models.mistral_model import MistralModel
 from camel.models.modelscope_model import ModelScopeModel
 from camel.models.moonshot_model import MoonshotModel
+from camel.models.nebius_model import NebiusModel
 from camel.models.netmind_model import NetmindModel
 from camel.models.novita_model import NovitaModel
 from camel.models.nvidia_model import NvidiaModel

--- a/camel/models/model_factory.py
+++ b/camel/models/model_factory.py
@@ -26,6 +26,7 @@ from camel.models.deepseek_model import DeepSeekModel
 from camel.models.gemini_model import GeminiModel
 from camel.models.groq_model import GroqModel
 from camel.models.internlm_model import InternLMModel
+from camel.models.nebius_model import NebiusModel
 from camel.models.litellm_model import LiteLLMModel
 from camel.models.lmstudio_model import LMStudioModel
 from camel.models.mistral_model import MistralModel
@@ -83,6 +84,7 @@ class ModelFactory:
         ModelPlatformType.AZURE: AzureOpenAIModel,
         ModelPlatformType.ANTHROPIC: AnthropicModel,
         ModelPlatformType.GROQ: GroqModel,
+        ModelPlatformType.NEBIUS: NebiusModel,
         ModelPlatformType.LMSTUDIO: LMStudioModel,
         ModelPlatformType.OPENROUTER: OpenRouterModel,
         ModelPlatformType.ZHIPU: ZhipuAIModel,

--- a/camel/models/nebius_model.py
+++ b/camel/models/nebius_model.py
@@ -1,0 +1,82 @@
+# ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
+import os
+from typing import Any, Dict, Optional, Union
+
+from camel.configs import NebiusConfig
+from camel.models.openai_compatible_model import OpenAICompatibleModel
+from camel.types import ModelType
+from camel.utils import (
+    BaseTokenCounter,
+    api_keys_required,
+)
+
+
+class NebiusModel(OpenAICompatibleModel):
+    r"""LLM API served by Nebius AI Studio in a unified OpenAICompatibleModel interface.
+
+    Args:
+        model_type (Union[ModelType, str]): Model for which a backend is
+            created.
+        model_config_dict (Optional[Dict[str, Any]], optional): A dictionary
+            that will be fed into:obj:`openai.ChatCompletion.create()`.
+            If:obj:`None`, :obj:`NebiusConfig().as_dict()` will be used.
+            (default: :obj:`None`)
+        api_key (Optional[str], optional): The API key for authenticating
+            with the Nebius AI Studio service. (default: :obj:`None`).
+        url (Optional[str], optional): The url to the Nebius AI Studio service.
+            (default: :obj:`None`)
+        token_counter (Optional[BaseTokenCounter], optional): Token counter to
+            use for the model. If not provided, :obj:`OpenAITokenCounter(
+            ModelType.GPT_4O_MINI)` will be used.
+            (default: :obj:`None`)
+        timeout (Optional[float], optional): The timeout value in seconds for
+            API calls. If not provided, will fall back to the MODEL_TIMEOUT
+            environment variable or default to 180 seconds.
+            (default: :obj:`None`)
+        max_retries (int, optional): Maximum number of retries for API calls.
+            (default: :obj:`3`)
+        **kwargs (Any): Additional arguments to pass to the client
+            initialization.
+    """
+
+    @api_keys_required([("api_key", "NEBIUS_API_KEY")])
+    def __init__(
+        self,
+        model_type: Union[ModelType, str],
+        model_config_dict: Optional[Dict[str, Any]] = None,
+        api_key: Optional[str] = None,
+        url: Optional[str] = None,
+        token_counter: Optional[BaseTokenCounter] = None,
+        timeout: Optional[float] = None,
+        max_retries: int = 3,
+        **kwargs: Any,
+    ) -> None:
+        if model_config_dict is None:
+            model_config_dict = NebiusConfig().as_dict()
+        api_key = api_key or os.environ.get("NEBIUS_API_KEY")
+        url = url or os.environ.get(
+            "NEBIUS_API_BASE_URL", "https://api.studio.nebius.com/v1"
+        )
+        timeout = timeout or float(os.environ.get("MODEL_TIMEOUT", 180))
+        super().__init__(
+            model_type=model_type,
+            model_config_dict=model_config_dict,
+            api_key=api_key,
+            url=url,
+            token_counter=token_counter,
+            timeout=timeout,
+            max_retries=max_retries,
+            **kwargs,
+        )

--- a/camel/models/nebius_model.py
+++ b/camel/models/nebius_model.py
@@ -24,7 +24,8 @@ from camel.utils import (
 
 
 class NebiusModel(OpenAICompatibleModel):
-    r"""LLM API served by Nebius AI Studio in a unified OpenAICompatibleModel interface.
+    r"""LLM API served by Nebius AI Studio in a unified OpenAICompatibleModel
+    interface.
 
     Args:
         model_type (Union[ModelType, str]): Model for which a backend is

--- a/camel/types/enums.py
+++ b/camel/types/enums.py
@@ -87,6 +87,11 @@ class ModelType(UnifiedModelType, Enum):
     GROQ_MIXTRAL_8_7B = "mixtral-8x7b-32768"
     GROQ_GEMMA_2_9B_IT = "gemma2-9b-it"
 
+    # Nebius AI Studio platform models
+    NEBIUS_LLAMA_3_1_8B_INSTRUCT = "meta-llama/Meta-Llama-3.1-8B-Instruct-fast"
+    NEBIUS_LLAMA_3_1_70B_INSTRUCT = "meta-llama/Meta-Llama-3.1-70B-Instruct-fast"
+    NEBIUS_LLAMA_3_1_405B_INSTRUCT = "meta-llama/Meta-Llama-3.1-405B-Instruct-fast"
+
     # OpenRouter models
     OPENROUTER_LLAMA_3_1_405B = "meta-llama/llama-3.1-405b-instruct"
     OPENROUTER_LLAMA_3_1_70B = "meta-llama/llama-3.1-70b-instruct"
@@ -601,6 +606,15 @@ class ModelType(UnifiedModelType, Enum):
             ModelType.GROQ_LLAMA_3_70B,
             ModelType.GROQ_MIXTRAL_8_7B,
             ModelType.GROQ_GEMMA_2_9B_IT,
+        }
+
+    @property
+    def is_nebius(self) -> bool:
+        r"""Returns whether this type of models is served by Nebius AI Studio."""
+        return self in {
+            ModelType.NEBIUS_LLAMA_3_1_8B_INSTRUCT,
+            ModelType.NEBIUS_LLAMA_3_1_70B_INSTRUCT,
+            ModelType.NEBIUS_LLAMA_3_1_405B_INSTRUCT,
         }
 
     @property
@@ -1532,6 +1546,7 @@ class ModelPlatformType(Enum):
     AZURE = "azure"
     ANTHROPIC = "anthropic"
     GROQ = "groq"
+    NEBIUS = "nebius"
     OPENROUTER = "openrouter"
     OLLAMA = "ollama"
     LITELLM = "litellm"

--- a/camel/types/enums.py
+++ b/camel/types/enums.py
@@ -1161,6 +1161,9 @@ class ModelType(UnifiedModelType, Enum):
             ModelType.NOVITA_MISTRAL_7B,
             ModelType.NOVITA_LLAMA_3_2_11B_VISION,
             ModelType.NOVITA_LLAMA_3_2_3B,
+            ModelType.NEBIUS_GPT_OSS_120B,
+            ModelType.NEBIUS_GPT_OSS_20B,
+            ModelType.NEBIUS_MISTRAL_7B_INSTRUCT,
         }:
             return 32_768
         elif self in {
@@ -1250,6 +1253,9 @@ class ModelType(UnifiedModelType, Enum):
             ModelType.ERNIE_4_5_TURBO_128K,
             ModelType.DEEPSEEK_V3,
             ModelType.MOONSHOT_KIMI_K2,
+            ModelType.NEBIUS_GLM_4_5,
+            ModelType.NEBIUS_DEEPSEEK_V3,
+            ModelType.NEBIUS_DEEPSEEK_R1,
         }:
             return 128_000
         elif self in {
@@ -1284,6 +1290,7 @@ class ModelType(UnifiedModelType, Enum):
             ModelType.NOVITA_LLAMA_4_SCOUT_17B,
             ModelType.NOVITA_LLAMA_3_3_70B,
             ModelType.NOVITA_MISTRAL_NEMO,
+            ModelType.NEBIUS_LLAMA_3_1_70B,
         }:
             return 131_072
         elif self in {

--- a/camel/types/enums.py
+++ b/camel/types/enums.py
@@ -1161,8 +1161,6 @@ class ModelType(UnifiedModelType, Enum):
             ModelType.NOVITA_MISTRAL_7B,
             ModelType.NOVITA_LLAMA_3_2_11B_VISION,
             ModelType.NOVITA_LLAMA_3_2_3B,
-            ModelType.NEBIUS_GPT_OSS_120B,
-            ModelType.NEBIUS_GPT_OSS_20B,
             ModelType.NEBIUS_MISTRAL_7B_INSTRUCT,
         }:
             return 32_768
@@ -1256,6 +1254,8 @@ class ModelType(UnifiedModelType, Enum):
             ModelType.NEBIUS_GLM_4_5,
             ModelType.NEBIUS_DEEPSEEK_V3,
             ModelType.NEBIUS_DEEPSEEK_R1,
+            ModelType.NEBIUS_GPT_OSS_120B,
+            ModelType.NEBIUS_GPT_OSS_20B,
         }:
             return 128_000
         elif self in {

--- a/camel/types/enums.py
+++ b/camel/types/enums.py
@@ -614,7 +614,8 @@ class ModelType(UnifiedModelType, Enum):
 
     @property
     def is_nebius(self) -> bool:
-        r"""Returns whether this type of models is served by Nebius AI Studio."""
+        r"""Returns whether this type of models is served by Nebius AI
+        Studio."""
         return self in {
             ModelType.NEBIUS_GPT_OSS_120B,
             ModelType.NEBIUS_GPT_OSS_20B,

--- a/camel/types/enums.py
+++ b/camel/types/enums.py
@@ -88,9 +88,13 @@ class ModelType(UnifiedModelType, Enum):
     GROQ_GEMMA_2_9B_IT = "gemma2-9b-it"
 
     # Nebius AI Studio platform models
-    NEBIUS_LLAMA_3_1_8B_INSTRUCT = "meta-llama/Meta-Llama-3.1-8B-Instruct-fast"
-    NEBIUS_LLAMA_3_1_70B_INSTRUCT = "meta-llama/Meta-Llama-3.1-70B-Instruct-fast"
-    NEBIUS_LLAMA_3_1_405B_INSTRUCT = "meta-llama/Meta-Llama-3.1-405B-Instruct-fast"
+    NEBIUS_GPT_OSS_120B = "gpt-oss-120b"
+    NEBIUS_GPT_OSS_20B = "gpt-oss-20b"
+    NEBIUS_GLM_4_5 = "GLM-4.5"
+    NEBIUS_DEEPSEEK_V3 = "deepseek-ai/DeepSeek-V3"
+    NEBIUS_DEEPSEEK_R1 = "deepseek-ai/DeepSeek-R1"
+    NEBIUS_LLAMA_3_1_70B = "meta-llama/Meta-Llama-3.1-70B-Instruct"
+    NEBIUS_MISTRAL_7B_INSTRUCT = "mistralai/Mistral-7B-Instruct-v0.3"
 
     # OpenRouter models
     OPENROUTER_LLAMA_3_1_405B = "meta-llama/llama-3.1-405b-instruct"
@@ -612,9 +616,13 @@ class ModelType(UnifiedModelType, Enum):
     def is_nebius(self) -> bool:
         r"""Returns whether this type of models is served by Nebius AI Studio."""
         return self in {
-            ModelType.NEBIUS_LLAMA_3_1_8B_INSTRUCT,
-            ModelType.NEBIUS_LLAMA_3_1_70B_INSTRUCT,
-            ModelType.NEBIUS_LLAMA_3_1_405B_INSTRUCT,
+            ModelType.NEBIUS_GPT_OSS_120B,
+            ModelType.NEBIUS_GPT_OSS_20B,
+            ModelType.NEBIUS_GLM_4_5,
+            ModelType.NEBIUS_DEEPSEEK_V3,
+            ModelType.NEBIUS_DEEPSEEK_R1,
+            ModelType.NEBIUS_LLAMA_3_1_70B,
+            ModelType.NEBIUS_MISTRAL_7B_INSTRUCT,
         }
 
     @property

--- a/camel/types/unified_model_type.py
+++ b/camel/types/unified_model_type.py
@@ -96,6 +96,11 @@ class UnifiedModelType(str):
         return True
 
     @property
+    def is_nebius(self) -> bool:
+        r"""Returns whether the model is a Nebius AI Studio served model."""
+        return True
+
+    @property
     def is_openrouter(self) -> bool:
         r"""Returns whether the model is a OpenRouter served model."""
         return True

--- a/docs/mintlify/key_modules/models.mdx
+++ b/docs/mintlify/key_modules/models.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Models"
-description: "CAMEL-AI: Flexible integration and deployment of top LLMs and multimodal models like [OpenAI](https://openai.com/), [Mistral](https://mistral.ai/), [Gemini](https://ai.google.dev/gemini-api/docs/models), [Llama](https://www.llama.com/), and more."
+description: "CAMEL-AI: Flexible integration and deployment of top LLMs and multimodal models like [OpenAI](https://openai.com/), [Mistral](https://mistral.ai/), [Gemini](https://ai.google.dev/gemini-api/docs/models), [Llama](https://www.llama.com/), [Nebius](https://nebius.com/), and more."
 icon: gear-code
 ---
 
@@ -16,7 +16,7 @@ Play with different models in our [interactive Colab Notebook](https://colab.res
   </Card>
 
   <Card title="Flexible Model Integration" icon="plug">
-    CAMEL allows quick integration and swapping of leading LLMs from providers like OpenAI, Gemini, Llama, and Anthropic, helping you match the best model to your task.
+    CAMEL allows quick integration and swapping of leading LLMs from providers like OpenAI, Gemini, Llama, Anthropic, Nebius, and more, helping you match the best model to your task.
   </Card>
 
   <Card title="Optimized for Customization" icon="sliders">
@@ -45,6 +45,7 @@ CAMEL supports a wide range of models, including [OpenAI’s GPT series](https:/
 | **Lingyiwanwu**  | yi-lightning, yi-large, yi-medium<br/>yi-large-turbo, yi-vision, yi-medium-200k<br/>yi-spark, yi-large-rag, yi-large-fc |
 | **Qwen**         | qwen3-coder-plus,qwq-32b-preview, qwen-max, qwen-plus, qwen-turbo, qwen-long<br/>qwen-vl-max, qwen-vl-plus, qwen-math-plus, qwen-math-turbo, qwen-coder-turbo<br/>qwen2.5-coder-32b-instruct, qwen2.5-72b-instruct, qwen2.5-32b-instruct, qwen2.5-14b-instruct |
 | **DeepSeek**     | deepseek-chat<br/>deepseek-reasoner |
+| **Nebius**       | **All models available on [Nebius AI Studio](https://studio.nebius.com/)**<br/>Including: gpt-oss-120b, gpt-oss-20b, GLM-4.5<br/>DeepSeek V3 & R1, LLaMA, Mistral, and more |
 | **ZhipuAI**      | glm-4, glm-4v, glm-4v-flash<br/>glm-4v-plus-0111, glm-4-plus, glm-4-air<br/>glm-4-air-0111, glm-4-airx, glm-4-long<br/>glm-4-flashx, glm-zero-preview, glm-4-flash, glm-3-turbo |
 | **InternLM**     | internlm3-latest, internlm3-8b-instruct<br/>internlm2.5-latest, internlm2-pro-chat |
 | **Reka**         | reka-core, reka-flash, reka-edge |
@@ -190,6 +191,61 @@ Integrate your favorite models into CAMEL-AI with straightforward Python calls. 
 
   response = agent.step("Say hi to CAMEL AI community.")
   print(response.msgs[0].content)
+  ```
+
+  </Tab>
+
+  <Tab title="Nebius">
+    
+  Leverage [Nebius AI Studio](https://nebius.com/)'s high-performance GPU cloud with OpenAI-compatible models:
+
+ - **Nebius AI Studio** ([Platform](https://studio.nebius.com/)): Access powerful models through their cloud infrastructure.
+ - **API Key Setup** ([Generate Key](https://studio.nebius.ai/settings/api-keys)): Obtain your Nebius API key to start integration.
+ - **Nebius Docs** ([Documentation](https://nebius.com/docs/)): Explore detailed Nebius API capabilities.
+
+  ```python
+  from camel.models import ModelFactory
+  from camel.types import ModelPlatformType, ModelType
+  from camel.configs import NebiusConfig
+  from camel.agents import ChatAgent
+
+  model = ModelFactory.create(
+      model_platform=ModelPlatformType.NEBIUS,
+      model_type=ModelType.NEBIUS_GPT_OSS_120B,
+      model_config_dict=NebiusConfig(temperature=0.2).as_dict(),
+  )
+
+  agent = ChatAgent(
+      system_message="You are a helpful assistant.",
+      model=model
+  )
+
+  response = agent.step("Say hi to CAMEL AI community.")
+  print(response.msgs[0].content)
+  ```
+
+  <Note type="info">
+    **Flexible Model Access:** You can use any model available on Nebius by passing the model name as a string to `model_type`, even if it's not in the predefined enums.
+  </Note>
+
+  **Environment Variables:**
+  ```bash
+  export NEBIUS_API_KEY="your_nebius_api_key"
+  export NEBIUS_API_BASE_URL="https://api.studio.nebius.com/v1"  # Optional
+  ```
+
+  **Model Support:**
+  - **Complete Access:** All models available on [Nebius AI Studio](https://studio.nebius.com/) are supported
+  - **Predefined Enums:** Common models like `NEBIUS_GPT_OSS_120B`, `NEBIUS_DEEPSEEK_V3`, etc.
+  - **String-based Access:** Use any model name directly as a string for maximum flexibility
+  
+  **Example with any model:**
+  ```python
+  # Use any model available on Nebius
+  model = ModelFactory.create(
+      model_platform=ModelPlatformType.NEBIUS,
+      model_type="your-custom-model-name"  # Any Nebius model
+  )
   ```
 
   </Tab>

--- a/examples/models/nebius_model_example.py
+++ b/examples/models/nebius_model_example.py
@@ -19,7 +19,7 @@ from camel.types import ModelPlatformType, ModelType
 
 model = ModelFactory.create(
     model_platform=ModelPlatformType.NEBIUS,
-    model_type=ModelType.NEBIUS_LLAMA_3_1_8B_INSTRUCT,
+    model_type=ModelType.NEBIUS_GPT_OSS_120B,
     model_config_dict=NebiusConfig(temperature=0.2).as_dict(),
 )
 

--- a/examples/models/nebius_model_example.py
+++ b/examples/models/nebius_model_example.py
@@ -38,11 +38,12 @@ print(response.msgs[0].content)
 
 '''
 ===============================================================================
-Hello to the CAMEL AI community! It's great to connect with a group of like-minded 
-individuals who are passionate about advancing the field of autonomous and 
-communicative agents. Your open-source approach is commendable as it fosters 
-collaboration, innovation, and knowledge sharing across the AI research community. 
-I'm excited to see what groundbreaking work you'll accomplish in the study of 
-intelligent agents. Keep up the excellent work in pushing the boundaries of AI!
+Hello to the CAMEL AI community! It's great to connect with a group of 
+like-minded individuals who are passionate about advancing the field of 
+autonomous and communicative agents. Your open-source approach is commendable 
+as it fosters collaboration, innovation, and knowledge sharing across the AI 
+research community. I'm excited to see what groundbreaking work you'll 
+accomplish in the study of intelligent agents. Keep up the excellent work in 
+pushing the boundaries of AI!
 ===============================================================================
 '''

--- a/examples/models/nebius_model_example.py
+++ b/examples/models/nebius_model_example.py
@@ -1,0 +1,48 @@
+# ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
+
+from camel.agents import ChatAgent
+from camel.configs import NebiusConfig
+from camel.models import ModelFactory
+from camel.types import ModelPlatformType, ModelType
+
+model = ModelFactory.create(
+    model_platform=ModelPlatformType.NEBIUS,
+    model_type=ModelType.NEBIUS_LLAMA_3_1_8B_INSTRUCT,
+    model_config_dict=NebiusConfig(temperature=0.2).as_dict(),
+)
+
+# Define system message
+sys_msg = "You are a helpful assistant."
+
+# Set agent
+camel_agent = ChatAgent(system_message=sys_msg, model=model)
+
+user_msg = """Say hi to CAMEL AI, one open-source community 
+    dedicated to the study of autonomous and communicative agents."""
+
+# Get response information
+response = camel_agent.step(user_msg)
+print(response.msgs[0].content)
+
+'''
+===============================================================================
+Hello to the CAMEL AI community! It's great to connect with a group of like-minded 
+individuals who are passionate about advancing the field of autonomous and 
+communicative agents. Your open-source approach is commendable as it fosters 
+collaboration, innovation, and knowledge sharing across the AI research community. 
+I'm excited to see what groundbreaking work you'll accomplish in the study of 
+intelligent agents. Keep up the excellent work in pushing the boundaries of AI!
+===============================================================================
+'''

--- a/test/models/test_nebius_model.py
+++ b/test/models/test_nebius_model.py
@@ -1,0 +1,98 @@
+# ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
+
+import pytest
+
+from camel.configs import NebiusConfig
+from camel.models import NebiusModel
+from camel.types import ModelType
+from camel.utils import api_keys_required
+
+
+@pytest.mark.model_backend
+class TestNebiusModel:
+    @pytest.mark.parametrize(
+        "model_type",
+        [
+            ModelType.NEBIUS_LLAMA_3_1_8B_INSTRUCT,
+            ModelType.NEBIUS_LLAMA_3_1_70B_INSTRUCT,
+            ModelType.NEBIUS_LLAMA_3_1_405B_INSTRUCT,
+        ],
+    )
+    def test_nebius_model_create(self, model_type: ModelType):
+        model = NebiusModel(model_type)
+        assert model.model_type == model_type
+
+    def test_nebius_model_create_with_config(self):
+        config_dict = NebiusConfig(
+            temperature=0.5,
+            top_p=1.0,
+            max_tokens=100,
+        ).as_dict()
+
+        model = NebiusModel(
+            model_type=ModelType.NEBIUS_LLAMA_3_1_8B_INSTRUCT,
+            model_config_dict=config_dict,
+        )
+
+        assert model.model_type == ModelType.NEBIUS_LLAMA_3_1_8B_INSTRUCT
+        assert model.model_config_dict == config_dict
+
+    def test_nebius_model_api_keys_required(self):
+        # Test that the api_keys_required decorator is applied
+        assert hasattr(NebiusModel.__init__, "__wrapped__")
+
+    def test_nebius_model_default_url(self, monkeypatch):
+        # Test default URL when no environment variable is set
+        monkeypatch.delenv("NEBIUS_API_BASE_URL", raising=False)
+        monkeypatch.setenv("NEBIUS_API_KEY", "test_key")
+
+        model = NebiusModel(ModelType.NEBIUS_LLAMA_3_1_8B_INSTRUCT)
+        assert model._url == "https://api.studio.nebius.com/v1"
+
+    def test_nebius_model_custom_url(self, monkeypatch):
+        # Test custom URL from environment variable
+        custom_url = "https://custom.nebius.endpoint/v1"
+        monkeypatch.setenv("NEBIUS_API_BASE_URL", custom_url)
+        monkeypatch.setenv("NEBIUS_API_KEY", "test_key")
+
+        model = NebiusModel(ModelType.NEBIUS_LLAMA_3_1_8B_INSTRUCT)
+        assert model._url == custom_url
+
+    def test_nebius_model_extends_openai_compatible(self):
+        # Test that NebiusModel inherits from OpenAICompatibleModel
+        from camel.models.openai_compatible_model import OpenAICompatibleModel
+
+        model = NebiusModel(ModelType.NEBIUS_LLAMA_3_1_8B_INSTRUCT)
+        assert isinstance(model, OpenAICompatibleModel)
+
+    def test_nebius_model_token_counter(self):
+        model = NebiusModel(ModelType.NEBIUS_LLAMA_3_1_8B_INSTRUCT)
+        # Should use the default OpenAI token counter
+        assert model.token_counter is not None
+        assert hasattr(model.token_counter, "count_tokens")
+
+    @pytest.mark.parametrize(
+        "model_type",
+        [
+            ModelType.NEBIUS_LLAMA_3_1_8B_INSTRUCT,
+            ModelType.NEBIUS_LLAMA_3_1_70B_INSTRUCT,
+            ModelType.NEBIUS_LLAMA_3_1_405B_INSTRUCT,
+        ],
+    )
+    def test_nebius_model_types_available(self, model_type: ModelType):
+        # Test that all defined Nebius model types are recognized
+        assert model_type.is_nebius
+        model = NebiusModel(model_type)
+        assert isinstance(model.model_type, ModelType)

--- a/test/models/test_nebius_model.py
+++ b/test/models/test_nebius_model.py
@@ -42,11 +42,11 @@ class TestNebiusModel:
         ).as_dict()
 
         model = NebiusModel(
-            model_type=ModelType.NEBIUS_LLAMA_3_1_8B_INSTRUCT,
+            model_type=ModelType.NEBIUS_GPT_OSS_120B,
             model_config_dict=config_dict,
         )
 
-        assert model.model_type == ModelType.NEBIUS_LLAMA_3_1_8B_INSTRUCT
+        assert model.model_type == ModelType.NEBIUS_GPT_OSS_120B
         assert model.model_config_dict == config_dict
 
     def test_nebius_model_api_keys_required(self):
@@ -58,7 +58,7 @@ class TestNebiusModel:
         monkeypatch.delenv("NEBIUS_API_BASE_URL", raising=False)
         monkeypatch.setenv("NEBIUS_API_KEY", "test_key")
 
-        model = NebiusModel(ModelType.NEBIUS_LLAMA_3_1_8B_INSTRUCT)
+        model = NebiusModel(ModelType.NEBIUS_GPT_OSS_120B)
         assert model._url == "https://api.studio.nebius.com/v1"
 
     def test_nebius_model_custom_url(self, monkeypatch):
@@ -67,18 +67,18 @@ class TestNebiusModel:
         monkeypatch.setenv("NEBIUS_API_BASE_URL", custom_url)
         monkeypatch.setenv("NEBIUS_API_KEY", "test_key")
 
-        model = NebiusModel(ModelType.NEBIUS_LLAMA_3_1_8B_INSTRUCT)
+        model = NebiusModel(ModelType.NEBIUS_GPT_OSS_120B)
         assert model._url == custom_url
 
     def test_nebius_model_extends_openai_compatible(self):
         # Test that NebiusModel inherits from OpenAICompatibleModel
         from camel.models.openai_compatible_model import OpenAICompatibleModel
 
-        model = NebiusModel(ModelType.NEBIUS_LLAMA_3_1_8B_INSTRUCT)
+        model = NebiusModel(ModelType.NEBIUS_GPT_OSS_120B)
         assert isinstance(model, OpenAICompatibleModel)
 
     def test_nebius_model_token_counter(self):
-        model = NebiusModel(ModelType.NEBIUS_LLAMA_3_1_8B_INSTRUCT)
+        model = NebiusModel(ModelType.NEBIUS_GPT_OSS_120B)
         # Should use the default OpenAI token counter
         assert model.token_counter is not None
         assert hasattr(model.token_counter, "count_tokens")
@@ -86,9 +86,13 @@ class TestNebiusModel:
     @pytest.mark.parametrize(
         "model_type",
         [
-            ModelType.NEBIUS_LLAMA_3_1_8B_INSTRUCT,
-            ModelType.NEBIUS_LLAMA_3_1_70B_INSTRUCT,
-            ModelType.NEBIUS_LLAMA_3_1_405B_INSTRUCT,
+            ModelType.NEBIUS_GPT_OSS_120B,
+            ModelType.NEBIUS_GPT_OSS_20B,
+            ModelType.NEBIUS_GLM_4_5,
+            ModelType.NEBIUS_DEEPSEEK_V3,
+            ModelType.NEBIUS_DEEPSEEK_R1,
+            ModelType.NEBIUS_LLAMA_3_1_70B,
+            ModelType.NEBIUS_MISTRAL_7B_INSTRUCT,
         ],
     )
     def test_nebius_model_types_available(self, model_type: ModelType):

--- a/test/models/test_nebius_model.py
+++ b/test/models/test_nebius_model.py
@@ -17,7 +17,6 @@ import pytest
 from camel.configs import NebiusConfig
 from camel.models import NebiusModel
 from camel.types import ModelType
-from camel.utils import api_keys_required
 
 
 @pytest.mark.model_backend
@@ -25,9 +24,9 @@ class TestNebiusModel:
     @pytest.mark.parametrize(
         "model_type",
         [
-            ModelType.NEBIUS_LLAMA_3_1_8B_INSTRUCT,
-            ModelType.NEBIUS_LLAMA_3_1_70B_INSTRUCT,
-            ModelType.NEBIUS_LLAMA_3_1_405B_INSTRUCT,
+            ModelType.NEBIUS_GPT_OSS_120B,
+            ModelType.NEBIUS_GPT_OSS_20B,
+            ModelType.NEBIUS_GLM_4_5,
         ],
     )
     def test_nebius_model_create(self, model_type: ModelType):


### PR DESCRIPTION
This PR adds support for Nebius AI Studio as a new model provider.

## What's Added
- NebiusModel class with OpenAI-compatible API support
- 7 available models including GPT-OSS, GLM-4.5, DeepSeek, LLaMA, and Mistral
- Configuration class and comprehensive tests
- Usage example

## Models Supported
- GPT-OSS (120B & 20B)
- GLM-4.5 
- DeepSeek V3 & R1
- LLaMA 3.1 70B
- Mistral 7B Instruct

Fixes #3045