### PR TITLE
feat: Add to_skill() method for converting toolkits to skill files

### DIFF
--- a/examples/toolkits/generated_skills/math.md
+++ b/examples/toolkits/generated_skills/math.md
@@ -1,0 +1,75 @@
+# math
+
+Mathematical operations for calculations
+
+## Available Tools
+
+### math_add
+`math_add(a: float, b: float)`
+
+Adds two numbers.
+
+**Parameters:**
+- `a` (float): The first number to be added.
+- `b` (float): The second number to be added.
+
+**Returns:** (float) The sum of the two numbers.
+
+---
+
+### math_subtract
+`math_subtract(a: float, b: float)`
+
+Do subtraction between two numbers.
+
+**Parameters:**
+- `a` (float): The minuend in subtraction.
+- `b` (float): The subtrahend in subtraction.
+
+**Returns:** (float) The result of subtracting :obj:`b` from :obj:`a`.
+
+---
+
+### math_multiply
+`math_multiply(a: float, b: float, decimal_places: int = 2)`
+
+Multiplies two numbers.
+
+**Parameters:**
+- `a` (float): The multiplier in the multiplication.
+- `b` (float): The multiplicand in the multiplication.
+- `decimal_places` (int): The number of decimal
+places to round to. Defaults to 2.
+
+**Returns:** (float) The product of the two numbers.
+
+---
+
+### math_divide
+`math_divide(a: float, b: float, decimal_places: int = 2)`
+
+Divides two numbers.
+
+**Parameters:**
+- `a` (float): The dividend in the division.
+- `b` (float): The divisor in the division.
+- `decimal_places` (int): The number of
+decimal places to round to. Defaults to 2.
+
+**Returns:** (float) The result of dividing :obj:`a` by :obj:`b`.
+
+---
+
+### math_round
+`math_round(a: float, decimal_places: int = 0)`
+
+Rounds a number to a specified number of decimal places.
+
+**Parameters:**
+- `a` (float): The number to be rounded.
+- `decimal_places` (int): The number of decimal places
+to round to. Defaults to 0.
+
+**Returns:** (float) The rounded number.
+
+---

--- a/examples/toolkits/skill_example.py
+++ b/examples/toolkits/skill_example.py
@@ -1,0 +1,144 @@
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+
+"""
+Example: Convert CAMEL Toolkit to Skill
+
+This example shows how to:
+1. Generate a skill file from a toolkit
+2. Use state persistence for stateful skills
+"""
+
+from camel.toolkits import MathToolkit, SearchToolkit
+
+# =============================================================================
+# Example 1: Basic skill generation
+# =============================================================================
+
+math_toolkit = MathToolkit()
+
+# Generate skill file
+skill_path = math_toolkit.to_skill(
+    output_dir="./examples/toolkits/generated_skills",
+    name="math",
+    description="Mathematical operations for calculations",
+)
+print(f"Generated skill: {skill_path}")
+
+# =============================================================================
+# Example 2: Custom skill content
+# =============================================================================
+
+search_toolkit = SearchToolkit()
+
+custom_content = """# Web Search
+
+Search the web using multiple search engines.
+
+## Tools
+
+### search_google
+Search Google for information.
+
+### search_duckduckgo
+Search DuckDuckGo for privacy-focused results.
+
+## Usage
+Use these tools to find up-to-date information from the web.
+"""
+
+skill_path = search_toolkit.to_skill(
+    output_dir="./examples/toolkits/generated_skills",
+    name="web-search",
+    content=custom_content,
+)
+print(f"Generated skill: {skill_path}")
+
+# =============================================================================
+# Example 3: Stateful skill with state persistence
+# =============================================================================
+
+# Save state after operations
+math_toolkit.save_state(
+    state={
+        "last_result": 42,
+        "history": ["add(1, 2)", "multiply(3, 4)"],
+    },
+    session_id="calculation-task",
+)
+print("State saved")
+
+# Later: restore state in a new session
+restored_state = math_toolkit.load_state(session_id="calculation-task")
+print(f"Restored state: {restored_state}")
+
+# =============================================================================
+# Example 4: Browser toolkit with stateful skill
+# =============================================================================
+
+# For stateful toolkits like browser, you can persist session data
+try:
+    from camel.toolkits import HybridBrowserToolkit
+
+    browser = HybridBrowserToolkit(headless=True)
+
+    # Generate skill with custom state instructions
+    browser.to_skill(
+        output_dir="./examples/toolkits/generated_skills",
+        name="browser",
+        content="""# Browser Automation
+
+Control a web browser for automation tasks.
+
+## State Management
+
+This skill persists browser state (cookies, current URL) between sessions.
+Use `session_id` to resume previous sessions.
+
+## Tools
+
+### browser_open
+Start browser and navigate to URL.
+
+### browser_click
+Click element by ref ID.
+
+### browser_type
+Type text into input field.
+
+### browser_get_page_snapshot
+Get interactive elements on current page.
+
+## Example
+
+```
+1. browser_open()
+2. browser_visit_page(url="https://example.com")
+3. snapshot = browser_get_page_snapshot()
+4. browser_click(ref="e5")
+```
+""",
+    )
+
+    # Save browser state for resumption
+    browser.save_state(
+        state={
+            "last_url": "https://example.com",
+            "cookies_saved": True,
+        },
+        session_id="browser-task-1",
+    )
+
+except ImportError:
+    print("HybridBrowserToolkit requires playwright")

