### PR TITLE
chore: fix message_integration

### DIFF
--- a/camel/toolkits/message_integration.py
+++ b/camel/toolkits/message_integration.py
@@ -170,7 +170,6 @@ class ToolkitMessageIntegration:
         for tool in original_tools:
             method_name = tool.func.__name__
             enhanced_func = self._add_messaging_to_tool(tool.func)
-            # Preserve toolkit binding so cloned agents can detect/clone toolkits.
             enhanced_func = self._create_bound_method_wrapper(
                 enhanced_func,
                 toolkit,


### PR DESCRIPTION
## Description

Cause: Message-integration wrappers were lost when toolkits were cloned because
  wrapped methods no longer looked like bound toolkit methods, so cloning skipped re-
  wrapping and tool schemas still included message_* parameters.

Fix: Preserve toolkit binding on wrapped methods and ensure cloned toolkits are re-
  registered by the integration, keeping function signatures and schemas aligned and
  preventing unexpected keyword argument 'message_title' errors.

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

- [ ] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide (**required**)
- [ ] I have linked this PR to an issue using the Development section on the right sidebar or by adding `Fixes #issue-number` in the PR description (**required**)
- [ ] I have checked if any dependencies need to be added or updated in `pyproject.toml` and `uv lock`
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed:
- [ ] I have added examples if this is a new feature

If you are unsure about any of these, don't hesitate to ask. We are here to help!
