### PR TITLE
perf(camel): set a timeout on semantic scholar toolkit HTTP calls

### DIFF
--- a/camel/toolkits/semantic_scholar_toolkit.py
+++ b/camel/toolkits/semantic_scholar_toolkit.py
@@ -67,7 +67,7 @@ class SemanticScholarToolkit(BaseToolkit):
         url = f"{self.base_url}/paper/search"
         query_params = {"query": paper_title, "fields": ",".join(fields)}
         try:
-            response = requests.get(url, params=query_params)
+            response = requests.get(url, params=query_params, timeout=10.0)
             response.raise_for_status()
             return response.json()
         except requests.exceptions.RequestException as e:
@@ -115,7 +115,7 @@ class SemanticScholarToolkit(BaseToolkit):
         url = f"{self.base_url}/paper/{paper_id}"
         query_params = {"fields": ",".join(fields)}
         try:
-            response = requests.get(url, params=query_params)
+            response = requests.get(url, params=query_params, timeout=10.0)
             response.raise_for_status()
             return response.json()
         except requests.exceptions.RequestException as e:


### PR DESCRIPTION
Set an HTTP timeout in toolkits/semantic_scholar_toolkit.py to prevent indefinite network hangs

Network calls without a timeout can hang a worker indefinitely.

Ran: `/Users/tejasattarde/Downloads/gh-patchbot/.venv/bin/python3.14 -m py_compile camel/toolkits/semantic_scholar_toolkit.py`.

`toolkits/semantic_scholar_toolkit.py` line 70.