### PR TITLE
feat: 解决跨系统下编码导致的乱码显示问题

### DIFF
--- a/camel/toolkits/excel_toolkit.py
+++ b/camel/toolkits/excel_toolkit.py
@@ -872,7 +872,7 @@ class ExcelToolkit(BaseToolkit):
             import csv
 
             with open(
-                resolved_csv_path, 'w', newline='', encoding='utf-8'
+                resolved_csv_path, 'w', newline='', encoding='utf-8-sig'
             ) as csvfile:
                 writer = csv.writer(csvfile)
                 writer.writerows(data)


### PR DESCRIPTION
在 Linux 环境下生成 CSV 文件后在 Windows 中打开会出现乱码，因为 Windows 系统默认对 UTF-8 编码的文件需要带有 BOM（Byte Order Mark）才能正确识别。
utf-8-sig编码与普通utf-8的区别是它会在文件开头添加一个特殊的 BOM 标识（\ufeff），这个标识对 Linux 和 macOS 系统没有影响，但能帮助 Windows 系统正确识别 UTF-8 编码，从而避免中文等非 ASCII 字符出现乱码的问题。