### PR TITLE
chore: remove default 180s timeout threshold

### DIFF
--- a/camel/utils/constants.py
+++ b/camel/utils/constants.py
@@ -37,4 +37,4 @@ class Constants:
     DEFAULT_SIMILARITY_THRESHOLD = 0.7
 
     # Default timeout threshold value
-    TIMEOUT_THRESHOLD = 180.0
+    TIMEOUT_THRESHOLD = None


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Related Issue

Closes #3897 

### Description

Change default timeout to none

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Checklist

- [ ] I have read and agree to the [AI-Generated Code Policy](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md#ai-generated-code-policy) (**required**)
- [ ] I have linked this PR to an issue (**required**)
- [ ] I have checked if any dependencies need to be added or updated in `pyproject.toml` and run `uv lock`
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed
- [ ] I have added examples if this is a new feature

If you are unsure about any of these, don't hesitate to ask. We are here to help!