### PR TITLE
chore: fix terminal_env_init

### DIFF
--- a/camel/toolkits/terminal_toolkit/terminal_toolkit.py
+++ b/camel/toolkits/terminal_toolkit/terminal_toolkit.py
@@ -15,7 +15,6 @@ import os
 import platform
 import select
 import shlex
-import shutil
 import subprocess
 import sys
 import threading
@@ -360,18 +359,6 @@ class TerminalToolkit(BaseToolkit):
         def update_callback(msg: str):
             logger.info(f"[ENV INIT] {msg.strip()}")
 
-        def cleanup_partial_env():
-            if os.path.exists(self.initial_env_path):
-                try:
-                    shutil.rmtree(self.initial_env_path)
-                    update_callback(
-                        "Removed partial .initial_env before retry"
-                    )
-                except Exception as exc:
-                    update_callback(
-                        f"Failed to remove partial .initial_env: {exc}"
-                    )
-
         # Try to ensure uv is available first
         success, uv_path = ensure_uv_available(update_callback)
 
@@ -389,11 +376,6 @@ class TerminalToolkit(BaseToolkit):
             success = setup_initial_env_with_venv(
                 self.initial_env_path, self.working_dir, update_callback
             )
-            if not success:
-                cleanup_partial_env()
-                success = setup_initial_env_with_venv(
-                    self.initial_env_path, self.working_dir, update_callback
-                )
 
         if success:
             # Update python executable to use the initial environment

--- a/camel/toolkits/terminal_toolkit/utils.py
+++ b/camel/toolkits/terminal_toolkit/utils.py
@@ -384,8 +384,11 @@ def setup_initial_env_with_venv(
                 symlinks=True,
             )
         except Exception:
+            # Clean up partial environment
+            if os.path.exists(env_path):
+                shutil.rmtree(env_path)
             # Fallback to symlinks=False if symlinks=True fails
-            # (e.g., on some Windows configurations)
+            # (e.g., on some Windows configurations or macOS Beta)
             venv.create(
                 env_path,
                 with_pip=True,
@@ -555,6 +558,9 @@ def clone_current_environment(
             try:
                 venv.create(env_path, with_pip=True, symlinks=True)
             except Exception:
+                # Clean up partial environment
+                if os.path.exists(env_path):
+                    shutil.rmtree(env_path)
                 # Fallback to symlinks=False if symlinks=True fails
                 venv.create(env_path, with_pip=True, symlinks=False)
 


### PR DESCRIPTION
## Description

fix: https://github.com/eigent-ai/eigent/issues/914

- Root cause: venv.create(..., symlinks=True) can segfault on macOS 26.0 Beta during
  ensurepip. The retry with symlinks=False reuses a partially created .initial_env,
  leading to shutil.SameFileError (.initial_env/bin/python points to the backend
  venv’s python).
- Fix: Before retrying the venv fallback in
  TerminalToolkit._setup_initial_environment, remove any partially
  created .initial_env and then re-run setup_initial_env_with_venv.

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

- [ ] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide (**required**)
- [ ] I have linked this PR to an issue using the Development section on the right sidebar or by adding `Fixes #issue-number` in the PR description (**required**)
- [ ] I have checked if any dependencies need to be added or updated in `pyproject.toml` and `uv lock`
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed:
- [ ] I have added examples if this is a new feature

If you are unsure about any of these, don't hesitate to ask. We are here to help!
