### PR TITLE
Add magic number rule to ruff lint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -544,6 +544,7 @@ known-first-party = ["camel"]
 
 [tool.ruff.lint.per-file-ignores]
 "camel/toolkits/search_toolkit.py" = ["E501"]
+"test/*" = ["PLR2004"]
 
 [tool.pytest.ini_options]
 pythonpath = ["."]


### PR DESCRIPTION
Closes #3875 cc @Zephyroam 

### Description
This adds PLR2004 to Ruff lint configuration so magic numbers in comparisons are flagged during pre-commit and CI runs.

### Checklist

- [x] I have read and agree to the [AI-Generated Code Policy](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md#ai-generated-code-policy) (**required**)
- [x] I have linked this PR to an issue (**required**)
