### PR TITLE
chore: fix_stream_parallel_tool_call

### DIFF
--- a/camel/agents/chat_agent.py
+++ b/camel/agents/chat_agent.py
@@ -448,10 +448,12 @@ class ChatAgent(BaseAgent):
         step_timeout (Optional[float], optional): Timeout in seconds for the
             entire step operation. If None, no timeout is applied.
             (default: :obj:`None`)
-        stream_accumulate (bool, optional): When True, partial streaming
-            updates return accumulated content (current behavior). When False,
-            partial updates return only the incremental delta. (default:
-            :obj:`True`)
+        stream_accumulate (Optional[bool], optional): When True, partial
+            streaming updates return accumulated content. When False, partial
+            updates return only the incremental delta (recommended).
+            If None, defaults to False with a deprecation warning for users
+            who previously relied on the old default (True).
+            (default: :obj:`None`, which behaves as :obj:`False`)
         summary_window_ratio (float, optional): Maximum fraction of the total
             context window that can be occupied by summary information. Used
             to limit how much of the model's context is reserved for
@@ -501,7 +503,7 @@ class ChatAgent(BaseAgent):
         retry_attempts: int = 3,
         retry_delay: float = 1.0,
         step_timeout: Optional[float] = Constants.TIMEOUT_THRESHOLD,
-        stream_accumulate: bool = True,
+        stream_accumulate: Optional[bool] = None,
         summary_window_ratio: float = 0.6,
     ) -> None:
         if isinstance(model, ModelManager):
@@ -615,7 +617,13 @@ class ChatAgent(BaseAgent):
         self.step_timeout = step_timeout
         self._context_utility: Optional[ContextUtility] = None
         self._context_summary_agent: Optional["ChatAgent"] = None
-        self.stream_accumulate = stream_accumulate
+
+        # Store whether user explicitly set stream_accumulate
+        # Warning will be issued only when streaming is actually used
+        self._stream_accumulate_explicit = stream_accumulate is not None
+        self.stream_accumulate = (
+            stream_accumulate if stream_accumulate is not None else False
+        )
         self._last_tool_call_record: Optional[ToolCallingRecord] = None
         self._last_tool_call_signature: Optional[str] = None
         self.summary_window_ratio = summary_window_ratio
@@ -4020,6 +4028,28 @@ class ChatAgent(BaseAgent):
         # Conservative estimate: ~3 chars per token
         return len(content) // 3
 
+    def _warn_stream_accumulate_deprecation(self) -> None:
+        r"""Issue deprecation warning for stream_accumulate default change.
+
+        Only warns once per agent instance, and only if the user didn't
+        explicitly set stream_accumulate.
+        """
+        if not self._stream_accumulate_explicit:
+            import warnings
+
+            warnings.warn(
+                "The default value of 'stream_accumulate' has changed from "
+                "True to False. In streaming mode, each chunk now returns "
+                "only the incremental delta instead of accumulated content. "
+                "To suppress this warning, explicitly set "
+                "stream_accumulate=False (recommended) or stream_accumulate="
+                "True if you need the old behavior.",
+                DeprecationWarning,
+                stacklevel=5,
+            )
+            # Only warn once per agent instance
+            self._stream_accumulate_explicit = True
+
     def _stream_response(
         self,
         openai_messages: List[OpenAIMessage],
@@ -4027,6 +4057,8 @@ class ChatAgent(BaseAgent):
         response_format: Optional[Type[BaseModel]] = None,
     ) -> Generator[ChatAgentResponse, None, None]:
         r"""Internal method to handle streaming responses with tool calls."""
+
+        self._warn_stream_accumulate_deprecation()
 
         tool_call_records: List[ToolCallingRecord] = []
         accumulated_tool_calls: Dict[str, Any] = {}
@@ -4346,12 +4378,20 @@ class ChatAgent(BaseAgent):
                             content_accumulator.get_full_reasoning_content()
                             or None
                         )
+                        # In delta mode, final response content should be empty
+                        # since all content was already yielded incrementally
+                        display_content = (
+                            final_content if self.stream_accumulate else ""
+                        )
+                        display_reasoning = (
+                            final_reasoning if self.stream_accumulate else None
+                        )
                         final_message = BaseMessage(
                             role_name=self.role_name,
                             role_type=self.role_type,
                             meta_dict={},
-                            content=final_content,
-                            reasoning_content=final_reasoning,
+                            content=display_content,
+                            reasoning_content=display_reasoning,
                         )
 
                         if response_format:
