### PR TITLE
fix llm guard

### DIFF
--- a/camel/runtimes/llm_guard_runtime.py
+++ b/camel/runtimes/llm_guard_runtime.py
@@ -11,7 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
-import json
 import logging
 from functools import wraps
 from typing import List, Optional, Union
@@ -153,19 +152,19 @@ class LLMGuardRuntime(BaseRuntime):
                     Kwargs: {kwargs}
                     """
                 )
-                tool_call = resp.info.get("external_tool_request", None)
+                tool_call = resp.info.get("external_tool_call_requests", None)
                 if not tool_call:
                     logger.error("No tool call found in response.")
                     return {
                         "error": "Risk assessment failed. Disabling function."
                     }
-                data = tool_call.function.arguments
-                data = json.loads(data)
-                if threshold < data["score"]:
+                score = tool_call[0].args["score"]
+                reason = tool_call[0].args["reason"]
+                if threshold < score:
                     message = (
                         f"Risk assessment not passed for {function_name}."
-                        f"Score: {data['score']} > Threshold: {threshold}"
-                        f"\nReason: {data['reason']}"
+                        f"Score: {score} > Threshold: {threshold}"
+                        f"\nReason: {reason}"
                     )
                     logger.warning(message)
                     return {"error": message}
@@ -173,14 +172,14 @@ class LLMGuardRuntime(BaseRuntime):
                 logger.info(
                     (
                         f"Function {function_name} passed risk assessment."
-                        f"Score: {data['score']}, Reason: {data['reason']}"
+                        f"Score: {score}, Reason: {reason}"
                     )
                 )
                 if self.verbose:
                     print(
                         (
                             f"Function {function_name} passed risk assessment."
-                            f"Score: {data['score']}, Reason: {data['reason']}"
+                            f"Score: {score}, Reason: {reason}"
                         )
                     )
                 return inner_func(*args, **kwargs)

--- a/examples/runtimes/code_execution_with_llm_guard_runtime.py
+++ b/examples/runtimes/code_execution_with_llm_guard_runtime.py
@@ -25,9 +25,7 @@ from camel.utils import print_text_animated
 toolkit = CodeExecutionToolkit(verbose=False)
 
 
-runtime = LLMGuardRuntime(verbose=True).add(
-    *CodeExecutionToolkit().get_tools()
-)
+runtime = LLMGuardRuntime(verbose=True).add(toolkit.get_tools())
 
 tools = runtime.get_tools()
 
@@ -75,12 +73,13 @@ for msg in response.msgs:
 Tools:
 ignore_risk
 execute_code
+execute_command
 user prompt:
 Weng earns $12 an hour for babysitting. Yesterday, she just did 51 minutes of babysitting. How much did she earn?
 
-Risk assessment not passed for function execute_code.Score: 3 > Threshold: 2
-Reason: The function 'execute_code' is designed to execute arbitrary code snippets, which inherently poses a significant risk. Although the provided code snippet appears harmless and simply calculates earnings based on hourly wage and minutes worked, the function itself allows for potentially dangerous operations if different code were to be executed. Therefore, the risk level is assessed as 3.
-Ignoring risk for function execute_code: The code is a simple arithmetic calculation that poses no risk.
+2026-01-22 12:15:24,610 - camel.runtimes.llm_guard_runtime - WARNING - Risk assessment not passed for execute_code.Score: 3 > Threshold: 2
+Reason: The function executes arbitrary code snippets provided as input, which inherently poses a risk of executing harmful or malicious code. Although the given code snippet is a harmless calculation of earnings, the function itself has the potential for dangerous operations depending on the code executed.
+Ignoring risk for function execute_code: The code snippet is a simple arithmetic calculation with no potential risks or harmful operations.
 Agent response:
-Weng earned $10.20 for 51 minutes of babysitting.
+Weng earned $10.20 for babysitting for 51 minutes.
 """


### PR DESCRIPTION
currently llm guard isnt properly working ref #3735  , this pr fixes -
1. uses the correct key in the functool wrap and remove json parsing since its already a map type.
2. in the examples, the tools was being overwritten and caused another bug of not recognizing the tool.