### PR TITLE
chore: fix retry when quality check failed

### DIFF
--- a/camel/societies/workforce/workforce.py
+++ b/camel/societies/workforce/workforce.py
@@ -3862,6 +3862,8 @@ class Workforce(BaseNode):
         # Record the start time when a task is posted
         self._task_start_times[task.id] = time.time()
 
+        # Ensure assignee mapping exists for retries and follow-up handling.
+        self._assignees[task.id] = assignee_id
         task.assigned_worker_id = assignee_id
 
         task_started_event = TaskStartedEvent(


### PR DESCRIPTION
## Description

Root cause:
  Quality-check recovery cleaned up task tracking (including _assignees) before
  retrying. The retry path posted the task again but did not restore the _assignees
  mapping, so subsequent quality checks could not find the assignee and logged “No
  assignee found in _assignees”.

  Fix:
  Update _post_task to always set self._assignees[task.id] = assignee_id whenever a
  task is posted. This guarantees assignee mapping is restored on retries (and any
  other reposts), preventing failures in the quality-check recovery flow.

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

- [ ] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide (**required**)
- [ ] I have linked this PR to an issue using the Development section on the right sidebar or by adding `Fixes #issue-number` in the PR description (**required**)
- [ ] I have checked if any dependencies need to be added or updated in `pyproject.toml` and `uv lock`
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed:
- [ ] I have added examples if this is a new feature

If you are unsure about any of these, don't hesitate to ask. We are here to help!