@@ -4413,31 +4453,37 @@ class ChatAgent(BaseAgent):
 
             # Determine entry key
             if index is not None:
+                index_str = str(index)
                 if tool_call_id:
                     # New ID provided: check if it differs from current mapping
-                    current_key = index_map.get(index)
+                    current_key = index_map.get(index_str)
                     if current_key is None:
-                        # First time seeing this index
-                        entry_key = index
-                    elif (
-                        current_key in accumulated_tool_calls
-                        and accumulated_tool_calls[current_key].get('id')
-                        and accumulated_tool_calls[current_key]['id']
-                        != tool_call_id
-                    ):
-                        # ID changed: use new ID as key
+                        # First time seeing this index, use tool_call_id as key
                         entry_key = tool_call_id
+                    elif current_key in accumulated_tool_calls:
+                        existing_id = accumulated_tool_calls[current_key].get(
+                            'id'
+                        )
+                        if existing_id and existing_id != tool_call_id:
+                            # ID changed: use new ID as key
+                            entry_key = tool_call_id
+                        else:
+                            # No existing ID or same ID: keep current key
+                            entry_key = current_key
                     else:
                         entry_key = current_key
                     # Update mapping
-                    index_map[index] = entry_key
+                    index_map[index_str] = entry_key
                 else:
-                    # No ID in this chunk: use existing mapping or index
-                    entry_key = index_map.get(index, index)
+                    # No ID in this chunk: use existing mapping or index as
+                    # string
+                    entry_key = index_map.get(index_str, index_str)
+                    if index_str not in index_map:
+                        index_map[index_str] = entry_key
             elif tool_call_id is not None:
                 entry_key = tool_call_id
             else:
-                entry_key = 0  # Default fallback
+                entry_key = '0'  # Default fallback as string
 
             # Initialize tool call entry if not exists
             if entry_key not in accumulated_tool_calls:
@@ -4975,6 +5021,8 @@ class ChatAgent(BaseAgent):
     ) -> AsyncGenerator[ChatAgentResponse, None]:
         r"""Async method to handle streaming responses with tool calls."""
 
+        self._warn_stream_accumulate_deprecation()
+
         tool_call_records: List[ToolCallingRecord] = []
         accumulated_tool_calls: Dict[str, Any] = {}
         step_token_usage = self._create_token_usage_tracker()
@@ -5349,12 +5397,20 @@ class ChatAgent(BaseAgent):
                             content_accumulator.get_full_reasoning_content()
                             or None
                         )
+                        # In delta mode, final response content should be empty
+                        # since all content was already yielded incrementally
+                        display_content = (
+                            final_content if self.stream_accumulate else ""
+                        )
+                        display_reasoning = (
+                            final_reasoning if self.stream_accumulate else None
+                        )
                         final_message = BaseMessage(
                             role_name=self.role_name,
                             role_type=self.role_type,
                             meta_dict={},
-                            content=final_content,
-                            reasoning_content=final_reasoning,
+                            content=display_content,
+                            reasoning_content=display_reasoning,
                         )
 
                         if response_format:

--- a/examples/agents/chatagent_stream.py
+++ b/examples/agents/chatagent_stream.py
@@ -11,70 +11,73 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+
 from camel.agents import ChatAgent
 from camel.models import ModelFactory
+from camel.toolkits import MathToolkit
 from camel.types import ModelPlatformType, ModelType
 
 # Create a streaming-capable model backend
 streaming_model = ModelFactory.create(
     model_platform=ModelPlatformType.DEFAULT,
-    model_type=ModelType.GPT_4O_MINI,
+    model_type=ModelType.DEFAULT,
     model_config_dict={
         "stream": True,
         "stream_options": {"include_usage": True},
     },
 )
 
