### PR TITLE
[feat] add browser agent memory for pruning

### DIFF
--- a/camel/agents/chat_agent.py
+++ b/camel/agents/chat_agent.py
@@ -565,7 +565,13 @@ class ChatAgent(BaseAgent):
             self.model_backend.token_counter,
             token_limit or self.model_backend.token_limit,
         )
-
+        # check the memory is a class type, then instantiate it
+        if memory is not None and inspect.isclass(memory):
+            memory = memory(
+                context_creator,
+                window_size=message_window_size,
+                agent_id=self.agent_id,
+                )
         self._memory: AgentMemory = memory or ChatHistoryMemory(
             context_creator,
             window_size=message_window_size,

--- a/camel/memories/__init__.py
+++ b/camel/memories/__init__.py
@@ -16,6 +16,7 @@ from .agent_memories import (
     ChatHistoryMemory,
     LongtermAgentMemory,
     VectorDBMemory,
+    BrowserChatHistoryMemory,
 )
 from .base import AgentMemory, BaseContextCreator, MemoryBlock
 from .blocks.chat_history_block import ChatHistoryBlock, EmptyMemoryWarning
@@ -32,6 +33,7 @@ __all__ = [
     'ScoreBasedContextCreator',
     'ChatHistoryMemory',
     'VectorDBMemory',
+    'BrowserChatHistoryMemory',
     'ChatHistoryBlock',
     'VectorDBBlock',
     'LongtermAgentMemory',

--- a/examples/agents/agent_browser_call_cache.py
+++ b/examples/agents/agent_browser_call_cache.py
@@ -1,0 +1,252 @@
+"""Example of creating a search agent with browser capabilities and tool call caching."""
+import os
+import uuid
+
+
+from camel.logger import get_logger
+
+from camel.agents.chat_agent import ChatAgent
+from camel.messages.base import BaseMessage
+from camel.models import BaseModelBackend, ModelFactory
+from camel.toolkits import (
+    ToolkitMessageIntegration, HybridBrowserToolkit)
+from camel.types import ModelPlatformType, ModelType
+from camel.memories import BrowserChatHistoryMemory
+
+
+logger = get_logger(__name__)
+WORKING_DIRECTORY = os.environ.get("CAMEL_WORKDIR") or os.path.abspath(
+    "working_dir/"
+)
+
+
+def send_message_to_user(
+    message_title: str,
+    message_description: str,
+    message_attachment: str = "",
+) -> str:
+    r"""Use this tool to send a tidy message to the user, including a
+    short title, a one-sentence description, and an optional attachment.
+
+    This one-way tool keeps the user informed about your progress,
+    decisions, or actions. It does not require a response.
+    You should use it to:
+    - Announce what you are about to do.
+      For example:
+      message_title="Starting Task"
+      message_description="Searching for papers on GUI Agents."
+    - Report the result of an action.
+      For example:
+      message_title="Search Complete"
+      message_description="Found 15 relevant papers."
+    - Report a created file.
+      For example:
+      message_title="File Ready"
+      message_description="The report is ready for your review."
+      message_attachment="report.pdf"
+    - State a decision.
+      For example:
+      message_title="Next Step"
+      message_description="Analyzing the top 10 papers."
+    - Give a status update during a long-running task.
+
+    Args:
+        message_title (str): The title of the message.
+        message_description (str): The short description.
+        message_attachment (str): The attachment of the message,
+            which can be a file path or a URL.
+
+    Returns:
+        str: Confirmation that the message was successfully sent.
+    """
+    print(f"\nAgent Message:\n{message_title} " f"\n{message_description}\n")
+    if message_attachment:
+        print(message_attachment)
+    logger.info(
+        f"\nAgent Message:\n{message_title} "
+        f"{message_description} {message_attachment}"
+    )
+    return (
+        f"Message successfully sent to user: '{message_title} "
+        f"{message_description} {message_attachment}'"
+    )
+
+
+def search_agent_factory(
+    model: BaseModelBackend,
+    task_id: str,
+):
+    r"""Factory for creating a search agent, based on user-provided code
+    structure.
+    """
+    # Initialize message integration
+    message_integration = ToolkitMessageIntegration(
+        message_handler=send_message_to_user
+    )
+
+    # Generate a unique identifier for this agent instance
+    agent_id = str(uuid.uuid4())[:8]
+
+    custom_tools = [
+        "browser_open",
+        "browser_select",
+        "browser_close",
+        "browser_back",
+        "browser_forward",
+        "browser_click",
+        "browser_type",
+        "browser_enter",
+        "browser_switch_tab",
+        "browser_visit_page",
+        "browser_get_page_snapshot",
+    ]
+    USER_DATA_DIR = os.getenv("CAMEL_BROWSER_USER_DATA_DIR", "user_data")
+    web_toolkit_custom = HybridBrowserToolkit(
+        headless=False,
+        enabled_tools=custom_tools,
+        browser_log_to_file=True,
+        stealth=True,
+        session_id=agent_id,
+        viewport_limit=False,
+        cache_dir=WORKING_DIRECTORY,
+        default_start_url="about:blank",
+        user_data_dir=USER_DATA_DIR,
+        log_dir=os.getenv("CAMEL_BROWSER_USER_LOG_DIR", "browser_logs"),
+    )
+
+    # Add messaging to toolkits
+    web_toolkit_custom = message_integration.register_toolkits(
+        web_toolkit_custom
+    )
+
+    tools = [
+        *web_toolkit_custom.get_tools(),
+    ]
+
+    system_message = """
+<role>
+You are a Senior Research Analyst, a key member of a multi-agent team. Your 
+primary responsibility is to conduct expert-level web research to gather, 
+analyze, and document information required to solve the user's task. You 
+operate with precision, efficiency, and a commitment to data quality.
+</role>
+
+<mandatory_instructions>
+- You MUST use the note-taking tools to record your findings. This is a
+    critical part of your role. Your notes are the primary source of
+    information for your teammates. To avoid information loss, you must not
+    summarize your findings. Instead, record all information in detail.
+    For every piece of information you gather, you must:
+    1.  **Extract ALL relevant details**: Quote all important sentences,
+        statistics, or data points. Your goal is to capture the information
+        as completely as possible.
+    2.  **Cite your source**: Include the exact URL where you found the
+        information.
+    Your notes should be a detailed and complete record of the information
+    you have discovered. High-quality, detailed notes are essential for the
+    team's success.
+
+- When you complete your task, your final response must be a comprehensive
+    summary of your findings, presented in a clear, detailed, and
+    easy-to-read format. Avoid using markdown tables for presenting data;
+    use plain text formatting instead.
+<mandatory_instructions>
+
+<capabilities>
+Your capabilities include:
+- Search and get information from the web using the search tools.
+- Use the rich browser related toolset to investigate websites.
+</capabilities>
+
+<web_search_workflow>
+- Browser-Based Exploration: Use the rich browser related toolset to
+    investigate websites.
+    
+    - **Navigation and Exploration**: Use `browser_visit_page` to open a URL.
+        `browser_visit_page` provides a snapshot of currently visible 
+        interactive elements, not the full page text. To see more content on 
+        long pages,  Navigate with `browser_click`, `browser_back`, and 
+        `browser_forward`. Manage multiple pages with `browser_switch_tab`.
+    - **Analysis**: Use `browser_get_som_screenshot` to understand the page 
+        layout and identify interactive elements. Since this is a heavy 
+        operation, only use it when visual analysis is necessary.
+    - **Interaction**: Use `browser_type` to fill out forms and 
+        `browser_enter` to submit or confirm search.
+
+- In your response, you should mention the URLs you have visited and processed.
+
+- When encountering verification challenges (like login, CAPTCHAs or
+    robot checks), you MUST request help using the human toolkit.
+- When encountering cookies page, you need to click accept all.
+</web_search_workflow>
+"""
+    agent = ChatAgent(
+        system_message=BaseMessage.make_assistant_message(
+            role_name="Search Agent",
+            content=system_message,
+        ),
+        model=model,
+        enable_tool_output_cache=False,
+        toolkits_to_register_agent=[web_toolkit_custom],
+        tools=tools,
+        memory=BrowserChatHistoryMemory
+    )
+
+    # Return both agent and toolkit for cleanup purposes
+    return agent, web_toolkit_custom
+
+
+async def main():
+    """Main function to run the search agent with browser capabilities and
+    tool call caching.
+    """
+    model_backend = ModelFactory.create(
+        model_platform=ModelPlatformType.OPENAI,
+        model_type=ModelType.GPT_4_1,
+        model_config_dict={
+            "stream": False,
+        },
+    )
+    search_agent, browser_toolkit = search_agent_factory(
+        model_backend, task_id=1
+    )
+    try:
+        task_message = (
+            "web: https://en.wikipedia.org/wiki/Agent"
+            "got this web and get the summary of it"
+        )
+        await search_agent.astep(input_message=task_message)
+        context = search_agent.memory.get_context()
+        # there will be 7 messages context: ([7*messages], token_count)
+        
+        print("\n--- Agent Pruned Memory Context ---")
+        # 0, system 
+        print(context[0][0]["content"])
+        # 1, user
+        print(context[0][1]["content"])
+        # 2, browse tool call
+        print(context[0][2]["content"])
+        # 3, browser content response
+        print(context[0][3]["content"])
+        # 4, snapeshot tool call
+        print(context[0][4]["content"])
+        # 5, snapshot response
+        print(context[0][5]["content"])
+        # 6, agent final response
+        print(context[0][6]["content"])
+    finally:
+        # IMPORTANT: Close browser after each task to prevent resource leaks
+        if browser_toolkit is not None:
+            try:
+                print(f"\n--- Closing Browser for Task ---")
+                await browser_toolkit.browser_close()
+                print("Browser closed successfully.")
+            except Exception as e:
+                print(f"Error closing browser: {e}")
+
+
+if __name__ == "__main__":
+    import asyncio
+    logger.info("Starting Search Agent with Browser Call Cache...")
+    asyncio.run(main())
+    logger.info("Search Agent run completed.")

--- a/examples/workforce/eigent.py
+++ b/examples/workforce/eigent.py
@@ -50,6 +50,7 @@ from camel.toolkits import (
     WebDeployToolkit,
     WhatsAppToolkit,
 )
+from camel.memories import BrowserChatHistoryMemory
 from camel.types import ModelPlatformType, ModelType
 
 logger = get_logger(__name__)
@@ -323,7 +324,7 @@ def search_agent_factory(
         "browser_visit_page",
         "browser_get_page_snapshot",
     ]
-    USER_DATA_DIR = "/Users/puzhen/Desktop/pre/camel_project/camel/UserData"
+    USER_DATA_DIR = "working_dir/user_data"
 
     web_toolkit_custom = HybridBrowserToolkit(
         headless=False,
@@ -335,7 +336,7 @@ def search_agent_factory(
         cache_dir=WORKING_DIRECTORY,
         default_start_url="about:blank",
         user_data_dir=USER_DATA_DIR,
-        log_dir="task2",
+        log_dir="search_agent_logs",
     )
 
     # Initialize toolkits
@@ -433,10 +434,10 @@ Your capabilities include:
             content=system_message,
         ),
         model=model,
-        enable_tool_output_cache=True,
         toolkits_to_register_agent=[web_toolkit_custom],
         tools=tools,
-        # prune_tool_calls_from_memory=True,
+        # browser history memory pruning for search agent
+        memory=BrowserChatHistoryMemory
     )
 
     # Return both agent and toolkit for cleanup purposes


### PR DESCRIPTION
## Description

For the browser agent, we are caching the whole content from the browser function tool.
But in history messages, we only need to keep the content-related information; the labels and content type can be pruned to reduce the whole context length.

example: examples\agents\agent_browser_call_cache.py
The pruned memory demonstration:
<img width="701" height="1193" alt="image" src="https://github.com/user-attachments/assets/f5a5b54b-5ef1-40d8-9b54-6bad797b37f0" />


## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have linked this PR to an issue using the Development section on the right sidebar or by adding `Fixes #issue-number` in the PR description (**required**)
- [x] I have checked if any dependencies need to be added or updated in `pyproject.toml` and `uv lock`
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [x] I have updated the documentation if needed:
- [x] I have added examples if this is a new feature

If you are unsure about any of these, don't hesitate to ask. We are here to help!