--- a/test/toolkits/test_base_toolkit_skill.py
+++ b/test/toolkits/test_base_toolkit_skill.py
@@ -1,0 +1,141 @@
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+
+import tempfile
+from pathlib import Path
+
+from camel.toolkits import MathToolkit
+
+
+class TestToSkill:
+    def test_to_skill_default_name(self):
+        """Test skill generation with default name from class."""
+        toolkit = MathToolkit()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_path = toolkit.to_skill(output_dir=tmpdir)
+
+            assert skill_path.exists()
+            assert skill_path.name == "math.md"
+
+    def test_to_skill_custom_name(self):
+        """Test skill generation with custom name."""
+        toolkit = MathToolkit()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_path = toolkit.to_skill(output_dir=tmpdir, name="calculator")
+
+            assert skill_path.exists()
+            assert skill_path.name == "calculator.md"
+
+    def test_to_skill_custom_description(self):
+        """Test skill generation with custom description."""
+        toolkit = MathToolkit()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_path = toolkit.to_skill(
+                output_dir=tmpdir,
+                description="Custom math description",
+            )
+
+            content = skill_path.read_text()
+            assert "Custom math description" in content
+
+    def test_to_skill_custom_content(self):
+        """Test skill generation with fully custom content."""
+        toolkit = MathToolkit()
+        custom = "# My Custom Skill\n\nCustom content here."
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_path = toolkit.to_skill(output_dir=tmpdir, content=custom)
+
+            content = skill_path.read_text()
+            assert content == custom
+
+    def test_to_skill_contains_tools(self):
+        """Test that generated skill contains tool documentation."""
+        toolkit = MathToolkit()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_path = toolkit.to_skill(output_dir=tmpdir)
+
+            content = skill_path.read_text()
+            assert "## Available Tools" in content
+            assert "math_add" in content
+            assert "math_subtract" in content
+            assert "**Parameters:**" in content
+            assert "**Returns:**" in content
+
+
+class TestStatePersistence:
+    def test_save_and_load_state(self):
+        """Test basic state save and load."""
+        toolkit = MathToolkit()
+        test_state = {"counter": 42, "history": ["op1", "op2"]}
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            toolkit.save_state(test_state, session_id="test", state_dir=tmpdir)
+            loaded = toolkit.load_state(session_id="test", state_dir=tmpdir)
+
+            assert loaded == test_state
+
+    def test_load_nonexistent_state(self):
+        """Test loading state that doesn't exist."""
+        toolkit = MathToolkit()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            loaded = toolkit.load_state(
+                session_id="nonexistent", state_dir=tmpdir
+            )
+
+            assert loaded is None
+
+    def test_state_isolation_by_session(self):
+        """Test that different sessions have isolated state."""
+        toolkit = MathToolkit()
+        state1 = {"value": 1}
+        state2 = {"value": 2}
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            toolkit.save_state(state1, session_id="session1", state_dir=tmpdir)
+            toolkit.save_state(state2, session_id="session2", state_dir=tmpdir)
+
+            loaded1 = toolkit.load_state(
+                session_id="session1", state_dir=tmpdir
+            )
+            loaded2 = toolkit.load_state(
+                session_id="session2", state_dir=tmpdir
+            )
+
+            assert loaded1 == state1
+            assert loaded2 == state2
+
+    def test_state_overwrite(self):
+        """Test that saving state overwrites previous state."""
+        toolkit = MathToolkit()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            toolkit.save_state({"v": 1}, session_id="test", state_dir=tmpdir)
+            toolkit.save_state({"v": 2}, session_id="test", state_dir=tmpdir)
+
+            loaded = toolkit.load_state(session_id="test", state_dir=tmpdir)
+            assert loaded == {"v": 2}
+
+    def test_save_state_returns_path(self):
+        """Test that save_state returns the state file path."""
+        toolkit = MathToolkit()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = toolkit.save_state(
+                {"k": "v"}, session_id="test", state_dir=tmpdir
+            )
+
+            assert isinstance(path, Path)
+            assert path.exists()
+            assert "MathToolkit_test.json" in str(path)


### PR DESCRIPTION
## Description

  Summary

  Added a to_skill() method to BaseToolkit that generates markdown skill files from toolkit docstrings,
  along with save_state()/load_state() methods for stateful skill persistence.

  Changes

  - BaseToolkit.to_skill() - Generate skill markdown file from tool docstrings
  - BaseToolkit.save_state() / load_state() - JSON-based state persistence for stateful skills
  - Added example: examples/toolkits/skill_example.py
  - Added tests: test/toolkits/test_base_toolkit_skill.py

  Usage
```
  from camel.toolkits import MathToolkit

  toolkit = MathToolkit()

  # Generate skill file (writes to ./skills/math.md)
  toolkit.to_skill(name="math", description="Math operations")

  # For stateful skills
  toolkit.save_state({"counter": 42}, session_id="task-1")
  state = toolkit.load_state(session_id="task-1")
```
## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

- [ ] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide (**required**)
- [ ] I have linked this PR to an issue using the Development section on the right sidebar or by adding `Fixes #issue-number` in the PR description (**required**)
- [ ] I have checked if any dependencies need to be added or updated in `pyproject.toml` and `uv lock`
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed:
- [ ] I have added examples if this is a new feature

If you are unsure about any of these, don't hesitate to ask. We are here to help!
