### PR TITLE
enhance: update camel doc and build cicd PR3885

### DIFF
--- a/.camel/skills/docs-incremental-update/scripts/auto_sync_docs_with_chatagent.py
+++ b/.camel/skills/docs-incremental-update/scripts/auto_sync_docs_with_chatagent.py
@@ -1,4 +1,16 @@
-#!/usr/bin/env python3
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
 """Auto-sync impacted docs using CAMEL ChatAgent.
 
 Reads a list of impacted .mdx doc paths plus an optional list of changed
@@ -11,6 +23,7 @@ from __future__ import annotations
 import argparse
 import subprocess
 import sys
+import traceback
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -101,13 +114,12 @@ def _git_status_paths(repo_root: Path) -> set[str] | None:
 
 
 def _write_agent_response_log(
-    repo_root: Path,
+    log_dir: Path,
     doc_path: Path,
     result: str,
     status: str,
 ) -> None:
     """Append the final agent response to a debug log for investigation."""
-    log_dir = repo_root / "terminal_logs"
     log_dir.mkdir(parents=True, exist_ok=True)
     log_path = log_dir / "agent_response.log"
     timestamp = datetime.now(timezone.utc).isoformat()
@@ -139,6 +151,7 @@ def _build_user_message(
 def _update_single_doc(
     doc_path: Path,
     repo_root: Path,
+    log_dir: Path,
     model_platform: str,
     model_type: str,
     changed_python_files: list[str],
@@ -163,9 +176,11 @@ def _update_single_doc(
         working_directory=str(repo_root),
         allowed_skills={SKILL_NAME},
     )
+    terminal_log_dir = str(log_dir / "terminal_sessions")
     terminal_toolkit = TerminalToolkit(
         working_directory=str(repo_root),
         safe_mode=True,
+        session_logs_dir=terminal_log_dir,
     )
     agent = ChatAgent(
         system_message=SYSTEM_PROMPT,
@@ -178,11 +193,13 @@ def _update_single_doc(
     response = agent.step(user_message)
 
     current_paths = _git_status_paths(repo_root)
+    target_posix = doc_path.as_posix()
+    log_dir_posix = log_dir.relative_to(repo_root).as_posix() + "/"
     if baseline_paths is not None and current_paths is not None:
         unexpected_paths = sorted(
             path
             for path in (current_paths - baseline_paths)
-            if path != doc_path.as_posix()
+            if path != target_posix and not path.startswith(log_dir_posix)
         )
         if unexpected_paths:
             raise RuntimeError(
@@ -194,7 +211,7 @@ def _update_single_doc(
     doc_changed = current_text != original_text
     result = response.msgs[0].content.strip() if response.msgs else ""
     status = "UPDATED" if doc_changed else "NO_WRITE"
-    _write_agent_response_log(repo_root, doc_path, result, status)
+    _write_agent_response_log(log_dir, doc_path, result, status)
 
     if not doc_changed:
         print(f"  SKIP (no doc update needed): {doc_path}")
@@ -253,6 +270,9 @@ def main() -> int:
     changed_python_files = _filter_changed_python_files(changed_files)
 
     repo_root = Path(".").resolve()
+    # Use a dedicated log directory separate from TerminalToolkit's log dir
+    # to avoid TerminalToolkit's init from cleaning up our response logs.
+    log_dir = repo_root / "docs_sync_logs"
     success = 0
     fail = 0
 
@@ -262,6 +282,7 @@ def main() -> int:
             _update_single_doc(
                 doc_path,
                 repo_root,
+                log_dir,
                 args.model_platform,
                 args.model_type,
                 changed_python_files,
@@ -269,6 +290,7 @@ def main() -> int:
             success += 1
         except Exception as exc:
             print(f"  FAIL: {doc_path} — {exc}")
+            traceback.print_exc()
             fail += 1
 
     print(f"\nDone. success={success} fail={fail}")

--- a/camel/models/watsonx_model.py
+++ b/camel/models/watsonx_model.py
@@ -199,7 +199,7 @@ class WatsonXModel(BaseModelBackend):
 
             # WatsonX expects messages as a list of dictionaries
             response = self._model.chat(
-                messages=messages,
+                messages=[dict(m) for m in messages],
                 params=request_config,
                 tools=tools,
             )
@@ -251,7 +251,7 @@ class WatsonXModel(BaseModelBackend):
 
             # WatsonX expects messages as a list of dictionaries
             response = await self._model.achat(
-                messages=messages,
+                messages=[dict(m) for m in messages],
                 params=request_config,
                 tools=tools,
             )

--- a/docs/mintlify/key_modules/loaders.mdx
+++ b/docs/mintlify/key_modules/loaders.mdx
@@ -9,7 +9,7 @@ doc_code_map:
 <Card title="What are Loaders?" icon="loader">
   CAMEL’s Loaders provide flexible ways to ingest and process all kinds of data
   structured files, unstructured text, web content, and even OCR from images.
-  They power your agent’s ability to interact with the outside world. itionally,
+  They power your agent’s ability to interact with the outside world. Additionally,
   several data readers were added, including `Apify Reader`, `Chunkr Reader`,
   `Firecrawl Reader`, `Jina_url Reader`, and `Mistral Reader`, which enable
   retrieval of external data for improved data integration and analysis.

--- a/docs/mintlify/key_modules/storages.mdx
+++ b/docs/mintlify/key_modules/storages.mdx
@@ -210,7 +210,7 @@ Here are practical usage patterns for each storage type—pick the ones you need
 
       os.environ["TIDB_DATABASE_URL"] = "The database url of your TiDB cluster."
       tidb_storage = TiDBStorage(
-          url_and_api_key=(os.getenv("DATABASE_URL"), ''),
+          url_and_api_key=(os.getenv("TIDB_DATABASE_URL"), ''),
           vector_dim=4,
           collection_name="my_collection"
       )

--- a/docs/mintlify/key_modules/tools.mdx
+++ b/docs/mintlify/key_modules/tools.mdx
@@ -151,7 +151,7 @@ CAMEL provides a variety of built-in toolkits that you can use right away. Here'
 | WeatherToolkit         | A toolkit for fetching weather data for cities using the OpenWeatherMap API.                                                                                                  |
 | WhatsAppToolkit        | A toolkit for interacting with the WhatsApp Business API, including sending messages, managing message templates, and accessing business profile information.                 |
 | ZapierToolkit          | A toolkit for interacting with Zapier's NLA API to execute actions through natural language commands and automate workflows.                                                  |
-| KlavisToolkit          | A toolkit for interacting with Kavis AI's API to create remote hosted production-ready MCP servers.                                                                           |
+| KlavisToolkit          | A toolkit for interacting with Klavis AI's API to create remote hosted production-ready MCP servers.                                                                           |
 
 ## Using Toolkits as MCP Servers
 

--- a/docs/mintlify/key_modules/workforce.mdx
+++ b/docs/mintlify/key_modules/workforce.mdx
@@ -233,14 +233,11 @@ from camel.societies.workforce import Workforce
 from camel.agents import ChatAgent
 from camel.toolkits import HumanToolkit
 
-# 1) Create the workforce
-workforce = Workforce("Interactive Workforce")
-
-# 2) Prepare human-in-the-loop tools
+# 1) Prepare human-in-the-loop tools
 human_toolkit = HumanToolkit()
 human_tools = human_toolkit.get_tools()  # includes ask_human_via_console, send_message_to_user, ...
 
-# 3) Attach HumanToolkit to any agents that may need human help
+# 2) Attach HumanToolkit to any agents that may need human help
 coordinator = ChatAgent(
     system_message="You coordinate tasks and may ask a human for help when needed.",
     tools=human_tools,
@@ -251,7 +248,7 @@ worker = ChatAgent(
     tools=[human_toolkit.ask_human_via_console],  # or use `human_tools`
 )
 
-# 4) Register agents into the workforce
+# 3) Register agents into the workforce
 workforce = Workforce(
     description="Interactive Workforce",
     coordinator_agent=coordinator,
@@ -259,7 +256,7 @@ workforce = Workforce(
 )
 workforce.add_single_agent_worker(description="Worker", worker=worker)
 
-# 5) Run tasks as usual. When an agent invokes a human tool, it will prompt via console.
+# 4) Run tasks as usual. When an agent invokes a human tool, it will prompt via console.
 # workforce.process_task(Task(content="Build a quick demo and confirm requirements with the human."))
 ```
 

--- a/docs/mintlify/mcp/export_camel_agent_as_mcp_server.mdx
+++ b/docs/mintlify/mcp/export_camel_agent_as_mcp_server.mdx
@@ -28,7 +28,7 @@ Configure your MCP client (Claude, Cursor, etc.) to connect:
   "camel-chat-agent": {
     "command": "/path/to/python",
     "args": [
-      "/path/to/camel/services/agent_mcp_server.py"
+      "/path/to/camel/services/agent_mcp/agent_mcp_server.py"
     ],
     "env": {
       "OPENAI_API_KEY": "...",

--- a/docs/mintlify/scripts/docs_sync/doc_code_map.py
+++ b/docs/mintlify/scripts/docs_sync/doc_code_map.py
@@ -11,8 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
-
-#!/usr/bin/env python3
 """Utilities for validating and using doc_code_map in Mintlify docs."""
 
 from __future__ import annotations
@@ -221,11 +219,11 @@ def main() -> int:
     changed_files: list[str] = []
     if args.changed_file:
         changed_files.extend(args.changed_file)
-    elif args.changed_files_file:
+    if args.changed_files_file:
         changed_files.extend(_read_path_list(Path(args.changed_files_file)))
-    elif args.base_ref:
+    if not changed_files and args.base_ref:
         changed_files.extend(_run_git_diff(args.base_ref, args.head_ref))
-    else:
+    if not changed_files and not args.changed_file and not args.changed_files_file and not args.base_ref:
         parser.error(
             "impacted requires --changed-file, --changed-files-file, or "
             "--base-ref/--head-ref."

--- a/test/docs/test_docs_sync.py
+++ b/test/docs/test_docs_sync.py
@@ -115,21 +115,22 @@ def test_build_user_message_includes_target_doc_and_changed_files():
 
     assert "## Target doc" in message
     assert "docs/mintlify/key_modules/runtimes.mdx" in message
-    assert "## Changed Python files for this run (optional context)" in message
+    assert "## Changed Python files for this run" in message
     assert "camel/runtimes/base.py" in message
     assert "camel/runtimes/docker_runtime.py" in message
     assert "any relevant code" in message
 
 
 def test_write_agent_response_log_appends_entries(tmp_path):
+    log_dir = tmp_path / "docs_sync_logs"
     auto_sync_docs._write_agent_response_log(
-        tmp_path,
+        log_dir,
         Path("docs/mintlify/mcp/example.mdx"),
         "UPDATED",
         "UPDATED",
     )
 
-    log_path = tmp_path / "terminal_logs" / "agent_response.log"
+    log_path = log_dir / "agent_response.log"
 
     assert log_path.exists()
     content = log_path.read_text(encoding="utf-8")


### PR DESCRIPTION
 Script & tooling fixes (auto_sync_docs_with_chatagent.py, doc_code_map.py):
  - Fix TerminalToolkit init wiping previous doc's agent_response.log by separating log directories
  - Fix elif chain in doc_code_map.py that silently drops --changed-files-file when --changed-file is also provided
  - Fix test assertion checking a string that doesn't exist in the actual code output
  - Add traceback.print_exc() so CI failures have usable stack traces
  - Add missing license header

  Doc content fixes:
  - storages.mdx: TiDB example sets TIDB_DATABASE_URL but reads DATABASE_URL — now consistent
  - export_camel_agent_as_mcp_server.mdx: wrong script path (services/agent_mcp_server.py → services/agent_mcp/agent_mcp_server.py)
  - loaders.mdx: truncated word "itionally" → "Additionally"
  - tools.mdx: misspelled "Kavis AI" → "Klavis AI"
  - workforce.mdx: remove dead code (workforce variable created then immediately overwritten)

  Unrelated fix:
  - watsonx_model.py: fix mypy errors by converting OpenAI typed messages to dicts as watsonx expects