### PR TITLE
fix: capture rich output from e2b execution results

### DIFF
--- a/camel/interpreters/e2b_interpreter.py
+++ b/camel/interpreters/e2b_interpreter.py
@@ -176,8 +176,7 @@ class E2BInterpreter(BaseInterpreter):
                 jpeg_data = result._repr_jpeg_()
                 if jpeg_data:
                     output_parts.append(
-                        f"\n![image](data:image/jpeg;base64,"
-                        f"{jpeg_data})\n"
+                        f"\n![image](data:image/jpeg;base64," f"{jpeg_data})\n"
                     )
                     continue
 


### PR DESCRIPTION
### Related Issue

  Fixes #1915

  ### Description

  E2BInterpreter.run() only checked execution.text and execution.logs,
  ignoring execution.results where the e2b SDK stores rich outputs like
  matplotlib plots (PNG/JPEG), SVG, and HTML. Added handling for these
  result types, consistent with JupyterKernelInterpreter's approach.
  Also improved error formatting and accumulated all output parts
  instead of returning on first match.

  ### What is the purpose of this pull request?

  - [X] Bug fix
  - [ ] New Feature
  - [ ] Documentation update
  - [ ] Other

  ### Checklist

  - [X] I have read and agree to the AI-Generated Code Policy
  - [X] I have linked this PR to an issue
  - [ ] I have checked if any dependencies need to be added or updated
  - [ ] I have updated the tests accordingly
  - [ ] I have updated the documentation if needed
  - [ ] I have added examples if this is a new feature
