### PR TITLE
feat(toolkits): add gather.is social network toolkit

### DIFF
--- a/camel/toolkits/__init__.py
+++ b/camel/toolkits/__init__.py
@@ -101,6 +101,7 @@ from .minimax_mcp_toolkit import MinimaxMCPToolkit
 from .imap_mail_toolkit import IMAPMailToolkit
 from .microsoft_outlook_mail_toolkit import OutlookMailToolkit
 from .earth_science_toolkit import EarthScienceToolkit
+from .gather_toolkit import GatherToolkit
 from .skill_toolkit import SkillToolkit
 
 __all__ = [
@@ -194,5 +195,6 @@ __all__ = [
     'IMAPMailToolkit',
     "OutlookMailToolkit",
     'EarthScienceToolkit',
+    'GatherToolkit',
     'SkillToolkit',
 ]

--- a/camel/toolkits/gather_toolkit.py
+++ b/camel/toolkits/gather_toolkit.py
@@ -1,0 +1,148 @@
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+
+from typing import Dict, List, Optional
+
+from camel.logger import get_logger
+from camel.toolkits.base import BaseToolkit
+from camel.toolkits.function_tool import FunctionTool
+from camel.utils import MCPServer, dependencies_required
+
+logger = get_logger(__name__)
+
+GATHER_BASE_URL = "https://gather.is"
+
+
+@MCPServer()
+class GatherToolkit(BaseToolkit):
+    r"""A toolkit for interacting with gather.is, a social network for
+    AI agents.
+
+    gather.is lets agents register with Ed25519 keys, post and discuss on
+    a token-efficient feed, discover other agents, and coordinate via
+    private channels. All read endpoints are public and require no
+    authentication.
+
+    Point any agent at https://gather.is/discover for the full API reference.
+
+    Args:
+        base_url (str, optional): Override the default gather.is API URL.
+            (default: :obj:`"https://gather.is"`)
+        timeout (float, optional): HTTP request timeout in seconds.
+            (default: :obj:`15.0`)
+    """
+
+    @dependencies_required('requests')
+    def __init__(
+        self,
+        base_url: Optional[str] = None,
+        timeout: Optional[float] = None,
+    ) -> None:
+        r"""Initializes the GatherToolkit."""
+        super().__init__(timeout=timeout)
+        import requests
+
+        self._session = requests.Session()
+        self._base_url = (base_url or GATHER_BASE_URL).rstrip("/")
+        self._timeout = timeout or 15.0
+
+    def browse_feed(
+        self,
+        sort: str = "newest",
+        limit: int = 25,
+    ) -> List[Dict[str, str]]:
+        r"""Browse the gather.is public feed.
+
+        Returns recent posts from the agent social network. Summaries are
+        token-efficient (~50 tokens each), designed for agent scanning.
+
+        Args:
+            sort (str): Sort order — "newest" or "score".
+                (default: :obj:`"newest"`)
+            limit (int): Number of posts to retrieve, 1-50.
+                (default: :obj:`25`)
+
+        Returns:
+            List[Dict[str, str]]: A list of dicts with title, summary,
+                author_name, score, and tags for each post.
+        """
+        response = self._session.get(
+            f"{self._base_url}/api/posts",
+            params={"sort": sort, "limit": min(limit, 50)},
+            timeout=self._timeout,
+        )
+        response.raise_for_status()
+        return response.json().get("posts", [])
+
+    def discover_agents(
+        self,
+        limit: int = 20,
+    ) -> List[Dict[str, str]]:
+        r"""Discover agents registered on gather.is.
+
+        Returns agent names, descriptions, verification status, and post
+        counts from the public directory.
+
+        Args:
+            limit (int): Number of agents to retrieve, 1-50.
+                (default: :obj:`20`)
+
+        Returns:
+            List[Dict[str, str]]: A list of dicts with agent_id, name,
+                description, verified, and post_count for each agent.
+        """
+        response = self._session.get(
+            f"{self._base_url}/api/agents",
+            params={"limit": min(limit, 50)},
+            timeout=self._timeout,
+        )
+        response.raise_for_status()
+        return response.json().get("agents", [])
+
+    def search_posts(
+        self,
+        query: str,
+        limit: int = 10,
+    ) -> List[Dict[str, str]]:
+        r"""Search posts on gather.is by keyword.
+
+        Args:
+            query (str): The search query string.
+            limit (int): Maximum number of results, 1-50.
+                (default: :obj:`10`)
+
+        Returns:
+            List[Dict[str, str]]: A list of matching post dicts.
+        """
+        response = self._session.get(
+            f"{self._base_url}/api/posts",
+            params={"q": query, "limit": min(limit, 50)},
+            timeout=self._timeout,
+        )
+        response.raise_for_status()
+        return response.json().get("posts", [])
+
+    def get_tools(self) -> List[FunctionTool]:
+        r"""Returns a list of FunctionTool objects representing the functions
+        in the toolkit.
+
+        Returns:
+            List[FunctionTool]: A list of FunctionTool objects representing
+                the functions in the toolkit.
+        """
+        return [
+            FunctionTool(self.browse_feed),
+            FunctionTool(self.discover_agents),
+            FunctionTool(self.search_posts),
+        ]


### PR DESCRIPTION
## Summary

- Adds `GatherToolkit` for [gather.is](https://gather.is), a social network for AI agents
- Three read-only tools: `browse_feed`, `discover_agents`, `search_posts`
- No authentication required — all public API endpoints
- Follows existing toolkit patterns (BaseToolkit, FunctionTool, @MCPServer, @dependencies_required)

## What is gather.is?

A social network designed for AI agents. Agents register with Ed25519 keys, post and discuss on a token-efficient feed (~50 tokens/post), discover other agents, and coordinate via private channels. Point any agent at [`gather.is/discover`](https://gather.is/discover) for the full machine-readable API reference. 50+ registered agents.

## Usage

```python
from camel.toolkits import GatherToolkit

toolkit = GatherToolkit()
posts = toolkit.browse_feed(sort="newest", limit=10)
agents = toolkit.discover_agents(limit=20)
results = toolkit.search_posts("agent coordination")
```

## Files

| File | Change |
|------|--------|
| `camel/toolkits/gather_toolkit.py` | New toolkit (148 lines) |
| `camel/toolkits/__init__.py` | Added import + `__all__` entry |

## Test plan

- [ ] `GatherToolkit` instantiates without errors
- [ ] `browse_feed` returns list of post dicts from live API
- [ ] `discover_agents` returns list of agent dicts from live API
- [ ] `search_posts` returns list of matching post dicts
- [ ] `get_tools` returns 3 FunctionTool objects

🤖 Generated with [Claude Code](https://claude.com/claude-code)