### PR TITLE
docs: standardize docstrings in agents, models, memories (#911)

### DIFF
--- a/camel/agents/chat_agent.py
+++ b/camel/agents/chat_agent.py
@@ -165,6 +165,18 @@ SIMPLE_FORMAT_PROMPT = TextPrompt(
 
 @dataclass
 class _ToolOutputHistoryEntry:
+    r"""Represents one tool output entry stored in conversation history.
+
+    Args:
+        tool_name (str): Name of the executed tool.
+        tool_call_id (str): Identifier of the tool call.
+        result_text (str): Text result returned by the tool.
+        record_uuids (List[str]): UUIDs of memory records tied to this result.
+        record_timestamps (List[float]): Timestamps for related records.
+        cached (bool, optional): Whether the result came from cache.
+            (default: :obj:`False`)
+    """
+
     tool_name: str
     tool_call_id: str
     result_text: str
@@ -174,8 +186,13 @@ class _ToolOutputHistoryEntry:
 
 
 class StreamContentAccumulator:
-    r"""Manages content accumulation across streaming responses to ensure
-    all responses contain complete cumulative content."""
+    r"""Manages content accumulation across streaming
+    responses to ensure all responses contain complete
+    cumulative content.
+
+    Args:
+        None.
+    """
 
     def __init__(self):
         self.base_content = ""  # Content before tool calls
@@ -233,6 +250,10 @@ class StreamingChatAgentResponse:
     This class wraps a Generator[ChatAgentResponse, None, None] and provides
     the same interface as ChatAgentResponse, so existing code doesn't need to
     change.
+
+    Args:
+        generator (Generator[ChatAgentResponse, None, None]): Streaming
+            generator that yields partial responses.
     """
 
     def __init__(self, generator: Generator[ChatAgentResponse, None, None]):
@@ -310,6 +331,10 @@ class AsyncStreamingChatAgentResponse:
 
     This class wraps an AsyncGenerator[ChatAgentResponse, None] and provides
     both awaitable and async iterable interfaces.
+
+    Args:
+        async_generator (AsyncGenerator[ChatAgentResponse, None]): Async
+            streaming generator that yields partial responses.
     """
 
     def __init__(

--- a/camel/agents/knowledge_graph_agent.py
+++ b/camel/agents/knowledge_graph_agent.py
@@ -117,22 +117,21 @@ class KnowledgeGraphAgent(ChatAgent):
     r"""An agent that can extract node and relationship information for
     different entities from given `Element` content.
 
+    Args:
+        model (BaseModelBackend, optional): Model backend used to generate
+            responses. (default: :obj:`OpenAIModel` with
+            :obj:`ModelType.GPT_4O_MINI`)
+
     Attributes:
-        task_prompt (TextPrompt): A prompt for the agent to extract node and
-            relationship information for different entities.
+        task_prompt (TextPrompt): Prompt used to extract nodes and
+            relationships for entities.
     """
 
     def __init__(
         self,
         model: Optional[BaseModelBackend] = None,
     ) -> None:
-        r"""Initialize the `KnowledgeGraphAgent`.
-
-        Args:
-        model (BaseModelBackend, optional): The model backend to use for
-            generating responses. (default: :obj:`OpenAIModel` with
-            `GPT_4O_MINI`)
-        """
+        r"""Initialize the `KnowledgeGraphAgent`."""
         system_message = BaseMessage(
             role_name="Graphify",
             role_type=RoleType.ASSISTANT,

--- a/camel/agents/mcp_agent.py
+++ b/camel/agents/mcp_agent.py
@@ -104,26 +104,29 @@ Please answer me according to the result directly.
 @track_agent(name="MCPAgent")
 class MCPAgent(ChatAgent):
     r"""A specialized agent designed to interact with MCP registries.
+
     The MCPAgent enhances a base ChatAgent by integrating MCP tools from
     various registries for search capabilities.
 
-    Attributes:
-        system_message (Optional[str]): The system message for the chat agent.
-            (default: :str:`"You are an assistant with search capabilities
-            using MCP tools."`)
-        model (BaseModelBackend): The model backend to use for generating
-            responses. (default: :obj:`ModelPlatformType.DEFAULT` with
-            `ModelType.DEFAULT`)
+    Args:
+        system_message (Optional[Union[str, BaseMessage]], optional): System
+            message for the agent. (default: :obj:`"You are an assistant with
+            search capabilities using MCP tools."`)
+        model (BaseModelBackend, optional): Model backend for responses.
+            (default: :obj:`ModelPlatformType.DEFAULT` with
+            :obj:`ModelType.DEFAULT`)
         registry_configs (List[BaseMCPRegistryConfig]): List of registry
-            configurations (default: :obj:`None`)
+            configurations. (default: :obj:`None`)
         local_config (Optional[Dict[str, Any]]): The local configuration for
             the MCP agent. (default: :obj:`None`)
         local_config_path (Optional[str]): The path to the local configuration
             file for the MCP agent. (default: :obj:`None`)
+        tools (Optional[List[Union[FunctionTool, Callable]]], optional):
+            Tools exposed to the agent. (default: :obj:`None`)
         function_calling_available (bool): Flag indicating whether the
             model is equipped with the function calling ability.
             (default: :obj:`True`)
-        **kwargs: Inherited from ChatAgent
+        **kwargs: Additional keyword arguments for :obj:`ChatAgent`.
     """
 
     def __init__(

--- a/camel/agents/multi_hop_generator_agent.py
+++ b/camel/agents/multi_hop_generator_agent.py
@@ -37,6 +37,10 @@ class MultiHopGeneratorAgent(ProgrammableChatAgent):
     facts and generates questions that require connecting these facts
     logically.
 
+    Args:
+        **kwargs (Any): Additional keyword arguments passed to
+            :obj:`ProgrammableChatAgent`.
+
     Attributes:
         model_config (ConfigDict): Configuration for model behavior.
         system_message (BaseMessage): System message defining agent's role and
@@ -46,12 +50,7 @@ class MultiHopGeneratorAgent(ProgrammableChatAgent):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     def __init__(self, **kwargs: Any) -> None:
-        r"""Initialize the MultiHopGeneratorAgent.
-
-        Args:
-            **kwargs (Any): Additional keyword arguments to pass to parent
-                class.
-        """
+        r"""Initialize the MultiHopGeneratorAgent."""
         super().__init__(**kwargs)
 
         system_text: str = textwrap.dedent(

--- a/camel/agents/programmed_agent_instruction.py
+++ b/camel/agents/programmed_agent_instruction.py
@@ -45,10 +45,10 @@ class ProgrammedAgentInstructionResult(BaseModel, Generic[T]):
     Contains the messages exchanged during execution and the computed value.
     The value type is specified by the generic type parameter T.
 
-    Attributes:
-        user_message (BaseMessage): The message sent by the user.
-        agent_message (BaseMessage): The message sent by the agent.
-        value (T): The computed result value of type T.
+    Args:
+        user_message (BaseMessage): Message sent by the user.
+        agent_message (BaseMessage): Message sent by the agent.
+        value (T): Computed result value.
     """
 
     user_message: BaseMessage
@@ -143,6 +143,10 @@ class ProgrammableChatAgent(ChatAgent, AbstractProgrammableAgent):
     and basic state tracking for message roles. Implementing classes need to
     provide specific repair logic for their use cases.
 
+    Args:
+        **kwargs (Any): Additional keyword arguments passed to
+            :obj:`ChatAgent`.
+
     Attributes:
         _operation_lock (threading.Lock): Lock for ensuring atomic operations.
         _last_message_role (Optional[str]): Role of the last message in the
@@ -150,12 +154,7 @@ class ProgrammableChatAgent(ChatAgent, AbstractProgrammableAgent):
     """
 
     def __init__(self, **kwargs: Any) -> None:
-        r"""Initialize the ProgrammableChatAgent.
-
-        Args:
-            **kwargs (Any): Additional keyword arguments to pass to parent
-                class.
-        """
+        r"""Initialize the ProgrammableChatAgent."""
         super().__init__(**kwargs)
         self._operation_lock = threading.Lock()
         self._last_message_role: Optional[str] = None

--- a/camel/agents/repo_agent.py
+++ b/camel/agents/repo_agent.py
@@ -40,6 +40,8 @@ logger = get_logger(__name__)
 
 
 class ProcessingMode(Enum):
+    r"""Defines repository processing modes for context construction."""
+
     FULL_CONTEXT = auto()
     RAG = auto()
 
@@ -47,7 +49,7 @@ class ProcessingMode(Enum):
 class GitHubFile(BaseModel):
     r"""Model to hold GitHub file information.
 
-    Attributes:
+    Args:
         content (str): The content of the GitHub text.
         file_path (str): The path of the file.
         html_url (str): The actual url of the file.
@@ -61,10 +63,11 @@ class GitHubFile(BaseModel):
 class RepositoryInfo(BaseModel):
     r"""Model to hold GitHub repository information.
 
-    Attributes:
+    Args:
         repo_name (str): The full name of the repository.
         repo_url (str): The URL of the repository.
-        contents (list): A list to hold the repository contents.
+        contents (List[GitHubFile], optional): Repository file contents.
+            (default: :obj:`[]`)
     """
 
     repo_name: str
@@ -84,33 +87,35 @@ class RepoAgent(ChatAgent):
         code/documentation chunks using a vector store when context
         length exceeds a specified token limit.
 
-    Attributes:
+    Args:
         vector_retriever (VectorRetriever): Retriever used to
             perform semantic search in RAG mode. Required if repo content
             exceeds context limit.
-        system_message (Optional[str]): The system message
-            for the chat agent. (default: :str:`"You are a code assistant
+        system_message (Optional[str], optional): The system message for
+            the chat agent. (default: :obj:`"You are a code assistant
             with repo context."`)
         repo_paths (Optional[List[str]]): List of GitHub repository URLs to
             load during initialization. (default: :obj:`None`)
-        model (BaseModelBackend): The model backend to use for generating
+        model (BaseModelBackend, optional): The model backend to use for
+            generating
             responses. (default: :obj:`ModelPlatformType.DEFAULT`
-            with `ModelType.DEFAULT`)
-        max_context_tokens (Optional[int]): Maximum number of tokens allowed
+            with :obj:`ModelType.DEFAULT`)
+        max_context_tokens (int, optional): Maximum number of tokens allowed
             before switching to RAG mode. (default: :obj:`2000`)
         github_auth_token (Optional[str]): GitHub personal access token
             for accessing private or rate-limited repositories. (default:
             :obj:`None`)
         chunk_size (Optional[int]): Maximum number of characters per code chunk
             when indexing files for RAG. (default: :obj:`8192`)
-        top_k (int): Number of top-matching chunks to retrieve from the vector
+        top_k (Optional[int]): Number of top-matching chunks to retrieve from
+            the vector
             store in RAG mode. (default: :obj:`5`)
         similarity (Optional[float]): Minimum similarity score required to
             include a chunk in the RAG context. (default: :obj:`0.6`)
         collection_name (Optional[str]): Name of the vector database
             collection to use for storing and retrieving chunks. (default:
             :obj:`None`)
-        **kwargs: Inherited from ChatAgent
+        **kwargs: Additional keyword arguments for :obj:`ChatAgent`.
 
     Note:
         The current implementation of RAG mode requires using Qdrant as the

--- a/camel/memories/base.py
+++ b/camel/memories/base.py
@@ -26,6 +26,9 @@ class MemoryBlock(ABC):
     However, it intentionally does not define a retrieval interface, as the
     structure of the data to be retrieved may vary in different types of
     memory blocks.
+
+    Args:
+        None.
     """
 
     @abstractmethod
@@ -86,15 +89,14 @@ class BaseContextCreator(ABC):
     primary goal is to create a context that is aligned with a specified token
     count limit, allowing subclasses to define their specific approach.
 
-    Subclasses should implement the :obj:`token_counter`,:obj: `token_limit`,
+    Subclasses should implement the :obj:`token_counter`, :obj:`token_limit`,
     and :obj:`create_context` methods to provide specific context creation
     logic.
 
-    Attributes:
-        token_counter (BaseTokenCounter): A token counter instance responsible
-            for counting tokens in a message.
-        token_limit (int): The maximum number of tokens allowed in the
-            generated context.
+    Args:
+        token_counter (BaseTokenCounter): Token counter implementation used by
+            subclasses.
+        token_limit (int): Maximum token budget used by subclasses.
     """
 
     @property
@@ -136,6 +138,10 @@ class AgentMemory(MemoryBlock, ABC):
     direct integration with an agent. Two key abstract functions, "retrieve"
     and "get_context_creator", are used for generating model context based on
     the memory records stored within the AgentMemory.
+
+    Args:
+        agent_id (Optional[str], optional): Identifier associated with records
+            in this memory. (default: :obj:`None`)
     """
 
     @property

--- a/camel/memories/records.py
+++ b/camel/memories/records.py
@@ -29,7 +29,7 @@ from camel.types import OpenAIBackendRole
 class MemoryRecord(BaseModel):
     r"""The basic message storing unit in the CAMEL memory system.
 
-    Attributes:
+    Args:
         message (BaseMessage): The main content of the record.
         role_at_backend (OpenAIBackendRole): An enumeration value representing
             the role this message played at the OpenAI backend. Note that this
@@ -38,12 +38,14 @@ class MemoryRecord(BaseModel):
         uuid (UUID, optional): A universally unique identifier for this record.
             This is used to uniquely identify this record in the memory system.
             If not given, it will be assigned with a random UUID.
+            (default: :obj:`uuid4()`)
         extra_info (Dict[str, str], optional): A dictionary of additional
             key-value pairs that provide more information. If not given, it
-            will be an empty `Dict`.
-        timestamp (float, optional): The timestamp when the record was created.
-        agent_id (str): The identifier of the agent associated with this
-            memory.
+            will be an empty dictionary. (default: :obj:`{}`)
+        timestamp (float, optional): Timestamp when the record was created.
+            (default: :obj:`time.time_ns() / 1_000_000_000`)
+        agent_id (str, optional): Identifier of the associated agent.
+            (default: :obj:`""`)
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -185,7 +187,14 @@ class MemoryRecord(BaseModel):
 
 
 class ContextRecord(BaseModel):
-    r"""The result of memory retrieving."""
+    r"""A scored memory record returned by retrieval.
+
+    Args:
+        memory_record (MemoryRecord): Retrieved memory record.
+        score (float): Retrieval relevance score.
+        timestamp (float, optional): Timestamp when the context record was
+            created. (default: :obj:`time.time_ns() / 1_000_000_000`)
+    """
 
     memory_record: MemoryRecord
     score: float

--- a/camel/models/base_audio_model.py
+++ b/camel/models/base_audio_model.py
@@ -22,6 +22,14 @@ from camel.utils import Constants
 class BaseAudioModel(ABC):
     r"""Base class for audio models providing Text-to-Speech (TTS) and
     Speech-to-Text (STT) functionality.
+
+    Args:
+        api_key (Optional[str], optional): API key for the audio service.
+            (default: :obj:`None`)
+        url (Optional[str], optional): Base URL for the audio API.
+            (default: :obj:`None`)
+        timeout (Optional[float], optional): Timeout in seconds for API calls.
+            (default: :obj:`Constants.TIMEOUT_THRESHOLD`)
     """
 
     def __init__(

--- a/camel/models/base_model.py
+++ b/camel/models/base_model.py
@@ -67,7 +67,13 @@ else:
 
 
 class _StreamLogger:
-    r"""Base for stream logging wrappers."""
+    r"""Base helper for stream logging wrappers.
+
+    Args:
+        log_path (Optional[str]): Path to the JSON log file.
+            (default: :obj:`None`)
+        log_enabled (bool): Whether streaming logs are enabled.
+    """
 
     def __init__(self, log_path: Optional[str], log_enabled: bool):
         self._log_path = log_path
@@ -119,7 +125,15 @@ class _StreamLogger:
 
 
 class _SyncStreamWrapper(_StreamLogger):
-    r"""Sync stream wrapper with logging."""
+    r"""Synchronous stream wrapper with logging support.
+
+    Args:
+        stream (Union[Stream[ChatCompletionChunk], Generator[
+            ChatCompletionChunk, None, None]]): Streaming iterator to wrap.
+        log_path (Optional[str]): Path to the JSON log file.
+            (default: :obj:`None`)
+        log_enabled (bool): Whether streaming logs are enabled.
+    """
 
     def __init__(
         self,
@@ -156,7 +170,15 @@ class _SyncStreamWrapper(_StreamLogger):
 
 
 class _AsyncStreamWrapper(_StreamLogger):
-    r"""Async stream wrapper with logging."""
+    r"""Asynchronous stream wrapper with logging support.
+
+    Args:
+        stream (Union[AsyncStream[ChatCompletionChunk], AsyncGenerator[
+            ChatCompletionChunk, None]]): Async streaming iterator to wrap.
+        log_path (Optional[str]): Path to the JSON log file.
+            (default: :obj:`None`)
+        log_enabled (bool): Whether streaming logs are enabled.
+    """
 
     def __init__(
         self,
@@ -200,6 +222,11 @@ class ModelBackendMeta(abc.ABCMeta):
     - Preprocess messages (remove <think> tags) before sending to the model.
     - Postprocess responses (extract <think> tags into reasoning_content)
       after receiving from the model.
+
+    Args:
+        name (str): Class name being created.
+        bases (Tuple[type, ...]): Base classes for the new class.
+        namespace (Dict[str, Any]): Namespace dictionary for the class body.
     """
 
     def __new__(mcs, name, bases, namespace):

--- a/camel/models/fish_audio_model.py
+++ b/camel/models/fish_audio_model.py
@@ -21,6 +21,14 @@ from camel.models.base_audio_model import BaseAudioModel
 class FishAudioModel(BaseAudioModel):
     r"""Provides access to FishAudio's Text-to-Speech (TTS) and Speech_to_Text
     (STT) models.
+
+    Args:
+        api_key (Optional[str], optional): API key for FishAudio.
+            If not provided, :obj:`FISHAUDIO_API_KEY` is used.
+            (default: :obj:`None`)
+        url (Optional[str], optional): Base URL for FishAudio API.
+            If not provided, :obj:`FISHAUDIO_API_BASE_URL` is used.
+            (default: :obj:`None`)
     """
 
     def __init__(

--- a/camel/models/model_factory.py
+++ b/camel/models/model_factory.py
@@ -65,10 +65,12 @@ from camel.utils import BaseTokenCounter, configure_langfuse
 
 
 class ModelFactory:
-    r"""Factory of backend models.
+    r"""Factory for creating model backend instances.
+
+    Use :meth:`create` to build a backend from a model platform and type.
 
     Raises:
-        ValueError: in case the provided model type is unknown.
+        ValueError: If the provided model platform is unknown.
     """
 
     _MODEL_PLATFORM_TO_CLASS_MAP: ClassVar[

--- a/camel/models/model_manager.py
+++ b/camel/models/model_manager.py
@@ -46,7 +46,11 @@ logger = logging.getLogger(__name__)
 
 
 class ModelProcessingError(Exception):
-    r"""Raised when an error occurs during model processing."""
+    r"""Raised when an error occurs during model processing.
+
+    Args:
+        *args: Positional arguments forwarded to :obj:`Exception`.
+    """
 
     pass
 
@@ -59,8 +63,8 @@ class ModelManager:
         models(Union[BaseModelBackend, List[BaseModelBackend]]):
             model backend or list of model backends
             (e.g., model instances, APIs)
-        scheduling_strategy (str): name of function that defines how
-            to select the next model. (default: :str:`round_robin`)
+        scheduling_strategy (str): Name of function that defines how
+            to select the next model. (default: :obj:`"round_robin"`)
     """
 
     def __init__(

--- a/camel/models/openai_audio_models.py
+++ b/camel/models/openai_audio_models.py
@@ -23,7 +23,19 @@ from camel.types import AudioModelType, VoiceType
 
 class OpenAIAudioModels(BaseAudioModel):
     r"""Provides access to OpenAI's Text-to-Speech (TTS) and Speech_to_Text
-    (STT) models."""
+    (STT) models.
+
+    Args:
+        api_key (Optional[str], optional): API key for OpenAI.
+            If not provided, :obj:`OPENAI_API_KEY` is used.
+            (default: :obj:`None`)
+        url (Optional[str], optional): Base URL for OpenAI APIs.
+            If not provided, :obj:`OPENAI_API_BASE_URL` is used.
+            (default: :obj:`None`)
+        timeout (Optional[float], optional): Timeout in seconds for API calls.
+            If not provided, :obj:`MODEL_TIMEOUT` is used.
+            (default: :obj:`None`)
+    """
 
     def __init__(
         self,

--- a/camel/models/stub_model.py
+++ b/camel/models/stub_model.py
@@ -31,6 +31,8 @@ from camel.utils import BaseTokenCounter
 
 
 class StubTokenCounter(BaseTokenCounter):
+    r"""Token counter implementation for stub models."""
+
     def count_tokens_from_messages(self, messages: List[OpenAIMessage]) -> int:
         r"""Token counting for STUB models, directly returning a constant.
 
@@ -71,7 +73,23 @@ class StubTokenCounter(BaseTokenCounter):
 
 
 class StubModel(BaseModelBackend):
-    r"""A dummy model used for unit tests."""
+    r"""A dummy model used for unit tests.
+
+    Args:
+        model_type (Union[ModelType, str]): Model identifier.
+        model_config_dict (Optional[Dict[str, Any]], optional): Model
+            configuration dictionary. (default: :obj:`None`)
+        api_key (Optional[str], optional): API key placeholder.
+            (default: :obj:`None`)
+        url (Optional[str], optional): Endpoint URL placeholder.
+            (default: :obj:`None`)
+        token_counter (Optional[BaseTokenCounter], optional): Token counter.
+            (default: :obj:`None`)
+        timeout (Optional[float], optional): Timeout in seconds.
+            (default: :obj:`None`)
+        max_retries (int, optional): Maximum retry attempts.
+            (default: :obj:`3`)
+    """
 
     model_type = ModelType.STUB
 


### PR DESCRIPTION
## Description
This PR standardizes class-level docstrings across core modules (`agents/`, `models/`, `memories/`) following the format specified in #911.

## Changes
- **15 files updated** across `camel/agents/`, `camel/models/`, and `camel/memories/`
- Added class-level `Args:` sections with proper type annotations
- Used `:obj:` references for default values consistently
- Moved `Args` from `__init__` to class docstrings where applicable
- Ensured all docstring lines stay under 79 characters
- Used `r"""` raw docstrings throughout

## Modules Covered
### agents/
- `chat_agent.py` — `_ToolOutputHistoryEntry`, `StreamContentAccumulator`, `StreamingChatAgentResponse`, `AsyncStreamingChatAgentResponse`
- `knowledge_graph_agent.py` — `KnowledgeGraphAgent`
- `mcp_agent.py` — `MCPAgent`
- `multi_hop_generator_agent.py` — `MultiHopGeneratorAgent`
- `programmed_agent_instruction.py` — `ProgrammedAgentInstructionResult`, `ProgrammableChatAgent`
- `repo_agent.py` — `ProcessingMode`, `GitHubFile`, `RepositoryInfo`, `RepoAgent`

### models/
- `base_audio_model.py` — `BaseAudioModel`
- `base_model.py` — `_StreamLogger`, `_SyncStreamWrapper`, `_AsyncStreamWrapper`, `ModelBackendMeta`
- `fish_audio_model.py` — `FishAudioModel`
- `model_factory.py` — `ModelFactory`
- `model_manager.py` — `ModelProcessingError`, `ModelManager`
- `openai_audio_models.py` — `OpenAIAudioModels`
- `stub_model.py` — `StubTokenCounter`, `StubModel`

### memories/
- `base.py` — `MemoryBlock`, `BaseContextCreator`, `AgentMemory`
- `records.py` — `MemoryRecord`, `ContextRecord`

## Testing
- No code logic changes; docstrings only
- Verified all new docstring lines are under 79 characters
- Python AST parsing confirms all targeted classes now have proper docstrings

Closes #911 (partial — covers agents, models, memories modules)