### PR TITLE
fix: support Langfuse v3 API in configure_langfuse

### DIFF
--- a/camel/utils/langfuse.py
+++ b/camel/utils/langfuse.py
@@ -27,12 +27,28 @@ _agent_session_id_var: ContextVar[Optional[str]] = ContextVar(
 # Global flag to track if Langfuse has been configured
 _langfuse_configured = False
 
+LANGFUSE_AVAILABLE = False
+_langfuse_context = None
+
 try:
-    from langfuse.decorators import langfuse_context
+    # Langfuse v3+: langfuse_context was removed from langfuse.decorators
+    # Check if v3 API is available (Langfuse class with auth_check)
+    from langfuse import Langfuse as _LangfuseClient  # noqa: F401
 
     LANGFUSE_AVAILABLE = True
+    _LANGFUSE_V3 = True
 except ImportError:
-    LANGFUSE_AVAILABLE = False
+    _LANGFUSE_V3 = False
+
+if not LANGFUSE_AVAILABLE:
+    try:
+        # Langfuse v2: uses langfuse_context from decorators
+        from langfuse.decorators import langfuse_context as _langfuse_context
+
+        LANGFUSE_AVAILABLE = True
+        _LANGFUSE_V3 = False
+    except ImportError:
+        pass
 
 
 @dependencies_required('langfuse')
@@ -100,14 +116,24 @@ def configure_langfuse(
         _langfuse_configured = False
 
     try:
-        # Configure langfuse_context with native method
-        langfuse_context.configure(
-            public_key=public_key,
-            secret_key=secret_key,
-            host=host,
-            debug=debug,
-            enabled=True,  # Always True here since we checked enabled above
-        )
+        if _LANGFUSE_V3:
+            # Langfuse v3+: configure via environment variables
+            # The @observe() decorator reads these automatically
+            os.environ["LANGFUSE_PUBLIC_KEY"] = public_key
+            os.environ["LANGFUSE_SECRET_KEY"] = secret_key
+            os.environ["LANGFUSE_HOST"] = host
+            os.environ["LANGFUSE_ENABLED"] = "true"
+            if debug:
+                os.environ["LANGFUSE_DEBUG"] = "true"
+        elif _langfuse_context is not None:
+            # Langfuse v2: configure via langfuse_context
+            _langfuse_context.configure(
+                public_key=public_key,
+                secret_key=secret_key,
+                host=host,
+                debug=debug,
+                enabled=True,
+            )
 
         logger.info("Langfuse tracing enabled for CAMEL models")
 


### PR DESCRIPTION
## Problem

Langfuse v3 removed `langfuse.decorators.langfuse_context`, causing `NameError: name 'langfuse_context' is not defined` when calling `configure_langfuse()`.

## Solution

- Detect Langfuse version at import time (v3 exports `Langfuse` class, v2 exports `langfuse_context`)
- **Langfuse v3+**: Configure via environment variables (`LANGFUSE_PUBLIC_KEY`, etc.) which `@observe()` reads automatically
- **Langfuse v2**: Use existing `langfuse_context.configure()` API
- Backward compatible — works with both v2 and v3

Fixes #3876