### PR TITLE
fix(oceanbase): fix vector index creation for oceanbase

### DIFF
--- a/camel/storages/vectordb_storages/oceanbase.py
+++ b/camel/storages/vectordb_storages/oceanbase.py
@@ -112,19 +112,19 @@ class OceanBaseStorage(BaseVectorStorage):
 
             # Create vector index
             index_params: IndexParams = IndexParams()
-            index_params.add_index_param(
-                IndexParam(
-                    index_name="embedding_idx",
-                    field_name="embedding",
-                    distance=self.distance,
-                    type="hnsw",
-                    m=16,
-                    ef_construction=256,
-                )
+            index_params.add_index(
+                field_name="embedding",
+                index_type="hnsw",
+                index_name="embedding_idx",
+                distance=self.distance,
+                m=16,
+                ef_construction=256,
             )
 
+            # Get the first index parameter
+            first_index_param = next(iter(index_params))
             self._client.create_vidx_with_vec_index_param(
-                table_name=self.table_name, vidx_param=index_params.params[0]
+                table_name=self.table_name, vidx_param=first_index_param
             )
 
             logger.info(f"Created table {self.table_name} with vector index")


### PR DESCRIPTION
## Description
add_index_param method does not exist in pyobvector, it has been checked, and it does not exist in various versions
Close #3222 

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have linked this PR to an issue using the Development section on the right sidebar or by adding `Fixes #issue-number` in the PR description (**required**)
- [x] I have checked if any dependencies need to be added or updated in `pyproject.toml` and `uv lock`
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [x] I have updated the documentation if needed:
- [x] I have added examples if this is a new feature
