### PR TITLE
enhance: fix terminal_env_init PR3723

### DIFF
--- a/camel/toolkits/terminal_toolkit/terminal_toolkit.py
+++ b/camel/toolkits/terminal_toolkit/terminal_toolkit.py
@@ -15,7 +15,6 @@ import os
 import platform
 import select
 import shlex
-import shutil
 import subprocess
 import sys
 import threading
@@ -360,18 +359,6 @@ class TerminalToolkit(BaseToolkit):
         def update_callback(msg: str):
             logger.info(f"[ENV INIT] {msg.strip()}")
 
-        def cleanup_partial_env():
-            if os.path.exists(self.initial_env_path):
-                try:
-                    shutil.rmtree(self.initial_env_path)
-                    update_callback(
-                        "Removed partial .initial_env before retry"
-                    )
-                except Exception as exc:
-                    update_callback(
-                        f"Failed to remove partial .initial_env: {exc}"
-                    )
-
         # Try to ensure uv is available first
         success, uv_path = ensure_uv_available(update_callback)
 
@@ -389,11 +376,6 @@ class TerminalToolkit(BaseToolkit):
             success = setup_initial_env_with_venv(
                 self.initial_env_path, self.working_dir, update_callback
             )
-            if not success:
-                cleanup_partial_env()
-                success = setup_initial_env_with_venv(
-                    self.initial_env_path, self.working_dir, update_callback
-                )
 
         if success:
             # Update python executable to use the initial environment

--- a/camel/toolkits/terminal_toolkit/utils.py
+++ b/camel/toolkits/terminal_toolkit/utils.py
@@ -384,8 +384,11 @@ def setup_initial_env_with_venv(
                 symlinks=True,
             )
         except Exception:
+            # Clean up partial environment
+            if os.path.exists(env_path):
+                shutil.rmtree(env_path)
             # Fallback to symlinks=False if symlinks=True fails
-            # (e.g., on some Windows configurations)
+            # (e.g., on some Windows configurations or macOS Beta)
             venv.create(
                 env_path,
                 with_pip=True,
@@ -555,6 +558,9 @@ def clone_current_environment(
             try:
                 venv.create(env_path, with_pip=True, symlinks=True)
             except Exception:
+                # Clean up partial environment
+                if os.path.exists(env_path):
+                    shutil.rmtree(env_path)
                 # Fallback to symlinks=False if symlinks=True fails
                 venv.create(env_path, with_pip=True, symlinks=False)
 


### PR DESCRIPTION
  - Remove redundant retry logic from terminal_toolkit.py - the retry after setup_initial_env_with_venv() returns False was
  ineffective since the function already handles internal retries
  - Add proper cleanup of partial .initial_env directory in utils.py before fallback retry with symlinks=False
  - Apply same fix to clone_current_environment() for consistency