### PR TITLE
feat: truncate terminal toolkit responses

### DIFF
--- a/camel/toolkits/terminal_toolkit/terminal_toolkit.py
+++ b/camel/toolkits/terminal_toolkit/terminal_toolkit.py
@@ -89,7 +89,7 @@ class TerminalToolkit(BaseToolkit):
         max_output_length (Optional[int]): Maximum length of output to return
             directly. If output exceeds this length, it will be saved to a
             file and a truncated response with file path will be returned.
-            Defaults to 5000 characters. Set to None to disable truncation.
+            Defaults to None.
     """
 
     def __init__(
@@ -103,7 +103,7 @@ class TerminalToolkit(BaseToolkit):
         allowed_commands: Optional[List[str]] = None,
         clone_current_env: bool = False,
         install_dependencies: Optional[List[str]] = None,
-        max_output_length: Optional[int] = 5000,
+        max_output_length: Optional[int] = None,
     ):
         # auto-detect if running inside a CAMEL runtime container
         # when inside a runtime, use local execution (already sandboxed)


### PR DESCRIPTION
## Description

Describe your changes in detail (optional if the linked issue already contains a detailed description of the changes).
- fixes https://github.com/camel-ai/camel/issues/3589
- fixes terminal_toolkit not attaching to Docker in windows

## Results:
example: Truncates the middle part and shows the first and last part.
```md
'total 31M\ndrwxr-xr-x 1 root root   4.0K Dec 16 12:14 .\ndrwxr-xr-x 1 root root   4.0K Oct 13 14:02 ..\n-rwxr-xr-x 1 root root    55K Jun 22 16:21 [\n-rwxr-xr-x 1 root root    15K Jun  5  2025 addpart\n-rwxr-xr-x 1 root root    19K Oct 22  2024 apt\n-rwxr-xr-x 1 root root    87K Oct 22  2\n\n
... OUTPUT TRUNCATED ...
\n\nx 1 root root   183K Apr  8  2024 grep\n-rwxr-xr-x 1 root root    35K Jun 22 16:21 groups\n-rwxr-xr-x 2 root root   2.3K Jan 27  2025 gunzip\n-rwxr-xr-x 1 root root   6.3K Jan 27  2025 gzexe\n'

'--- FULL OUTPUT SAVED ---\nTotal: 5111 characters\nContainer path: /workspace/terminal_logs/output_blocking_ls-usr-bin_20251217_204214_1.log\nUse shell_exec with truncate=False to view complete output,\nor read the file with: cat /workspace/terminal_logs/output_blocking_ls-usr-bin_20251217_204214_1.log'
```
FROM
```md
> bash -c "ls -lah /usr/bin | head -100"
--- Output ---
total 31M
drwxr-xr-x 1 root root   4.0K Dec 16 12:14 .
drwxr-xr-x 1 root root   4.0K Oct 13 14:02 ..
-rwxr-xr-x 1 root root    55K Jun 22 16:21 [
-rwxr-xr-x 1 root root    15K Jun  5  2025 addpart
-rwxr-xr-x 1 root root    19K Oct 22  2024 apt
-rwxr-xr-x 1 root root    87K Oct 22  2024 apt-cache
-rwxr-xr-x 1 root root    27K Oct 22  2024 apt-cdrom
-rwxr-xr-x 1 root root    31K Oct 22  2024 apt-config
-rwxr-xr-x 1 root root    51K Oct 22  2024 apt-get
-rwxr-xr-x 1 root root    28K Oct 22  2024 apt-key
-rwxr-xr-x 1 root root    55K Oct 22  2024 apt-mark
-rwxr-xr-x 1 root root    35K Jun 22 16:21 arch
lrwxrwxrwx 1 root root     21 Apr  8  2024 awk -> /etc/alternatives/awk
-rwxr-xr-x 1 root root    55K Jun 22 16:21 b2sum
-rwxr-xr-x 1 root root    39K Jun 22 16:21 base32
-rwxr-xr-x 1 root root    39K Jun 22 16:21 base64
-rwxr-xr-x 1 root root    35K Jun 22 16:21 basename
-rwxr-xr-x 1 root root    47K Jun 22 16:21 basenc
-rwxr-xr-x 1 root root   1.4M Mar 31  2024 bash
-rwxr-xr-x 1 root root   6.9K Mar 31  2024 bashbug
-rwxr-xr-x 1 root root   6.7K Sep 18 11:12 c_rehash
lrwxrwxrwx 1 root root      3 Apr  8  2024 captoinfo -> tic
-rwxr-xr-x 1 root root    39K Jun 22 16:21 cat
-rwxr-sr-x 1 root shadow  71K May 30  2024 chage
-rwxr-xr-x 1 root root    15K Apr 28  2024 chattr
-rwxr-xr-x 1 root root    59K Jun 22 16:21 chcon
-rwsr-xr-x 1 root root    72K May 30  2024 chfn
-rwxr-xr-x 1 root root    59K Jun 22 16:21 chgrp
-rwxr-xr-x 1 root root    55K Jun 22 16:21 chmod
-rwxr-xr-x 1 root root    23K Jun  5  2025 choom
-rwxr-xr-x 1 root root    59K Jun 22 16:21 chown
-rwxr-xr-x 1 root root    31K Jun  5  2025 chrt
-rwsr-xr-x 1 root root    44K May 30  2024 chsh
-rwxr-xr-x 1 root root   103K Jun 22 16:21 cksum
-rwxr-xr-x 1 root root    15K Apr  8  2024 clear
-rwxr-xr-x 1 root root    15K Mar 31  2024 clear_console
-rwxr-xr-x 1 root root    43K Apr  8  2024 cmp
-rwxr-xr-x 1 root root    39K Jun 22 16:21 comm
-rwxr-xr-x 1 root root   139K Jun 22 16:21 cp
-rwxr-xr-x 1 root root    51K Jun 22 16:21 csplit
-rwxr-xr-x 1 root root    39K Jun 22 16:21 cut
-rwxr-xr-x 1 root root   127K Mar 31  2024 dash
-rwxr-xr-x 1 root root   107K Jun 22 16:21 date
-rwxr-xr-x 1 root root    71K Jun 22 16:21 dd
-rwxr-xr-x 1 root root    24K Dec  6  2023 deb-systemd-helper
-rwxr-xr-x 1 root root   7.0K Dec  6  2023 deb-systemd-invoke
-rwxr-xr-x 1 root root   2.9K Apr 12  2024 debconf
-rwxr-xr-x 1 root root    12K Apr 12  2024 debconf-apt-progress
-rwxr-xr-x 1 root root    623 Apr 12  2024 debconf-communicate
-rwxr-xr-x 1 root root   1.7K Apr 12  2024 debconf-copydb
-rwxr-xr-x 1 root root    668 Apr 12  2024 debconf-escape
-rwxr-xr-x 1 root root   3.2K Apr 12  2024 debconf-set-selections
-rwxr-xr-x 1 root root   1.8K Apr 12  2024 debconf-show
-rwxr-xr-x 1 root root    15K Jun  5  2025 delpart
-rwxr-xr-x 1 root root    88K Jun 22 16:21 df
-rwxr-xr-x 1 root root   135K Apr  8  2024 diff
-rwxr-xr-x 1 root root    59K Apr  8  2024 diff3
-rwxr-xr-x 1 root root   139K Jun 22 16:21 dir
-rwxr-xr-x 1 root root    47K Jun 22 16:21 dircolors
-rwxr-xr-x 1 root root    35K Jun 22 16:21 dirname
-rwxr-xr-x 1 root root    69K Jun  5  2025 dmesg
lrwxrwxrwx 1 root root      8 Apr  8  2024 dnsdomainname -> hostname
lrwxrwxrwx 1 root root      8 Apr  8  2024 domainname -> hostname
-rwxr-xr-x 1 root root   311K Sep 18 17:43 dpkg
-rwxr-xr-x 1 root root   143K Sep 18 17:43 dpkg-deb
-rwxr-xr-x 1 root root   119K Sep 18 17:43 dpkg-divert
-rwxr-xr-x 1 root root    21K Sep 18 17:43 dpkg-maintscript-helper
-rwxr-xr-x 1 root root   135K Sep 18 17:43 dpkg-query
-rwxr-xr-x 1 root root   4.1K Sep 18 17:43 dpkg-realpath
-rwxr-xr-x 1 root root    99K Sep 18 17:43 dpkg-split
-rwxr-xr-x 1 root root    51K Sep 18 17:43 dpkg-statoverride
-rwxr-xr-x 1 root root    43K Sep 18 17:43 dpkg-trigger
-rwxr-xr-x 1 root root    99K Jun 22 16:21 du
-rwxr-xr-x 1 root root    35K Jun 22 16:21 echo
-rwxr-xr-x 1 root root     41 Apr  8  2024 egrep
-rwxr-xr-x 1 root root    47K Jun 22 16:21 env
-rwxr-xr-x 1 root root    35K Jun 22 16:21 expand
-rwxr-sr-x 1 root shadow  27K May 30  2024 expiry
-rwxr-xr-x 1 root root    43K Jun 22 16:21 expr
-rwxr-xr-x 1 root root    63K Jun 22 16:21 factor
-rwxr-xr-x 1 root root    23K May 30  2024 faillog
-rwxr-xr-x 1 root root    27K Jun  5  2025 fallocate
-rwxr-xr-x 1 root root    27K Jun 22 16:21 false
-rwxr-xr-x 1 root root     41 Apr  8  2024 fgrep
-rwxr-xr-x 1 root root   200K Apr  8  2024 find
-rwxr-xr-x 1 root root    68K Jun  5  2025 findmnt
-rwxr-xr-x 1 root root    23K Jun  5  2025 flock
-rwxr-xr-x 1 root root    39K Jun 22 16:21 fmt
-rwxr-xr-x 1 root root    35K Jun 22 16:21 fold
-rwxr-xr-x 1 root root    27K Sep 26  2024 free
-rwxr-xr-x 1 root root    27K Sep 17 14:55 getconf
-rwxr-xr-x 1 root root    39K Sep 17 14:55 getent
-rwxr-xr-x 1 root root    23K Jun  5  2025 getopt
-rwsr-xr-x 1 root root    75K May 30  2024 gpasswd
-rwxr-xr-x 1 root root   304K Jun 26 13:17 gpgv
-rwxr-xr-x 1 root root   183K Apr  8  2024 grep
-rwxr-xr-x 1 root root    35K Jun 22 16:21 groups
-rwxr-xr-x 2 root root   2.3K Jan 27  2025 gunzip
-rwxr-xr-x 1 root root   6.3K Jan 27  2025 gzexe

Truncated from 5111 to 500 chars
```

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have linked this PR to an issue using the Development section on the right sidebar or by adding `Fixes #issue-number` in the PR description (**required**)
- [x] I have checked if any dependencies need to be added or updated in `pyproject.toml` and `uv lock`
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed:
- [ ] I have added examples if this is a new feature

If you are unsure about any of these, don't hesitate to ask. We are here to help!
