### PR TITLE
enhance: throw runtime error on absent ffmpeg binary

### DIFF
--- a/camel/toolkits/video_download_toolkit.py
+++ b/camel/toolkits/video_download_toolkit.py
@@ -43,10 +43,13 @@ def _check_ffmpeg_installed() -> None:
         raise RuntimeError(
             "FFmpeg is not installed or not found in your system PATH. "
             "Please install FFmpeg:\n"
-            "  - Windows: 'winget install ffmpeg' or download from https://ffmpeg.org/download.html\n"
+            "  - Windows: 'winget install ffmpeg' or download "
+            "from https://ffmpeg.org/download.html\n"
             "  - macOS: 'brew install ffmpeg'\n"
-            "  - Linux: 'sudo apt install ffmpeg' or 'sudo yum install ffmpeg'\n"
-            "After installation, restart your terminal for the changes to take effect."
+            "  - Linux: 'sudo apt install ffmpeg' or 'sudo "
+            "yum install ffmpeg'\n"
+            "After installation, restart your terminal for the "
+            "changes to take effect."
         )
 
 

--- a/test/toolkits/test_video_download_function.py
+++ b/test/toolkits/test_video_download_function.py
@@ -91,7 +91,9 @@ def test_check_ffmpeg_installed_when_present():
 
 
 def test_check_ffmpeg_installed_when_missing():
-    r"""Test that _check_ffmpeg_installed raises RuntimeError when FFmpeg is missing."""
+    r"""Test that _check_ffmpeg_installed raises RuntimeError when FFmpeg is
+    missing.
+    """
     # Mock shutil.which to return None (FFmpeg not installed)
     with patch('shutil.which', return_value=None):
         with pytest.raises(RuntimeError) as exc_info:
@@ -105,7 +107,10 @@ def test_check_ffmpeg_installed_when_missing():
         assert "macOS" in error_msg
         assert "brew install ffmpeg" in error_msg
         assert "Linux" in error_msg
-        assert "apt install ffmpeg" in error_msg or "yum install ffmpeg" in error_msg
+        assert (
+            "apt install ffmpeg" in error_msg
+            or "yum install ffmpeg" in error_msg
+        )
         assert "https://ffmpeg.org/download.html" in error_msg
 
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Related Issue

<!-- REQUIRED: Link to the issue this PR resolves. PRs without a linked issue will be closed. -->
<!-- Example: Closes #123 or Fixes #456 -->

Closes #3849 

### Description
throws the below on runtime if not present, rather than an obscure error along the stack.
```
RuntimeError: FFmpeg is not installed or not found in your system PATH. Please install FFmpeg:
  - Windows: 'winget install ffmpeg' or download from https://ffmpeg.org/download.html
  - macOS: 'brew install ffmpeg'
  - Linux: 'sudo apt install ffmpeg' or 'sudo yum install ffmpeg'
After installation, restart your terminal for the changes to take effect.
```
<!-- REQUIRED: Describe what this PR does and why. PRs without a description will not be reviewed. -->

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Checklist

- [x] I have read and agree to the [AI-Generated Code Policy](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md#ai-generated-code-policy) (**required**)
- [x] I have linked this PR to an issue (**required**)
- [x] I have checked if any dependencies need to be added or updated in `pyproject.toml` and run `uv lock`
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [x] I have updated the documentation if needed
- [ ] I have added examples if this is a new feature

If you are unsure about any of these, don't hesitate to ask. We are here to help!
