### PR TITLE
fix: catch Anthropic RateLimitError alongside OpenAI's

### DIFF
--- a/camel/agents/chat_agent.py
+++ b/camel/agents/chat_agent.py
@@ -56,6 +56,19 @@ from openai import (
 )
 from pydantic import BaseModel, ValidationError
 
+try:
+    from anthropic import RateLimitError as AnthropicRateLimitError
+except ImportError:
+    AnthropicRateLimitError = None  # type: ignore[misc,assignment]
+
+# Tuple of all rate limit errors to catch during retry logic.
+# OpenAI and Anthropic have separate RateLimitError classes.
+_RATE_LIMIT_ERRORS: tuple = (
+    (RateLimitError, AnthropicRateLimitError)
+    if AnthropicRateLimitError is not None
+    else (RateLimitError,)
+)
+
 from camel.agents._types import ModelResponse, ToolCallRequest
 from camel.agents._utils import (
     build_default_summary_prompt,
@@ -3592,7 +3605,7 @@ class ChatAgent(BaseAgent):
                 )
                 if response:
                     break
-            except RateLimitError as e:
+            except _RATE_LIMIT_ERRORS as e:
                 last_error = e
                 if attempt < self.retry_attempts - 1:
                     delay = min(self.retry_delay * (2**attempt), 60.0)
@@ -3654,7 +3667,7 @@ class ChatAgent(BaseAgent):
                 )
                 if response:
                     break
-            except RateLimitError as e:
+            except _RATE_LIMIT_ERRORS as e:
                 last_error = e
                 if attempt < self.retry_attempts - 1:
                     delay = min(self.retry_delay * (2**attempt), 60.0)


### PR DESCRIPTION
## Problem

The retry logic in `chat_agent.py` only catches `openai.RateLimitError`. When using Anthropic models, `anthropic.RateLimitError` (a different class) is not caught, causing rate limit errors to propagate as unrecoverable exceptions instead of being retried.

```
# With OpenAI model: RateLimitError → retried ✅
# With Anthropic model: anthropic.RateLimitError → crashes ❌
```

The issue reporter confirmed this at `camel/agents/chat_agent.py:3495` — the `except RateLimitError` block only handles OpenAI's error class.

## Fix

1. Import `anthropic.RateLimitError` with `try/except ImportError` fallback (consistent with the codebase's optional dependency pattern)
2. Build a `_RATE_LIMIT_ERRORS` tuple containing all available rate limit error classes
3. Replace `except RateLimitError` with `except _RATE_LIMIT_ERRORS` in both sync and async retry loops

This ensures rate limit retry works regardless of which model backend (OpenAI, Anthropic, or others) is being used.
