### PR TITLE
feat(browser-toolkit): add reasoning parameter for browser actions

### DIFF
--- a/camel/toolkits/hybrid_browser_toolkit/hybrid_browser_toolkit.py
+++ b/camel/toolkits/hybrid_browser_toolkit/hybrid_browser_toolkit.py
@@ -77,6 +77,11 @@ class HybridBrowserToolkit(BaseToolkit):
             as snapshot instead of actual page content. The
             browser_get_page_snapshot method will still return the actual
             snapshot. Defaults to False.
+        enable_reasoning (bool): When True, adds a 'reasoning' parameter
+            to browser action methods. Agents can provide reasoning for
+            their actions which gets stored in the agent's context,
+            improving decision-making especially for actions that require
+            waiting for page updates. Defaults to False.
         **kwargs: Additional keyword arguments passed to the
             implementation.
 
@@ -109,6 +114,7 @@ class HybridBrowserToolkit(BaseToolkit):
         cdp_url: Optional[str] = None,
         cdp_keep_current_page: bool = False,
         full_visual_mode: bool = False,
+        enable_reasoning: bool = False,
         **kwargs: Any,
     ) -> Any:
         r"""Create a HybridBrowserToolkit instance with the specified mode.
@@ -165,6 +171,11 @@ class HybridBrowserToolkit(BaseToolkit):
                 as snapshot instead of actual page content. The
                 browser_get_page_snapshot method will still return the actual
                 snapshot. Defaults to False.
+            enable_reasoning (bool): When True, adds a 'reasoning' parameter
+                to browser action methods. Agents can provide reasoning for
+                their actions which gets stored in the agent's context,
+                improving decision-making especially for actions that require
+                waiting for page updates. Defaults to False.
             **kwargs: Additional keyword arguments passed to the
                 implementation.
 
@@ -198,6 +209,7 @@ class HybridBrowserToolkit(BaseToolkit):
                 cdp_url=cdp_url,
                 cdp_keep_current_page=cdp_keep_current_page,
                 full_visual_mode=full_visual_mode,
+                enable_reasoning=enable_reasoning,
                 **kwargs,
             )
         elif mode == "python":
@@ -238,6 +250,7 @@ class HybridBrowserToolkit(BaseToolkit):
                 screenshot_timeout=screenshot_timeout,
                 page_stability_timeout=page_stability_timeout,
                 dom_content_loaded_timeout=dom_content_loaded_timeout,
+                enable_reasoning=enable_reasoning,
                 **kwargs,
             )
         else:

--- a/camel/toolkits/hybrid_browser_toolkit/hybrid_browser_toolkit_ts.py
+++ b/camel/toolkits/hybrid_browser_toolkit/hybrid_browser_toolkit_ts.py
@@ -115,6 +115,7 @@ class HybridBrowserToolkit(BaseToolkit, RegisteredAgentToolkit):
         cdp_url: Optional[str] = None,
         cdp_keep_current_page: bool = False,
         full_visual_mode: bool = False,
+        enable_reasoning: bool = False,
     ) -> None:
         r"""Initialize the HybridBrowserToolkit.
 
@@ -165,6 +166,11 @@ class HybridBrowserToolkit(BaseToolkit, RegisteredAgentToolkit):
             full_visual_mode (bool): When True, browser actions like click,
             browser_open, visit_page, etc. will not return snapshots.
             Defaults to False.
