### PR TITLE
fix(prompt): wrap TextPrompt with str for clearer multiline display in debug view

### DIFF
--- a/camel/societies/workforce/role_playing_worker.py
+++ b/camel/societies/workforce/role_playing_worker.py
@@ -119,11 +119,13 @@ class RolePlayingWorker(Worker):
                 `TaskState.FAILED`.
         """
         dependency_tasks_info = self._get_dep_tasks_info(dependencies)
-        prompt = ROLEPLAY_PROCESS_TASK_PROMPT.format(
-            content=task.content,
-            parent_task_content=task.parent.content if task.parent else "",
-            dependency_tasks_info=dependency_tasks_info,
-            additional_info=task.additional_info,
+        prompt = str(
+            ROLEPLAY_PROCESS_TASK_PROMPT.format(
+                content=task.content,
+                parent_task_content=task.parent.content if task.parent else "",
+                dependency_tasks_info=dependency_tasks_info,
+                additional_info=task.additional_info,
+            )
         )
         role_play_session = RolePlaying(
             assistant_role_name=self.assistant_role_name,
@@ -183,12 +185,14 @@ class RolePlayingWorker(Worker):
             input_msg = assistant_response.msg
 
         chat_history_str = "\n".join(chat_history)
-        prompt = ROLEPLAY_SUMMARIZE_PROMPT.format(
-            user_role=self.user_role_name,
-            assistant_role=self.assistant_role_name,
-            content=task.content,
-            chat_history=chat_history_str,
-            additional_info=task.additional_info,
+        prompt = str(
+            ROLEPLAY_SUMMARIZE_PROMPT.format(
+                user_role=self.user_role_name,
+                assistant_role=self.assistant_role_name,
+                content=task.content,
+                chat_history=chat_history_str,
+                additional_info=task.additional_info,
+            )
         )
         if self.use_structured_output_handler and self.structured_handler:
             # Use structured output handler for prompt-based extraction

--- a/camel/societies/workforce/single_agent_worker.py
+++ b/camel/societies/workforce/single_agent_worker.py
@@ -359,11 +359,15 @@ class SingleAgentWorker(Worker):
 
         try:
             dependency_tasks_info = self._get_dep_tasks_info(dependencies)
-            prompt = PROCESS_TASK_PROMPT.format(
-                content=task.content,
-                parent_task_content=task.parent.content if task.parent else "",
-                dependency_tasks_info=dependency_tasks_info,
-                additional_info=task.additional_info,
+            prompt = str(
+                PROCESS_TASK_PROMPT.format(
+                    content=task.content,
+                    parent_task_content=task.parent.content
+                    if task.parent
+                    else "",
+                    dependency_tasks_info=dependency_tasks_info,
+                    additional_info=task.additional_info,
+                )
             )
 
             if self.use_structured_output_handler and self.structured_handler:

--- a/camel/societies/workforce/workforce.py
+++ b/camel/societies/workforce/workforce.py
@@ -863,10 +863,12 @@ class Workforce(BaseNode):
             Union[List[Task], Generator[List[Task], None, None]]:
             The subtasks or generator of subtasks.
         """
-        decompose_prompt = TASK_DECOMPOSE_PROMPT.format(
-            content=task.content,
-            child_nodes_info=self._get_child_nodes_info(),
-            additional_info=task.additional_info,
+        decompose_prompt = str(
+            TASK_DECOMPOSE_PROMPT.format(
+                content=task.content,
+                child_nodes_info=self._get_child_nodes_info(),
+                additional_info=task.additional_info,
+            )
         )
         self.task_agent.reset()
         result = task.decompose(self.task_agent, decompose_prompt)
@@ -993,16 +995,18 @@ class Workforce(BaseNode):
             ]
 
         # Format the unified analysis prompt
-        analysis_prompt = TASK_ANALYSIS_PROMPT.format(
-            task_id=task.id,
-            task_content=task.content,
-            task_result=task_result,
-            failure_count=task.failure_count,
-            task_depth=task.get_depth(),
-            assigned_worker=task.assigned_worker_id or "unknown",
-            issue_type=issue_type,
-            issue_specific_analysis=issue_analysis,
-            response_format=response_format,
+        analysis_prompt = str(
+            TASK_ANALYSIS_PROMPT.format(
+                task_id=task.id,
+                task_content=task.content,
+                task_result=task_result,
+                failure_count=task.failure_count,
+                task_depth=task.get_depth(),
+                assigned_worker=task.assigned_worker_id or "unknown",
+                issue_type=issue_type,
+                issue_specific_analysis=issue_analysis,
+                response_format=response_format,
+            )
         )
 
         try:
@@ -3121,10 +3125,12 @@ class Workforce(BaseNode):
         Returns:
             Worker: The created worker node.
         """
-        prompt = CREATE_NODE_PROMPT.format(
-            content=task.content,
-            child_nodes_info=self._get_child_nodes_info(),
-            additional_info=task.additional_info,
+        prompt = str(
+            CREATE_NODE_PROMPT.format(
+                content=task.content,
+                child_nodes_info=self._get_child_nodes_info(),
+                additional_info=task.additional_info,
+            )
         )
         # Check if we should use structured handler
         if self.use_structured_output_handler:


### PR DESCRIPTION


## Description

Wrap TextPrompt with str() to improve readability of multiline prompts in debug view.

Fixes #3336 

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have linked this PR to an issue using the Development section on the right sidebar or by adding `Fixes #issue-number` in the PR description (**required**)
- [ ] I have checked if any dependencies need to be added or updated in `pyproject.toml` and `uv lock`
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed:
- [ ] I have added examples if this is a new feature

If you are unsure about any of these, don't hesitate to ask. We are here to help!
