### PR TITLE
fix(screenshot_toolkit): prevent re-entrant agent.step() in read_image

### DIFF
--- a/camel/toolkits/screenshot_toolkit.py
+++ b/camel/toolkits/screenshot_toolkit.py
@@ -30,6 +30,8 @@ logger = get_logger(__name__)
 class ScreenshotToolkit(BaseToolkit, RegisteredAgentToolkit):
     r"""A toolkit for taking screenshots."""
 
+    _vision_agent = None
+
     @dependencies_required('PIL')
     def __init__(
         self,
@@ -63,6 +65,33 @@ class ScreenshotToolkit(BaseToolkit, RegisteredAgentToolkit):
         self.ImageGrab = ImageGrab
         self.screenshots_dir = path
         self.screenshots_dir.mkdir(parents=True, exist_ok=True)
+
+    def _get_vision_agent(self):
+        r"""Return a dedicated agent for image analysis.
+
+        Creates a lightweight agent on first call, reusing the registered
+        agent's model backend. This avoids re-entering the calling agent's
+        ``step()`` during tool execution, which would corrupt the tool-call
+        message sequence.
+        """
+        if self.agent is None:
+            raise RuntimeError(
+                "Cannot create vision agent: no agent registered. "
+                "Please pass this toolkit to ChatAgent via the "
+                "'toolkits_to_register_agent' parameter."
+            )
+        if self._vision_agent is None:
+            from camel.agents import ChatAgent
+
+            self._vision_agent = ChatAgent(
+                system_message=(
+                    "You are a vision assistant. Describe and analyze the "
+                    "provided image according to the user's instructions."
+                ),
+                model=self.agent.model_backend,
+                agent_id=f"{self.agent.agent_id}_vision",
+            )
+        return self._vision_agent
 
     def read_image(
         self,
@@ -116,8 +145,10 @@ class ScreenshotToolkit(BaseToolkit, RegisteredAgentToolkit):
                 image_list=[img],
             )
 
-            # Record the message in agent's memory
-            response = self.agent.step(message)
+            # Use a separate agent for image analysis to avoid re-entering
+            # the calling agent's step() during tool execution, which would
+            # corrupt the tool-call message sequence.
+            response = self._get_vision_agent().step(message)
             return response.msgs[0].content
 
         except Exception as e:

--- a/test/toolkits/test_screenshot_toolkit.py
+++ b/test/toolkits/test_screenshot_toolkit.py
@@ -1,0 +1,60 @@
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from camel.agents import ChatAgent
+from camel.toolkits.screenshot_toolkit import ScreenshotToolkit
+
+
+def test_read_image_uses_separate_vision_agent():
+    """Verify read_image delegates to a dedicated vision agent, not the
+    calling agent, to prevent re-entrant step() calls that corrupt the
+    tool-call message sequence.
+
+    Regression test for https://github.com/camel-ai/camel/issues/3869.
+    """
+    toolkit = ScreenshotToolkit.__new__(ScreenshotToolkit)
+    toolkit.screenshots_dir = Path(tempfile.mkdtemp())
+    toolkit._vision_agent = None
+
+    # Create a small test image
+    from PIL import Image
+
+    img_path = toolkit.screenshots_dir / "test.png"
+    Image.new("RGB", (10, 10), color="red").save(str(img_path))
+
+    # Mock the registered agent (the calling agent)
+    mock_agent = MagicMock(spec=ChatAgent)
+    mock_agent.agent_id = "caller"
+    mock_agent.model_backend = MagicMock()
+    toolkit._agent = mock_agent
+
+    # Pre-inject a mock vision agent to avoid building a real ChatAgent
+    mock_vision_agent = MagicMock(spec=ChatAgent)
+    mock_vision_response = MagicMock()
+    mock_vision_response.msgs = [MagicMock(content="Image analysis result")]
+    mock_vision_agent.step.return_value = mock_vision_response
+    toolkit._vision_agent = mock_vision_agent
+
+    result = toolkit.read_image(str(img_path), "describe this")
+
+    # The calling agent's step() must NOT be called
+    mock_agent.step.assert_not_called()
+
+    # The vision agent's step() should have been called instead
+    mock_vision_agent.step.assert_called_once()
+    assert result == "Image analysis result"


### PR DESCRIPTION
## Summary

`read_image()` called `self.agent.step(message)` during tool execution, creating a re-entrant call that corrupts the tool-call message sequence. The OpenAI API requires that a `tool_calls` message be followed by a tool-result message, but the nested `step()` injects a new user message instead, causing an API error.

## Root Cause

`ScreenshotToolkit.read_image()` at line 120 invoked `self.agent.step(message)` — the **calling** agent. When an agent calls a tool and that tool calls back into the same agent's `step()`, it interleaves a user-message inside the pending tool-call response, breaking the message contract.

## Fix

Delegate the vision analysis to a dedicated lightweight `ChatAgent` (`_vision_agent`) that reuses the registered agent's `model_backend`. This follows the same pattern established by `ContextSummarizerToolkit`, which similarly creates a separate agent for auxiliary LLM calls during tool execution.

### Changes

- **`camel/toolkits/screenshot_toolkit.py`**:
  - Added `_vision_agent` class attribute (lazy-initialized)
  - Added `_get_vision_agent()` method with defensive `RuntimeError` guard
  - Changed `read_image()` to call `self._get_vision_agent().step(message)` instead of `self.agent.step(message)`

- **`test/toolkits/test_screenshot_toolkit.py`** (new):
  - Regression test verifying the calling agent's `step()` is NOT called and the vision agent's `step()` IS called

Fixes #3869