+            enable_reasoning (bool): When True, adds a 'reasoning' parameter
+            to browser action methods. Agents can provide reasoning for
+            their actions which gets stored in the agent's context,
+            improving decision-making especially for actions that require
+            waiting for page updates. Defaults to False.
         """
         super().__init__()
         RegisteredAgentToolkit.__init__(self)
@@ -244,6 +250,18 @@ class HybridBrowserToolkit(BaseToolkit, RegisteredAgentToolkit):
 
         self._ws_wrapper: Optional[WebSocketBrowserWrapper] = None
         self._ws_config = self.config_loader.to_ws_config()
+
+        # Enable reasoning support if requested
+        self._enable_reasoning = enable_reasoning
+        if enable_reasoning:
+            from camel.toolkits.hybrid_browser_toolkit_py.reasoning_decorator import (
+                enable_reasoning_for_toolkit,
+            )
+
+            enable_reasoning_for_toolkit(self)
+            logger.info(
+                "Reasoning support enabled for browser toolkit actions"
+            )
 
     async def _ensure_ws_wrapper(self):
         """Ensure WebSocket wrapper is initialized."""

--- a/camel/toolkits/hybrid_browser_toolkit_py/__init__.py
+++ b/camel/toolkits/hybrid_browser_toolkit_py/__init__.py
@@ -13,5 +13,15 @@
 # ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
 
 from .hybrid_browser_toolkit import HybridBrowserToolkit
+from .reasoning_decorator import (
+    ReasoningContextManager,
+    enable_reasoning_for_toolkit,
+    with_reasoning,
+)
 
-__all__ = ["HybridBrowserToolkit"]
+__all__ = [
+    "HybridBrowserToolkit",
+    "ReasoningContextManager",
+    "enable_reasoning_for_toolkit",
+    "with_reasoning",
+]

--- a/camel/toolkits/hybrid_browser_toolkit_py/reasoning_decorator.py
+++ b/camel/toolkits/hybrid_browser_toolkit_py/reasoning_decorator.py
@@ -1,0 +1,629 @@
+# ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
+
+"""Decorator for adding reasoning capability to browser toolkit actions.
+
+This module provides a decorator that enables agents to provide reasoning
+while executing browser actions. The reasoning is stored in the agent's
+context, helping to improve decision-making especially for actions that
+require waiting for page updates.
+
+Key Features:
+    1. Required reasoning parameter for browser actions
+    2. Reasoning is injected into agent's memory for chain-of-thought
+    3. Wait suggestions when actions may trigger page updates
+    4. Internal method calls bypass the requirement automatically
+
+Example:
+    >>> from camel.toolkits.hybrid_browser_toolkit_py import (
+    ...     HybridBrowserToolkit
+    ... )
+    >>> from camel.toolkits.hybrid_browser_toolkit_py import (
+    ...     enable_reasoning_for_toolkit
+    ... )
+    >>>
+    >>> toolkit = HybridBrowserToolkit()
+    >>> toolkit = enable_reasoning_for_toolkit(toolkit)
+    >>>
+    >>> # Now browser tools require a 'reasoning' parameter
+    >>> # The reasoning is stored in context for chain-of-thought
+"""
+
+import inspect
+import time
+from contextvars import ContextVar
+from functools import wraps
+from typing import TYPE_CHECKING, Any, Callable, List, Optional
+
+from camel.logger import get_logger
+
+if TYPE_CHECKING:
+    from camel.agents import ChatAgent
+
+logger = get_logger(__name__)
+
+# Context variable to track when we're inside a reasoning-enabled action
+# This allows internal method calls to bypass reasoning requirement
+_in_reasoning_action: ContextVar[bool] = ContextVar(
+    '_in_reasoning_action', default=False
+)
+
+# Keywords that suggest waiting may be needed after an action
+_WAIT_TRIGGER_KEYWORDS = [
+    # Form submission
+    'submit',
+    'submitting',
+    'send',
+    'sending',
+    'post',
+    'posting',
+    # Authentication
+    'login',
+    'logging in',
+    'sign in',
+    'signing in',
+    'authenticate',
+    'logout',
+    'sign out',
+    # Navigation expectations
+    'navigate',
+    'navigation',
+    'redirect',
+    'redirecting',
+    'page will change',
+    'page will update',
+    'page will load',
+    'new page',
+    'next page',
+    'another page',
+    # Loading expectations
+    'load',
+    'loading',
+    'reload',
+    'reloading',
+    'refresh',
+    'wait for',
+    'waiting for',
+    'expect',
+    'expecting',
+    # Form actions
+    'confirm',
+    'confirming',
+    'save',
+    'saving',
+    'update',
+    'updating',
+    'delete',
+    'deleting',
+    'remove',
+    'removing',
+    # Payment/checkout
+    'checkout',
+    'payment',
+    'pay',
+    'purchase',
+    'order',
+    # Search
+    'search',
+    'searching',
+    'query',
+    'filter',
+    'filtering',
+]
+
+# Actions that commonly require waiting
+_WAIT_TRIGGER_ACTIONS = [
+    'browser_click',
+    'browser_enter',
+    'browser_type',  # when followed by enter
+    'browser_select',
+]
+
+
+def _should_suggest_wait(action_name: str, reasoning: str) -> bool:
+    r"""Determine if a wait suggestion should be added based on the action
+    and reasoning.
+
+    Args:
+        action_name: Name of the browser action being performed.
+        reasoning: The reasoning provided by the agent.
+
+    Returns:
+        True if waiting is likely needed after this action.
+    """
+    # Only suggest waiting for certain actions
+    if action_name not in _WAIT_TRIGGER_ACTIONS:
+        return False
+
+    # Check if reasoning contains keywords suggesting page changes
+    reasoning_lower = reasoning.lower()
+    for keyword in _WAIT_TRIGGER_KEYWORDS:
+        if keyword in reasoning_lower:
+            return True
+
+    return False
+
+
+def _create_wait_suggestion(action_name: str, reasoning: str) -> str:
+    r"""Create a wait suggestion message based on the action and reasoning.
+
+    Args:
+        action_name: Name of the browser action performed.
+        reasoning: The reasoning provided by the agent.
+
+    Returns:
+        A suggestion message for the agent.
+    """
+    # Identify what kind of wait might be needed
+    reasoning_lower = reasoning.lower()
+
+    if any(
+        kw in reasoning_lower
+        for kw in ['submit', 'login', 'sign in', 'checkout', 'payment']
+    ):
+        return (
+            "WAIT SUGGESTION: This action may trigger a form submission or "
+            "authentication. The page will likely update. Consider using "
+            "browser_wait_user(timeout_sec=3) to wait for the page to load, "
+            "then get a fresh snapshot to see the result."
+        )
+    elif any(kw in reasoning_lower for kw in ['search', 'filter', 'query']):
+        return (
+            "WAIT SUGGESTION: This action may trigger a search or filter "
+            "operation. Results may take time to load. Consider using "
+            "browser_wait_user(timeout_sec=2) before checking the results."
+        )
+    elif any(
+        kw in reasoning_lower
+        for kw in ['navigate', 'redirect', 'new page', 'next page']
+    ):
+        return (
+            "WAIT SUGGESTION: This action may cause navigation to a new page. "
+            "Use browser_wait_user(timeout_sec=3) to wait for the new page "
+            "to load before taking further actions."
+        )
+    else:
+        return (
+            "WAIT SUGGESTION: Based on your reasoning, this action may cause "
+            "page updates. Consider using browser_wait_user(timeout_sec=2) "
+            "if the page doesn't update immediately, then get a fresh "
+            "snapshot."
+        )
+
+
+def with_reasoning(func: Callable) -> Callable:
+    r"""Decorator that adds a 'reasoning' parameter to browser action methods.
+
+    When the decorated function is called with a 'reasoning' argument,
+    the reasoning is logged and optionally stored in the agent's context
+    (if an agent is registered with the toolkit).
+
+    This decorator is designed to work with async methods of browser toolkits
+    that inherit from RegisteredAgentToolkit.
+
+    Args:
+        func: The async method to decorate.
+
+    Returns:
+        The wrapped function with 'reasoning' parameter support.
+
+    Example:
+        >>> class MyToolkit(BaseToolkit, RegisteredAgentToolkit):
+        ...     @with_reasoning
+        ...     async def browser_click(self, *, ref: str) -> Dict[str, Any]:
+        ...         # Implementation
+        ...         pass
+        ...
+        >>> # Now browser_click accepts an optional 'reasoning' parameter
+    """
+    # Get the original signature
+    original_sig = inspect.signature(func)
+
+    # Check if the function is async
+    if not inspect.iscoroutinefunction(func):
+        raise TypeError(
+            f"with_reasoning decorator can only be applied to async "
+            f"functions. '{func.__name__}' is not async."
+        )
+
+    # Create new parameters list with 'reasoning' added
+    new_params = list(original_sig.parameters.values())
+
+    # Check if 'reasoning' already exists
+    if 'reasoning' not in original_sig.parameters:
+        # Add 'reasoning' as a required keyword-only parameter (no default)
+        reasoning_param = inspect.Parameter(
+            'reasoning',
+            inspect.Parameter.KEYWORD_ONLY,
+            annotation=str,  # Required string, not Optional
+        )
+
+        # Insert before **kwargs if it exists, otherwise at the end
+        insert_index = len(new_params)
+        for i, param in enumerate(new_params):
+            if param.kind == inspect.Parameter.VAR_KEYWORD:
+                insert_index = i
+                break
+
+        new_params.insert(insert_index, reasoning_param)
+
+    # Create new signature
+    new_sig = original_sig.replace(parameters=new_params)
+
+    @wraps(func)
+    async def wrapper(self, *args, **kwargs):
+        # Check if inside another reasoning-enabled action (internal call)
+        # If so, reasoning is optional to allow internal method calls
+        is_internal_call = _in_reasoning_action.get()
+
+        # Extract reasoning from kwargs
+        reasoning = kwargs.pop('reasoning', None)
+
+        if reasoning is None:
+            if not is_internal_call:
+                # External call without reasoning - raise error
+                raise TypeError(
+                    f"{func.__name__}() missing required keyword "
+                    f"argument: 'reasoning'. When reasoning is enabled, "
+                    f"you must provide a reasoning string explaining "
+                    f"why you are performing this action."
+                )
+            # Internal call without reasoning - allowed, skip processing
+        elif not isinstance(reasoning, str) or not reasoning.strip():
+            raise ValueError(
+                f"{func.__name__}() requires a non-empty reasoning string. "
+                f"Please provide a clear explanation for this action."
+            )
+        else:
+            # Process the reasoning
+            action_name = func.__name__
+            _process_reasoning(self, action_name, reasoning)
+
+        # Set context to indicate we're in a reasoning action
+        # This allows internal calls to bypass reasoning requirement
+        token = _in_reasoning_action.set(True)
+        try:
+            # Execute the original function
+            result = await func(self, *args, **kwargs)
+        finally:
+            # Reset context
+            _in_reasoning_action.reset(token)
+
+        # Add wait suggestion if appropriate (only for external calls with
+        # reasoning)
+        if reasoning and _should_suggest_wait(func.__name__, reasoning):
+            wait_suggestion = _create_wait_suggestion(func.__name__, reasoning)
+            logger.info(f"[WAIT SUGGESTION] {wait_suggestion}")
+
+            # Add to result if it's a dict
+            if isinstance(result, dict):
+                result['wait_suggestion'] = wait_suggestion
+
+            # Also inject the suggestion into agent context
+            agent: Optional["ChatAgent"] = getattr(self, '_agent', None)
+            if agent is None and hasattr(self, 'agent'):
+                agent = getattr(self, 'agent', None)
+
+            if agent is not None:
+                try:
+                    _inject_wait_suggestion_to_context(
+                        agent, func.__name__, wait_suggestion
+                    )
+                except Exception as e:
+                    logger.warning(
+                        f"Failed to inject wait suggestion into context: {e}"
+                    )
+
+        return result
+
+    # Apply the new signature
+    wrapper.__signature__ = new_sig  # type: ignore[attr-defined]
+
+    # Mark as enhanced
+    wrapper.__reasoning_enhanced__ = True  # type: ignore[attr-defined]
+
+    # Enhance docstring
+    if func.__doc__:
+        enhanced_doc = func.__doc__.rstrip()
+        # Add reasoning parameter documentation
+        reasoning_doc = (
+            "\n        reasoning (str): **Required.** Agent's reasoning "
+            "for this action.\n            The reasoning is stored in the "
+            "agent's context, helping to\n            maintain a chain of "
+            "thought during browser automation."
+        )
+
+        # Find Args section and add to it
+        if 'Args:' in enhanced_doc:
+            # Find position after last existing arg
+            lines = enhanced_doc.split('\n')
+            for i, line in enumerate(lines):
+                if line.strip().startswith('Returns:'):
+                    # Insert before Returns
+                    lines.insert(i, reasoning_doc)
+                    break
+            else:
+                # No Returns section, add at end
+                lines.append(reasoning_doc)
+            enhanced_doc = '\n'.join(lines)
+        else:
+            # No Args section exists
+            enhanced_doc += f"\n\n    Args:{reasoning_doc}"
+
+        wrapper.__doc__ = enhanced_doc
+
+    return wrapper
+
+
+def _process_reasoning(
+    toolkit_instance: Any,
+    action_name: str,
+    reasoning: str,
+) -> None:
+    r"""Process and store reasoning in the agent's context.
+
+    Args:
+        toolkit_instance: The toolkit instance (must have 'agent' attr).
+        action_name: Name of the action being performed.
+        reasoning: The reasoning text provided by the agent.
+    """
+    # Log the reasoning
+    logger.info(f"[REASONING] {action_name}: {reasoning}")
+
+    # Store in agent context if an agent is registered
+    agent: Optional["ChatAgent"] = getattr(toolkit_instance, '_agent', None)
+    if agent is None:
+        # Try the 'agent' property
+        if hasattr(toolkit_instance, 'agent'):
+            agent = getattr(toolkit_instance, 'agent', None)
+
+    if agent is not None:
+        try:
+            _inject_reasoning_to_context(agent, action_name, reasoning)
+        except Exception as e:
+            logger.warning(
+                f"Failed to inject reasoning into agent context: {e}"
+            )
+    else:
+        logger.debug(
+            "No agent registered with toolkit - reasoning logged only, "
+            "not stored in context."
+        )
+
+
+def _inject_reasoning_to_context(
+    agent: "ChatAgent",
+    action_name: str,
+    reasoning: str,
+) -> None:
+    r"""Inject reasoning into the agent's memory/context.
+
+    This creates an assistant message with the reasoning and writes it
+    to the agent's memory, making it part of the conversation history.
+
+    Args:
+        agent: The ChatAgent instance.
+        action_name: Name of the action being performed.
+        reasoning: The reasoning text.
+    """
+    from camel.memories import MemoryRecord
+    from camel.messages import BaseMessage
+    from camel.types import OpenAIBackendRole
+
+    # Format the reasoning as a message
+    reasoning_content = f"[Action Reasoning - {action_name}]\n{reasoning}"
+
+    # Create an assistant message with the reasoning
+    reasoning_message = BaseMessage.make_assistant_message(
+        role_name="assistant",
+        content=reasoning_content,
+    )
+
+    # Create a memory record
+    record = MemoryRecord(
+        message=reasoning_message,
+        role_at_backend=OpenAIBackendRole.ASSISTANT,
+        timestamp=time.time_ns() / 1_000_000_000,
+        agent_id=getattr(agent, 'agent_id', 'unknown'),
+    )
+
+    # Write to memory
+    agent.memory.write_record(record)
+    logger.debug(f"Reasoning injected into agent context for {action_name}")
+
+
+def _inject_wait_suggestion_to_context(
+    agent: "ChatAgent",
+    action_name: str,
+    wait_suggestion: str,
+) -> None:
+    r"""Inject wait suggestion into the agent's memory/context.
+
+    This creates a system-like message with the wait suggestion and writes it
+    to the agent's memory, helping the agent decide when to use
+    browser_wait_user.
+
+    Args:
+        agent: The ChatAgent instance.
+        action_name: Name of the action that was performed.
+        wait_suggestion: The wait suggestion text.
+    """
+    from camel.memories import MemoryRecord
+    from camel.messages import BaseMessage
+    from camel.types import OpenAIBackendRole
+
+    # Format the suggestion as a message
+    suggestion_content = (
+        f"[System Hint - After {action_name}]\n{wait_suggestion}"
+    )
+
+    # Create an assistant message with the suggestion
+    # Using assistant role so it appears as part of the agent's thinking
+    suggestion_message = BaseMessage.make_assistant_message(
+        role_name="assistant",
+        content=suggestion_content,
+    )
+
+    # Create a memory record
+    record = MemoryRecord(
+        message=suggestion_message,
+        role_at_backend=OpenAIBackendRole.ASSISTANT,
+        timestamp=time.time_ns() / 1_000_000_000,
+        agent_id=getattr(agent, 'agent_id', 'unknown'),
+    )
+
+    # Write to memory
+    agent.memory.write_record(record)
+    logger.debug(
+        f"Wait suggestion injected into agent context after {action_name}"
+    )
+
+
+def enable_reasoning_for_toolkit(
+    toolkit,
+    tool_names: Optional[List[str]] = None,
+) -> Any:
+    r"""Enable reasoning for specific browser toolkit methods.
+
+    This function modifies a browser toolkit instance to add reasoning
+    support to its methods. When enabled, agents can provide optional
+    reasoning when calling browser actions.
+
+    Args:
+        toolkit: The browser toolkit instance to enhance.
+        tool_names: List of tool names to enhance. If None, enhances
+            all browser action tools.
+
+    Returns:
+        The same toolkit instance with reasoning support added.
+
+    Example:
+        >>> toolkit = HybridBrowserToolkit()
+        >>> toolkit = enable_reasoning_for_toolkit(toolkit)
+        >>>
+        >>> # Now the toolkit's tools support reasoning
+        >>> result = await toolkit.browser_click(
+        ...     ref="e1",
+        ...     reasoning="Clicking submit button to submit the form"
+        ... )
+    """
+    # Default browser action tools to enhance with reasoning
+    default_tools = [
+        "browser_open",
+        "browser_close",
+        "browser_click",
+        "browser_type",
+        "browser_select",
+        "browser_scroll",
+        "browser_enter",
+        "browser_visit_page",
+        "browser_back",
+        "browser_forward",
+        "browser_wait_user",
+        "browser_press_key",
+        "browser_mouse_control",
+        "browser_mouse_drag",
+        "browser_console_exec",
+    ]
+
+    tools_to_enhance = tool_names if tool_names is not None else default_tools
+
+    import types
+
+    for tool_name in tools_to_enhance:
+        if hasattr(toolkit, tool_name):
+            method = getattr(toolkit, tool_name)
+
+            # Skip if already enhanced
+            if getattr(method, '__reasoning_enhanced__', False):
+                continue
+
+            # Check if it's an async method
+            if inspect.iscoroutinefunction(method):
+                # Get the underlying function from the bound method
+                # If it's bound, get __func__, otherwise use it directly
+                if hasattr(method, '__func__'):
+                    underlying_func = method.__func__
+                else:
+                    underlying_func = method
+
+                # Apply the with_reasoning decorator
+                enhanced_func = with_reasoning(underlying_func)
+
+                # Bind the enhanced function to the toolkit instance
+                bound_method = types.MethodType(enhanced_func, toolkit)
+                setattr(toolkit, tool_name, bound_method)
+                logger.debug(f"Enhanced {tool_name} with reasoning support")
+            else:
+                logger.debug(f"Skipping {tool_name} - not an async method")
+
+    # Mark toolkit as enhanced
+    toolkit._reasoning_enabled = True
+
+    return toolkit
+
+
+class ReasoningContextManager:
+    r"""Context manager for collecting reasoning during a browser session.
+
+    This class provides a way to collect and store all reasoning provided
+    during a browser automation session, which can be useful for debugging
+    or analysis.
+
+    Example:
+        >>> with ReasoningContextManager() as ctx:
+        ...     result = await toolkit.browser_click(
+        ...         ref="e1",
+        ...         reasoning="Clicking login button"
+        ...     )
+        ...     ctx.add_reasoning("browser_click", "Clicking login button")
+        ...
+        >>> print(ctx.get_all_reasoning())
+    """
+
+    def __init__(self):
+        self._reasoning_log: List[dict] = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return False
+
+    def add_reasoning(self, action_name: str, reasoning: str) -> None:
+        r"""Add a reasoning entry to the log.
+
+        Args:
+            action_name: Name of the action.
+            reasoning: The reasoning text.
+        """
+        self._reasoning_log.append(
+            {
+                "action": action_name,
+                "reasoning": reasoning,
+                "timestamp": time.time(),
+            }
+        )
+
+    def get_all_reasoning(self) -> List[dict]:
+        r"""Get all reasoning entries.
+
+        Returns:
+            List of reasoning entries with action names and timestamps.
+        """
+        return self._reasoning_log.copy()
+
+    def clear(self) -> None:
+        r"""Clear all reasoning entries."""
+        self._reasoning_log.clear()

--- a/examples/toolkits/browser_toolkit_with_reasoning.py
+++ b/examples/toolkits/browser_toolkit_with_reasoning.py
@@ -1,0 +1,236 @@
+# ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
+
+"""
+Example: Browser Toolkit with Reasoning Support
+
+This example demonstrates how to use the reasoning decorator with the
+HybridBrowserToolkit. The reasoning feature allows agents to provide
+explanations for their actions, which are stored in the agent's context.
+
+This is particularly useful for:
+- Improving agent decision-making by maintaining a chain of thought
+- Debugging agent behavior by seeing the reasoning behind actions
+- Better handling of actions that require waiting (e.g., after clicking submit)
+
+Usage:
+    python browser_toolkit_with_reasoning.py
+
+Requirements:
+    - Set OPENAI_API_KEY environment variable
+    - playwright installed with browsers (npx playwright install)
+"""
+
+import asyncio
+import logging
+
+from camel.agents import ChatAgent
+from camel.models import ModelFactory
+from camel.toolkits.hybrid_browser_toolkit_py import (
+    HybridBrowserToolkit,
+    ReasoningContextManager,
+    enable_reasoning_for_toolkit,
+)
+from camel.types import ModelPlatformType, ModelType
+
+# Configure logging to see reasoning messages
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+)
+logging.getLogger(
+    'camel.toolkits.hybrid_browser_toolkit_py.reasoning_decorator'
+).setLevel(logging.DEBUG)
+
+# Example 1: Create toolkit with reasoning enabled at initialization
+# This is the recommended approach - simple and clean
+print("=" * 60)
+print("Example 1: Toolkit with reasoning enabled at initialization")
+print("=" * 60)
+
+toolkit = HybridBrowserToolkit(
+    headless=True,  # Set to False to see the browser
+    enable_reasoning=True,  # Enable reasoning for all browser actions
+    enabled_tools=[
+        "browser_open",
+        "browser_close",
+        "browser_visit_page",
+        "browser_click",
+        "browser_type",
+        "browser_enter",
+        "browser_wait_user",
+    ],
+)
+
+print(f"Reasoning enabled: {toolkit._enable_reasoning}")
+print(f"Enabled tools: {toolkit.enabled_tools}")
+
+
+# Example 2: Enable reasoning on an existing toolkit
+# Use this when you want to add reasoning to a toolkit after creation
+print("\n" + "=" * 60)
+print("Example 2: Enable reasoning on existing toolkit")
+print("=" * 60)
+
+toolkit2 = HybridBrowserToolkit(headless=True)
+toolkit2 = enable_reasoning_for_toolkit(toolkit2)
+
+print(f"Reasoning enabled: {toolkit2._reasoning_enabled}")
+
+
+# Example 3: Using reasoning in browser actions (manual demonstration)
+print("\n" + "=" * 60)
+print("Example 3: Demonstrating reasoning in actions")
+print("=" * 60)
+
+
+async def demo_reasoning():
+    """Demonstrate how reasoning works with browser actions."""
+    print("\nStarting browser session...")
+
+    # Open browser and visit a page
+    result = await toolkit.browser_open()
+    print(f"Browser opened: {result.get('result', 'No result')}")
+
+    # Visit a page with reasoning (REQUIRED when reasoning is enabled)
+    # The reasoning parameter forces the agent to explain why it's
+    # performing this action - this is now mandatory, not optional
+    result = await toolkit.browser_visit_page(
+        url="https://example.com",
+        reasoning=(
+            "I'm visiting example.com to demonstrate the reasoning feature. "
+            "This page is simple and loads quickly."
+        ),
+    )
+    print(f"\nVisited page: {result.get('result', 'No result')}")
+    print("Reasoning was stored in context")
+
+    # Close the browser
+    await toolkit.browser_close()
+    print("\nBrowser closed")
+
+
+# Run the demonstration
+asyncio.run(demo_reasoning())
+
+
+# Example 4: Full agent integration with reasoning
+print("\n" + "=" * 60)
+print("Example 4: Full agent integration")
+print("=" * 60)
+
+
+async def demo_agent_with_reasoning():
+    """
+    Demonstrate using the browser toolkit with reasoning in an agent.
+
+    When the agent uses browser actions with reasoning, the reasoning
+    is automatically stored in the agent's context/memory, helping
+    maintain a chain of thought.
+    """
+    # Create model backend
+    model = ModelFactory.create(
+        model_platform=ModelPlatformType.OPENAI,
+        model_type=ModelType.GPT_4O_MINI,
+        model_config_dict={"temperature": 0.0},
+    )
+
+    # Create toolkit with reasoning enabled
+    browser_toolkit = HybridBrowserToolkit(
+        headless=True,
+        enable_reasoning=True,
+        enabled_tools=[
+            "browser_open",
+            "browser_close",
+            "browser_visit_page",
+            "browser_click",
+            "browser_type",
+            "browser_enter",
+        ],
+    )
+
+    # Create agent with the toolkit
+    # The toolkits_to_register_agent parameter is important - it allows
+    # the toolkit to access the agent's memory for storing reasoning
+    chat_agent = ChatAgent(
+        model=model,
+        tools=[*browser_toolkit.get_tools()],
+        toolkits_to_register_agent=[browser_toolkit],
+        max_iteration=5,
+        system_message="""
+        You are a web automation assistant. When performing browser
+        actions, always provide reasoning for your actions using the
+        'reasoning' parameter.
+
+        For example, when clicking a button, explain why you're clicking
+        it and what you expect to happen. This helps maintain a clear
+        chain of thought.
+
+        If an action requires waiting for page updates (like clicking
+        submit), explain this in your reasoning.
+        """,
+    )
+
+    print("Agent created with reasoning-enabled browser toolkit")
+    print("The agent will store its reasoning in context when using browser")
+    print("actions, improving decision-making for subsequent actions.")
+    print(f"Agent initialized: {chat_agent is not None}")
+
+    # Note: In a real scenario, you would have the agent perform tasks
+    # and it would automatically use the reasoning parameter when calling
+    # browser actions, with the reasoning stored in its memory.
+
+    # Clean up
+    try:
+        await browser_toolkit.browser_close()
+    except Exception:
+        pass
+
+
+# Uncomment to run the agent demo (requires OPENAI_API_KEY)
+# asyncio.run(demo_agent_with_reasoning())
+
+
+# Example 5: Using ReasoningContextManager for tracking
+print("\n" + "=" * 60)
+print("Example 5: Using ReasoningContextManager")
+print("=" * 60)
+
+# The ReasoningContextManager can be used to collect and track
+# reasoning during a browser session
+with ReasoningContextManager() as ctx:
+    # Add reasoning entries manually (in practice, this is done
+    # automatically by the decorator)
+    ctx.add_reasoning(
+        "browser_click",
+        "Clicking login button to access the user dashboard",
+    )
+    ctx.add_reasoning(
+        "browser_type",
+        "Entering username to authenticate",
+    )
+    ctx.add_reasoning(
+        "browser_wait_user",
+        "Waiting for 2FA verification to complete",
+    )
+
+    # Get all reasoning
+    all_reasoning = ctx.get_all_reasoning()
+    print(f"Collected {len(all_reasoning)} reasoning entries:")
+    for entry in all_reasoning:
+        print(f"  - {entry['action']}: {entry['reasoning'][:50]}...")
+
+print("\n" + "=" * 60)
+print("Examples complete!")
+print("=" * 60)

--- a/test/toolkits/test_reasoning_decorator.py
+++ b/test/toolkits/test_reasoning_decorator.py
@@ -1,0 +1,438 @@
+# ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
+
+"""Tests for the reasoning decorator in the browser toolkit."""
+
+import inspect
+from typing import Any, Dict
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from camel.toolkits.hybrid_browser_toolkit_py.reasoning_decorator import (
+    ReasoningContextManager,
+    enable_reasoning_for_toolkit,
+    with_reasoning,
+)
+
+
+class MockToolkit:
+    """Mock toolkit for testing the reasoning decorator."""
+
+    def __init__(self):
+        self._agent = None
+
+    async def browser_click(self, *, ref: str) -> Dict[str, Any]:
+        """Mock click action."""
+        return {"result": f"Clicked {ref}", "snapshot": "mock snapshot"}
+
+    async def browser_type(self, *, ref: str, text: str) -> Dict[str, Any]:
+        """Mock type action."""
+        return {"result": f"Typed '{text}' into {ref}", "snapshot": "mock"}
+
+
+class TestWithReasoningDecorator:
+    """Tests for the @with_reasoning decorator."""
+
+    def test_adds_reasoning_parameter(self):
+        """Test that the decorator adds a required reasoning parameter."""
+
+        @with_reasoning
+        async def sample_action(self, *, ref: str) -> Dict[str, Any]:
+            return {"ref": ref}
+
+        sig = inspect.signature(sample_action)
+        params = list(sig.parameters.keys())
+
+        assert 'reasoning' in params
+        # Reasoning should be required (no default value)
+        assert sig.parameters['reasoning'].default is inspect.Parameter.empty
+        assert sig.parameters['reasoning'].annotation is str
+
+    def test_preserves_original_parameters(self):
+        """Test that original parameters are preserved."""
+
+        @with_reasoning
+        async def sample_action(
+            self, *, ref: str, text: str = ""
+        ) -> Dict[str, Any]:
+            return {"ref": ref, "text": text}
+
+        sig = inspect.signature(sample_action)
+        params = list(sig.parameters.keys())
+
+        assert 'self' in params
+        assert 'ref' in params
+        assert 'text' in params
+        assert 'reasoning' in params
+
+    def test_raises_error_for_non_async_function(self):
+        """Test that decorator raises TypeError for non-async functions."""
+
+        with pytest.raises(TypeError, match="can only be applied to async"):
+
+            @with_reasoning
+            def sync_function(self, ref: str) -> Dict[str, Any]:
+                return {"ref": ref}
+
+    @pytest.mark.asyncio
+    async def test_function_raises_error_without_reasoning(self):
+        """Test that decorated function raises error without reasoning."""
+
+        @with_reasoning
+        async def sample_action(self, *, ref: str) -> Dict[str, Any]:
+            return {"ref": ref, "success": True}
+
+        mock_self = MockToolkit()
+
+        with pytest.raises(TypeError, match="missing required keyword"):
+            await sample_action(mock_self, ref="e1")
+
+    @pytest.mark.asyncio
+    async def test_function_raises_error_with_empty_reasoning(self):
+        """Test that decorated function raises error with empty reasoning."""
+
+        @with_reasoning
+        async def sample_action(self, *, ref: str) -> Dict[str, Any]:
+            return {"ref": ref, "success": True}
+
+        mock_self = MockToolkit()
+
+        with pytest.raises(ValueError, match="non-empty reasoning string"):
+            await sample_action(mock_self, ref="e1", reasoning="")
+
+        with pytest.raises(ValueError, match="non-empty reasoning string"):
+            await sample_action(mock_self, ref="e1", reasoning="   ")
+
+    @pytest.mark.asyncio
+    async def test_function_works_with_reasoning(self):
+        """Test that decorated function works when reasoning is provided."""
+
+        @with_reasoning
+        async def sample_action(self, *, ref: str) -> Dict[str, Any]:
+            return {"ref": ref, "success": True}
+
+        mock_self = MockToolkit()
+
+        # Patch the _process_reasoning function
+        with patch(
+            'camel.toolkits.hybrid_browser_toolkit_py.'
+            'reasoning_decorator._process_reasoning'
+        ) as mock_process:
+            result = await sample_action(
+                mock_self, ref="e1", reasoning="Clicking submit button"
+            )
+
+            # Verify _process_reasoning was called
+            mock_process.assert_called_once()
+            call_args = mock_process.call_args[0]
+            assert call_args[0] is mock_self
+            assert call_args[1] == "sample_action"
+            assert call_args[2] == "Clicking submit button"
+
+        assert result["ref"] == "e1"
+        assert result["success"] is True
+
+    def test_docstring_is_enhanced(self):
+        """Test that the decorator enhances the docstring."""
+
+        @with_reasoning
+        async def sample_action(self, *, ref: str) -> Dict[str, Any]:
+            """Click an element.
+
+            Args:
+                ref (str): The element reference.
+
+            Returns:
+                Dict: The result.
+            """
+            return {"ref": ref}
+
+        assert 'reasoning' in sample_action.__doc__
+        assert 'chain of thought' in sample_action.__doc__
+
+    def test_marks_function_as_enhanced(self):
+        """Test that the decorator marks the function as enhanced."""
+
+        @with_reasoning
+        async def sample_action(self, *, ref: str) -> Dict[str, Any]:
+            return {"ref": ref}
+
+        assert getattr(sample_action, '__reasoning_enhanced__', False) is True
+
+
+class TestEnableReasoningForToolkit:
+    """Tests for the enable_reasoning_for_toolkit function."""
+
+    def test_enhances_specified_tools(self):
+        """Test that specified tools are enhanced with reasoning."""
+        toolkit = MockToolkit()
+
+        # Verify tools don't have reasoning initially
+        original_sig = inspect.signature(toolkit.browser_click)
+        assert 'reasoning' not in original_sig.parameters
+
+        # Enable reasoning
+        enable_reasoning_for_toolkit(toolkit, tool_names=["browser_click"])
+
+        # Verify browser_click has reasoning now
+        enhanced_sig = inspect.signature(toolkit.browser_click)
+        assert 'reasoning' in enhanced_sig.parameters
+
+        # Verify browser_type was not enhanced (not in tool_names)
+        type_sig = inspect.signature(toolkit.browser_type)
+        assert 'reasoning' not in type_sig.parameters
+
+    def test_enhances_all_default_tools_when_no_names_specified(self):
+        """Test that default tools are enhanced when no names specified."""
+        toolkit = MockToolkit()
+
+        enable_reasoning_for_toolkit(toolkit)
+
+        # Both tools should have reasoning
+        click_sig = inspect.signature(toolkit.browser_click)
+        type_sig = inspect.signature(toolkit.browser_type)
+
+        assert 'reasoning' in click_sig.parameters
+        assert 'reasoning' in type_sig.parameters
+
+    def test_marks_toolkit_as_enhanced(self):
+        """Test that the toolkit is marked as having reasoning enabled."""
+        toolkit = MockToolkit()
+
+        assert not hasattr(toolkit, '_reasoning_enabled')
+
+        enable_reasoning_for_toolkit(toolkit)
+
+        assert toolkit._reasoning_enabled is True
+
+    def test_does_not_double_enhance(self):
+        """Test that tools are not enhanced twice."""
+        toolkit = MockToolkit()
+
+        # Enhance once
+        enable_reasoning_for_toolkit(toolkit)
+        sig1 = inspect.signature(toolkit.browser_click)
+
+        # Enhance again
+        enable_reasoning_for_toolkit(toolkit)
+        sig2 = inspect.signature(toolkit.browser_click)
+
+        # Signatures should be the same
+        assert list(sig1.parameters.keys()) == list(sig2.parameters.keys())
+
+
+class TestReasoningContextManager:
+    """Tests for the ReasoningContextManager class."""
+
+    def test_context_manager_entry_exit(self):
+        """Test context manager enter and exit."""
+        with ReasoningContextManager() as ctx:
+            assert ctx is not None
+            assert isinstance(ctx.get_all_reasoning(), list)
+            assert len(ctx.get_all_reasoning()) == 0
+
+    def test_add_reasoning(self):
+        """Test adding reasoning entries."""
+        ctx = ReasoningContextManager()
+
+        ctx.add_reasoning("browser_click", "Clicking submit button")
+        ctx.add_reasoning("browser_type", "Entering username")
+
+        reasoning_log = ctx.get_all_reasoning()
+
+        assert len(reasoning_log) == 2
+        assert reasoning_log[0]["action"] == "browser_click"
+        assert reasoning_log[0]["reasoning"] == "Clicking submit button"
+        assert "timestamp" in reasoning_log[0]
+        assert reasoning_log[1]["action"] == "browser_type"
+
+    def test_clear_reasoning(self):
+        """Test clearing reasoning entries."""
+        ctx = ReasoningContextManager()
+
+        ctx.add_reasoning("browser_click", "Test reasoning")
+        assert len(ctx.get_all_reasoning()) == 1
+
+        ctx.clear()
+        assert len(ctx.get_all_reasoning()) == 0
+
+    def test_get_all_reasoning_returns_copy(self):
+        """Test that get_all_reasoning returns a copy, not the original."""
+        ctx = ReasoningContextManager()
+
+        ctx.add_reasoning("browser_click", "Test")
+        log1 = ctx.get_all_reasoning()
+        log2 = ctx.get_all_reasoning()
+
+        assert log1 is not log2
+        assert log1 == log2
+
+
+class TestReasoningInjection:
+    """Tests for reasoning injection into agent context."""
+
+    @pytest.mark.asyncio
+    async def test_reasoning_injected_into_agent_memory(self):
+        """Test that reasoning is injected into agent memory."""
+
+        # Create a mock agent with memory
+        mock_agent = MagicMock()
+        mock_agent.memory = MagicMock()
+        mock_agent.agent_id = "test_agent"
+
+        toolkit = MockToolkit()
+        toolkit._agent = mock_agent
+
+        enable_reasoning_for_toolkit(toolkit)
+
+        # Call with required reasoning
+        # Note: "submit" triggers wait suggestion, so we expect 2 write_record
+        # calls - one for reasoning, one for wait suggestion
+        await toolkit.browser_click(
+            ref="e1", reasoning="Clicking the submit button"
+        )
+
+        # Verify memory.write_record was called (at least once for reasoning,
+        # possibly twice with wait suggestion)
+        assert mock_agent.memory.write_record.call_count >= 1
+
+        # Get the first record (reasoning) that was written
+        first_call_args = mock_agent.memory.write_record.call_args_list[0][0]
+        record = first_call_args[0]
+
+        # Verify the record contains the reasoning
+        assert "Clicking the submit button" in record.message.content
+        assert "browser_click" in record.message.content
+
+    @pytest.mark.asyncio
+    async def test_wait_suggestion_injected_for_submit_actions(self):
+        """Test that wait suggestion is injected when reasoning suggests
+        page updates."""
+
+        # Create a mock agent with memory
+        mock_agent = MagicMock()
+        mock_agent.memory = MagicMock()
+        mock_agent.agent_id = "test_agent"
+
+        toolkit = MockToolkit()
+        toolkit._agent = mock_agent
+
+        enable_reasoning_for_toolkit(toolkit)
+
+        # Call with reasoning that triggers wait suggestion
+        result = await toolkit.browser_click(
+            ref="e1", reasoning="Clicking submit to login"
+        )
+
+        # Should be called twice: once for reasoning, once for wait suggestion
+        assert mock_agent.memory.write_record.call_count == 2
+
+        # Check the wait suggestion was added to result
+        assert "wait_suggestion" in result
+        assert "WAIT SUGGESTION" in result["wait_suggestion"]
+
+        # Get the second record (wait suggestion)
+        second_call_args = mock_agent.memory.write_record.call_args_list[1][0]
+        wait_record = second_call_args[0]
+
+        # Verify it contains the wait suggestion
+        assert "WAIT SUGGESTION" in wait_record.message.content
+
+    @pytest.mark.asyncio
+    async def test_no_wait_suggestion_for_simple_reasoning(self):
+        """Test that no wait suggestion is added for simple actions."""
+
+        # Create a mock agent with memory
+        mock_agent = MagicMock()
+        mock_agent.memory = MagicMock()
+        mock_agent.agent_id = "test_agent"
+
+        toolkit = MockToolkit()
+        toolkit._agent = mock_agent
+
+        enable_reasoning_for_toolkit(toolkit)
+
+        # Call with reasoning that doesn't trigger wait suggestion
+        result = await toolkit.browser_click(
+            ref="e1", reasoning="Clicking the menu item to expand it"
+        )
+
+        # Should only be called once (just reasoning, no wait suggestion)
+        assert mock_agent.memory.write_record.call_count == 1
+
+        # No wait suggestion in result
+        assert "wait_suggestion" not in result
+
+    @pytest.mark.asyncio
+    async def test_no_injection_when_no_agent(self):
+        """Test that no error occurs when no agent is registered."""
+        toolkit = MockToolkit()
+        toolkit._agent = None
+
+        enable_reasoning_for_toolkit(toolkit)
+
+        # Reasoning is required but injection is optional when no agent
+        result = await toolkit.browser_click(
+            ref="e1", reasoning="Clicking element to test without agent"
+        )
+
+        assert result["result"] == "Clicked e1"
+
+    @pytest.mark.asyncio
+    async def test_reasoning_required_after_enabling(self):
+        """Test that reasoning becomes required after enabling."""
+        toolkit = MockToolkit()
+        enable_reasoning_for_toolkit(toolkit)
+
+        # Should raise error when reasoning is not provided
+        with pytest.raises(TypeError, match="missing required keyword"):
+            await toolkit.browser_click(ref="e1")
+
+
+class TestToolkitIntegration:
+    """Integration tests with the actual HybridBrowserToolkit."""
+
+    def test_enable_reasoning_parameter_exists(self):
+        """Test that enable_reasoning parameter exists in toolkit init."""
+        from camel.toolkits.hybrid_browser_toolkit_py import (
+            HybridBrowserToolkit,
+        )
+
+        sig = inspect.signature(HybridBrowserToolkit.__init__)
+        assert 'enable_reasoning' in sig.parameters
+
+    @pytest.mark.asyncio
+    async def test_toolkit_with_reasoning_enabled(self):
+        """Test creating toolkit with reasoning enabled."""
+        from camel.toolkits.hybrid_browser_toolkit_py import (
+            HybridBrowserToolkit,
+        )
+
+        toolkit = HybridBrowserToolkit(enable_reasoning=True)
+
+        # Verify reasoning is enabled
+        assert toolkit._enable_reasoning is True
+        assert hasattr(toolkit, '_reasoning_enabled')
+        assert toolkit._reasoning_enabled is True
+
+        # Verify browser_click has reasoning parameter
+        sig = inspect.signature(toolkit.browser_click)
+        assert 'reasoning' in sig.parameters
+
+        # Clean up
+        try:
+            await toolkit.browser_close()
+        except Exception:
+            pass  # Browser may not be open


### PR DESCRIPTION
## Summary
- Added `@with_reasoning` decorator requiring agents to provide reasoning for browser actions
- Reasoning is stored in agent's memory context (not just logged)
- Auto-generates wait suggestions when reasoning indicates page updates (submit, login, search)
- Updated docstrings with guidance on `browser_wait_user` usage

Closes #3494