-agent_accumulated = ChatAgent(
-    system_message="You are a helpful assistant that provides detailed "
-    "and informative responses.",
+# Initialize MathToolkit for parallel calculation demo
+math_toolkit = MathToolkit()
+
+# Create agent with math tools for parallel tool call demonstration
+# stream_accumulate=False means each chunk returns only delta (incremental)
+# content
+agent_with_tools = ChatAgent(
+    system_message="You are a helpful math assistant. When asked to perform "
+    "multiple calculations, use the math tools to compute each one. "
+    "Always use the tools for calculations.",
     model=streaming_model,
+    tools=math_toolkit.get_tools(),
+    stream_accumulate=False,  # Recommended: get delta content per chunk
 )
 
-# Example user message
-user_message = "How many Rs are there in the word 'strawberry'?"
+# User message that triggers parallel tool calls
+user_message = (
+    "Please calculate the following three operations simultaneously:\n"
+    "1. 123.45 + 678.90\n"
+    "2. 100 * 3.14159\n"
+    "3. 1000 / 7"
+)
 
-# Accumulated streaming mode (default)
-streaming_response = agent_accumulated.step(user_message)
+# Stream the response with tool calls
+streaming_response = agent_with_tools.step(user_message)
 
 for chunk_response in streaming_response:
     message = chunk_response.msgs[0]
-    reasoning_text = message.reasoning_content
-    if reasoning_text:
-        print(reasoning_text, end="", flush=True)
 
-    content_text = message.content
-    if content_text:
-        print(content_text, end="", flush=True)
-usage = streaming_response.info.get("usage", {})
-print(
-    f"\n\nUsage: prompt={usage.get('prompt_tokens')}, "
-    f"completion={usage.get('completion_tokens')}, "
-    f"total={usage.get('total_tokens')}"
-)
-print("\n\n---\nDelta streaming mode (stream_accumulate=False):\n")
+    # Print reasoning content if available (for models that support it)
+    if message.reasoning_content:
+        print(message.reasoning_content, end="", flush=True)
 
-# Delta streaming mode (only new content per chunk)
-agent_delta = ChatAgent(
-    system_message="You are a helpful assistant that provides concise "
-    "and informative responses.",
-    model=streaming_model,
-    stream_accumulate=False,
-)
-
-streaming_response_delta = agent_delta.step(user_message)
-
-for chunk_response in streaming_response_delta:
-    message = chunk_response.msgs[0]
-    reasoning_delta = message.reasoning_content or ""
-    if reasoning_delta:
-        print(reasoning_delta, end="", flush=True)
-
+    # Print main content (delta mode - each chunk contains only new content)
     if message.content:
         print(message.content, end="", flush=True)
+
+# Print usage statistics
 usage = streaming_response.info.get("usage", {})
 print(
     f"\n\nUsage: prompt={usage.get('prompt_tokens')}, "
     f"completion={usage.get('completion_tokens')}, "
     f"total={usage.get('total_tokens')}"
 )
+
+# Print tool call records if any
+tool_calls = streaming_response.info.get("tool_calls", [])
+if tool_calls:
+    print(f"\nTool calls made: {len(tool_calls)}")
+    for i, tool_call in enumerate(tool_calls, 1):
+        print(
+            f"  {i}. {tool_call.tool_name}({tool_call.args}) = "
+            f"{tool_call.result}"
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,7 +188,7 @@ dev_tools = [
     "langfuse>=2.60.5",
 ]
 model_platforms = [
-    "litellm>=1.38.1,<2",
+    "litellm>=1.38.1,<1.80.12",
     "mistralai>=1.1.0,<2",
     "reka-api>=3.0.8,<4",
     "anthropic>=0.47.0,<0.50.0",
@@ -383,7 +383,7 @@ all = [
     "markitdown>=0.1.1; python_version >= '3.13'",
     "nebula3-python==3.8.2",
     "rank-bm25>=0.2.2,<0.3",
-    "litellm>=1.38.1,<2",
+    "litellm>=1.38.1,<1.80.12",
     "mistralai>=1.1.0,<2",
     "fish-audio-sdk>=1.0.0",
     "anthropic>=0.47.0,<0.50.0",

--- a/test/agents/test_chat_agent.py
+++ b/test/agents/test_chat_agent.py
@@ -736,7 +736,9 @@ def test_chat_agent_stream_output(step_call_count=3):
         model_config_dict=stream_model_config.as_dict(),
     )
     model.run = MagicMock(return_value=model_backend_rsp_base)
-    stream_assistant = ChatAgent(system_msg, model=model)
+    stream_assistant = ChatAgent(
+        system_msg, model=model, stream_accumulate=False
+    )
     stream_assistant.reset()
     for i in range(step_call_count):
         stream_assistant_response = stream_assistant.step(user_msg)
@@ -768,7 +770,7 @@ def test_chat_agent_stream_accumulate_mode_accumulated():
         "total_tokens": 0,
     }
 
-    agent = ChatAgent()
+    agent = ChatAgent(stream_accumulate=True)
     accumulator = StreamContentAccumulator()
     outputs = []
     for c in chunks:
@@ -786,7 +788,7 @@ def test_chat_agent_stream_accumulate_mode_accumulated():
 
 @pytest.mark.model_backend
 def test_chat_agent_stream_accumulate_mode_delta():
-    """Verify delta streaming behavior (stream_accumulate=False)."""
+    """Verify delta streaming behavior (stream_accumulate=False, default)."""
     chunks = ["Hello", " ", "world"]
     step_usage = {
         "completion_tokens": 0,
@@ -1471,7 +1473,9 @@ async def test_chat_agent_async_stream_with_async_generator():
         model_config_dict={"stream": True},
     )
 
-    agent = ChatAgent(system_message=system_msg, model=model)
+    agent = ChatAgent(
+        system_message=system_msg, model=model, stream_accumulate=True
+    )
 
     # Create mock streaming chunks
     chunks = [
@@ -1609,6 +1613,7 @@ async def test_chat_agent_async_stream_with_async_generator_tool_calls():
         system_message=system_msg,
         model=model,
         tools=[FunctionTool(test_add)],
+        stream_accumulate=False,
     )
 
     # Create mock streaming chunks with tool calls

--- a/uv.lock
+++ b/uv.lock
@@ -1489,8 +1489,8 @@ requires-dist = [
     { name = "langfuse", marker = "extra == 'dev-tools'", specifier = ">=2.60.5" },
     { name = "linkup-sdk", marker = "extra == 'all'", specifier = ">=0.2.1,<0.3" },
     { name = "linkup-sdk", marker = "extra == 'web-tools'", specifier = ">=0.2.1,<0.3" },
-    { name = "litellm", marker = "extra == 'all'", specifier = ">=1.38.1,<2" },
-    { name = "litellm", marker = "extra == 'model-platforms'", specifier = ">=1.38.1,<2" },
+    { name = "litellm", marker = "extra == 'all'", specifier = ">=1.38.1,<1.80.12" },
+    { name = "litellm", marker = "extra == 'model-platforms'", specifier = ">=1.38.1,<1.80.12" },
     { name = "markitdown", marker = "python_full_version >= '3.13' and extra == 'all'", specifier = ">=0.1.1" },
     { name = "markitdown", marker = "python_full_version >= '3.13' and extra == 'document-tools'", specifier = ">=0.1.1" },
     { name = "markitdown", marker = "python_full_version >= '3.13' and extra == 'eigent'", specifier = ">=0.1.1" },
@@ -7295,7 +7295,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -8266,7 +8266,7 @@ name = "pyobjc-framework-cocoa"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "python_full_version >= '3.13' or sys_platform == 'darwin'" },
+    { name = "pyobjc-core", marker = "(python_full_version >= '3.13' and sys_platform != 'win32') or sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/02/a3/16ca9a15e77c061a9250afbae2eae26f2e1579eb8ca9462ae2d2c71e1169/pyobjc_framework_cocoa-12.1.tar.gz", hash = "sha256:5556c87db95711b985d5efdaaf01c917ddd41d148b1e52a0c66b1a2e2c5c1640", size = 2772191, upload-time = "2025-11-14T10:13:02.069Z" }
 wheels = [
@@ -8284,8 +8284,8 @@ name = "pyobjc-framework-quartz"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "python_full_version >= '3.13' or sys_platform == 'darwin'" },
-    { name = "pyobjc-framework-cocoa", marker = "python_full_version >= '3.13' or sys_platform == 'darwin'" },
+    { name = "pyobjc-core", marker = "(python_full_version >= '3.13' and sys_platform != 'win32') or sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-cocoa", marker = "(python_full_version >= '3.13' and sys_platform != 'win32') or sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/94/18/cc59f3d4355c9456fc945eae7fe8797003c4da99212dd531ad1b0de8a0c6/pyobjc_framework_quartz-12.1.tar.gz", hash = "sha256:27f782f3513ac88ec9b6c82d9767eef95a5cf4175ce88a1e5a65875fee799608", size = 3159099, upload-time = "2025-11-14T10:21:24.31Z" }
 wheels = [


### PR DESCRIPTION
## Description

- Cause: In streaming mode, parallel tool-call chunks could get concatenated into a
    single arguments string (same index, ID changes or new payload after completion),
    producing invalid JSON and Extra data errors.
- Fix: Detect call boundaries during accumulation; when the tool-call ID changes or
  a completed call receives new payload, move the old entry and start a new one,
  while reusing the active entry for chunks missing index/id to avoid accidental
  merges.

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

- [ ] I have linked this PR to an issue using the Development section on the right sidebar or by adding `Fixes #issue-number` in the PR description (**required**)
- [ ] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide (**required**)
- [ ] I have checked if any dependencies need to be added or updated in `pyproject.toml` and `uv lock`
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed:
- [ ] I have added examples if this is a new feature

If you are unsure about any of these, don't hesitate to ask. We are here to help!
