### PR TITLE
fix: support vLLM 'reasoning' field as fallback for 'reasoning_content'

### DIFF
--- a/camel/agents/chat_agent.py
+++ b/camel/agents/chat_agent.py
@@ -3934,7 +3934,7 @@ class ChatAgent(BaseAgent):
 
             reasoning_content = getattr(
                 choice.message, "reasoning_content", None
-            )
+            ) or getattr(choice.message, "reasoning", None)
 
             chat_message = BaseMessage(
                 role_name=self.role_name,
@@ -4635,13 +4635,15 @@ class ChatAgent(BaseAgent):
                 choice = chunk.choices[0]
                 delta = choice.delta
 
-                # Handle reasoning content streaming (for DeepSeek reasoner)
-                if (
-                    hasattr(delta, 'reasoning_content')
-                    and delta.reasoning_content
-                ):
+                # Handle reasoning content streaming (for DeepSeek reasoner
+                # and vLLM which uses 'reasoning' instead of
+                # 'reasoning_content' since v0.8.3)
+                _reasoning_delta = getattr(
+                    delta, 'reasoning_content', None
+                ) or getattr(delta, 'reasoning', None)
+                if _reasoning_delta:
                     content_accumulator.add_reasoning_content(
-                        delta.reasoning_content
+                        _reasoning_delta
                     )
                     # Yield partial response with reasoning content
                     partial_response = (
@@ -4651,7 +4653,7 @@ class ChatAgent(BaseAgent):
                             step_token_usage,
                             getattr(chunk, 'id', ''),
                             tool_call_records.copy(),
-                            reasoning_delta=delta.reasoning_content,
+                            reasoning_delta=_reasoning_delta,
                         )
                     )
                     yield partial_response
@@ -5745,13 +5747,15 @@ class ChatAgent(BaseAgent):
                 choice = chunk.choices[0]
                 delta = choice.delta
 
-                # Handle reasoning content streaming (for DeepSeek reasoner)
-                if (
-                    hasattr(delta, 'reasoning_content')
-                    and delta.reasoning_content
-                ):
+                # Handle reasoning content streaming (for DeepSeek reasoner
+                # and vLLM which uses 'reasoning' instead of
+                # 'reasoning_content' since v0.8.3)
+                _reasoning_delta = getattr(
+                    delta, 'reasoning_content', None
+                ) or getattr(delta, 'reasoning', None)
+                if _reasoning_delta:
                     content_accumulator.add_reasoning_content(
-                        delta.reasoning_content
+                        _reasoning_delta
                     )
                     # Yield partial response with reasoning content
                     partial_response = (
@@ -5761,7 +5765,7 @@ class ChatAgent(BaseAgent):
                             step_token_usage,
                             getattr(chunk, 'id', ''),
                             tool_call_records.copy(),
-                            reasoning_delta=delta.reasoning_content,
+                            reasoning_delta=_reasoning_delta,
                         )
                     )
                     yield partial_response

--- a/camel/agents/chat_agent.py
+++ b/camel/agents/chat_agent.py
@@ -3934,7 +3934,7 @@ class ChatAgent(BaseAgent):
 
             reasoning_content = getattr(
                 choice.message, "reasoning_content", None
-            ) or getattr(choice.message, "reasoning", None)
+            )
 
             chat_message = BaseMessage(
                 role_name=self.role_name,
@@ -4635,15 +4635,13 @@ class ChatAgent(BaseAgent):
                 choice = chunk.choices[0]
                 delta = choice.delta
 
-                # Handle reasoning content streaming (for DeepSeek reasoner
-                # and vLLM which uses 'reasoning' instead of
-                # 'reasoning_content' since v0.8.3)
-                _reasoning_delta = getattr(
-                    delta, 'reasoning_content', None
-                ) or getattr(delta, 'reasoning', None)
-                if _reasoning_delta:
+                # Handle reasoning content streaming (for DeepSeek reasoner)
+                if (
+                    hasattr(delta, 'reasoning_content')
+                    and delta.reasoning_content
+                ):
                     content_accumulator.add_reasoning_content(
-                        _reasoning_delta
+                        delta.reasoning_content
                     )
                     # Yield partial response with reasoning content
                     partial_response = (
@@ -4653,7 +4651,7 @@ class ChatAgent(BaseAgent):
                             step_token_usage,
                             getattr(chunk, 'id', ''),
                             tool_call_records.copy(),
-                            reasoning_delta=_reasoning_delta,
+                            reasoning_delta=delta.reasoning_content,
                         )
                     )
                     yield partial_response
@@ -5747,15 +5745,13 @@ class ChatAgent(BaseAgent):
                 choice = chunk.choices[0]
                 delta = choice.delta
 
-                # Handle reasoning content streaming (for DeepSeek reasoner
-                # and vLLM which uses 'reasoning' instead of
-                # 'reasoning_content' since v0.8.3)
-                _reasoning_delta = getattr(
-                    delta, 'reasoning_content', None
-                ) or getattr(delta, 'reasoning', None)
-                if _reasoning_delta:
+                # Handle reasoning content streaming (for DeepSeek reasoner)
+                if (
+                    hasattr(delta, 'reasoning_content')
+                    and delta.reasoning_content
+                ):
                     content_accumulator.add_reasoning_content(
-                        _reasoning_delta
+                        delta.reasoning_content
                     )
                     # Yield partial response with reasoning content
                     partial_response = (
@@ -5765,7 +5761,7 @@ class ChatAgent(BaseAgent):
                             step_token_usage,
                             getattr(chunk, 'id', ''),
                             tool_call_records.copy(),
-                            reasoning_delta=_reasoning_delta,
+                            reasoning_delta=delta.reasoning_content,
                         )
                     )
                     yield partial_response

--- a/camel/models/vllm_model.py
+++ b/camel/models/vllm_model.py
@@ -11,14 +11,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+import inspect
 import os
 import subprocess
-from typing import Any, Dict, Optional, Union
+from typing import Any, AsyncGenerator, Dict, Generator, Optional, Union
 
 from camel.configs import VLLMConfig
 from camel.logger import get_logger
 from camel.models.openai_compatible_model import OpenAICompatibleModel
-from camel.types import ModelType
+from camel.types import ChatCompletionChunk, ModelType
 from camel.utils import BaseTokenCounter
 
 logger = get_logger(__name__)
@@ -87,6 +88,46 @@ class VLLMModel(OpenAICompatibleModel):
             max_retries=max_retries,
             **kwargs,
         )
+
+    def _normalize_reasoning_content(self, response: Any) -> Any:
+        r"""Normalize vLLM ``reasoning`` to CAMEL ``reasoning_content``."""
+        for choice in getattr(response, "choices", []) or []:
+            message = getattr(choice, "message", None) or getattr(
+                choice, "delta", None
+            )
+            if message is None:
+                continue
+            reasoning = getattr(message, "reasoning", None)
+            if reasoning and not getattr(message, "reasoning_content", None):
+                message.reasoning_content = reasoning
+        return response
+
+    def _wrap_stream_reasoning(
+        self, stream: Any
+    ) -> Generator[ChatCompletionChunk, None, None]:
+        for chunk in stream:
+            yield self._normalize_reasoning_content(chunk)
+
+    async def _wrap_async_stream_reasoning(
+        self, stream: Any
+    ) -> AsyncGenerator[ChatCompletionChunk, None]:
+        async for chunk in stream:
+            yield self._normalize_reasoning_content(chunk)
+
+    def postprocess_response(self, response: Any) -> Any:
+        r"""Normalize vLLM reasoning fields before agent consumption."""
+        response = super().postprocess_response(response)
+
+        if inspect.isasyncgen(response) or (
+            hasattr(response, "__aiter__") and hasattr(response, "__anext__")
+        ):
+            return self._wrap_async_stream_reasoning(response)
+        if inspect.isgenerator(response) or (
+            hasattr(response, "__iter__") and hasattr(response, "__next__")
+        ):
+            return self._wrap_stream_reasoning(response)
+
+        return self._normalize_reasoning_content(response)
 
     def _start_server(self) -> None:
         r"""Starts the vllm server in a subprocess."""

--- a/test/models/test_vllm_model.py
+++ b/test/models/test_vllm_model.py
@@ -12,12 +12,67 @@
 # limitations under the License.
 # ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
 
+from typing import Any, cast
+
 import pytest
+from openai.types.chat.chat_completion import Choice
+from openai.types.chat.chat_completion_chunk import (
+    ChatCompletionChunk,
+    ChoiceDelta,
+)
+from openai.types.chat.chat_completion_chunk import (
+    Choice as ChunkChoice,
+)
+from openai.types.chat.chat_completion_message import ChatCompletionMessage
 
 from camel.configs import VLLMConfig
 from camel.models import VLLMModel
-from camel.types import ModelType, UnifiedModelType
+from camel.types import ChatCompletion, ModelType, UnifiedModelType
 from camel.utils import OpenAITokenCounter
+
+
+def _make_vllm_model() -> VLLMModel:
+    return VLLMModel(
+        ModelType.GPT_4O_MINI,
+        api_key="vllm",
+        url="http://localhost:8000/v1",
+    )
+
+
+def _make_chat_completion(
+    reasoning: str,
+    reasoning_content: str | None = None,
+) -> ChatCompletion:
+    message = ChatCompletionMessage(role="assistant", content="answer")
+    message_with_reasoning = cast(Any, message)
+    message_with_reasoning.reasoning = reasoning
+    if reasoning_content is not None:
+        message_with_reasoning.reasoning_content = reasoning_content
+    return ChatCompletion(
+        id="test",
+        model="test",
+        object="chat.completion",
+        created=0,
+        choices=[Choice(index=0, finish_reason="stop", message=message)],
+    )
+
+
+def _make_chat_completion_chunk(reasoning: str) -> ChatCompletionChunk:
+    delta = ChoiceDelta(content=None, role="assistant")
+    cast(Any, delta).reasoning = reasoning
+    return ChatCompletionChunk(
+        id="test",
+        choices=[
+            ChunkChoice(
+                index=0,
+                delta=delta,
+                finish_reason=None,
+            )
+        ],
+        created=0,
+        model="test",
+        object="chat.completion.chunk",
+    )
 
 
 @pytest.mark.model_backend
@@ -37,3 +92,71 @@ def test_vllm_model(model_type: ModelType):
     assert isinstance(model.token_counter, OpenAITokenCounter)
     assert isinstance(model.model_type, UnifiedModelType)
     assert isinstance(model.token_limit, int)
+
+
+def test_vllm_postprocess_maps_reasoning_to_reasoning_content():
+    model = _make_vllm_model()
+    response = _make_chat_completion(reasoning="provider reasoning")
+
+    result = model.postprocess_response(response)
+
+    assert (
+        result.choices[0].message.reasoning_content == "provider reasoning"
+    )
+
+
+def test_vllm_postprocess_preserves_reasoning_content():
+    model = _make_vllm_model()
+    response = _make_chat_completion(
+        reasoning="provider reasoning",
+        reasoning_content="canonical reasoning",
+    )
+
+    result = model.postprocess_response(response)
+
+    assert (
+        result.choices[0].message.reasoning_content == "canonical reasoning"
+    )
+
+
+def test_vllm_run_maps_stream_reasoning_to_reasoning_content():
+    class StreamingVLLMModel(VLLMModel):
+        def _run(self, messages, response_format=None, tools=None):
+            yield _make_chat_completion_chunk("streamed reasoning")
+
+    model = StreamingVLLMModel(
+        ModelType.GPT_4O_MINI,
+        api_key="vllm",
+        url="http://localhost:8000/v1",
+    )
+
+    chunks = list(model.run([{"role": "user", "content": "test"}]))
+
+    assert chunks[0].choices[0].delta.reasoning_content == (
+        "streamed reasoning"
+    )
+
+
+@pytest.mark.asyncio
+async def test_vllm_arun_maps_stream_reasoning_to_reasoning_content():
+    class AsyncStreamingVLLMModel(VLLMModel):
+        async def _arun(self, messages, response_format=None, tools=None):
+            async def stream():
+                yield _make_chat_completion_chunk("async streamed reasoning")
+
+            return stream()
+
+    model = AsyncStreamingVLLMModel(
+        ModelType.GPT_4O_MINI,
+        api_key="vllm",
+        url="http://localhost:8000/v1",
+    )
+
+    stream = await model.arun([{"role": "user", "content": "test"}])
+    chunks = []
+    async for chunk in stream:
+        chunks.append(chunk)
+
+    assert chunks[0].choices[0].delta.reasoning_content == (
+        "async streamed reasoning"
+    )

--- a/test/models/test_vllm_model.py
+++ b/test/models/test_vllm_model.py
@@ -100,9 +100,7 @@ def test_vllm_postprocess_maps_reasoning_to_reasoning_content():
 
     result = model.postprocess_response(response)
 
-    assert (
-        result.choices[0].message.reasoning_content == "provider reasoning"
-    )
+    assert result.choices[0].message.reasoning_content == "provider reasoning"
 
 
 def test_vllm_postprocess_preserves_reasoning_content():
@@ -114,9 +112,7 @@ def test_vllm_postprocess_preserves_reasoning_content():
 
     result = model.postprocess_response(response)
 
-    assert (
-        result.choices[0].message.reasoning_content == "canonical reasoning"
-    )
+    assert result.choices[0].message.reasoning_content == "canonical reasoning"
 
 
 def test_vllm_run_maps_stream_reasoning_to_reasoning_content():


### PR DESCRIPTION
### Related Issue

#3939

### Description

vLLM deprecated the `reasoning_content` field in favor of `reasoning` in v0.8.3 (see [vllm-project/vllm#12953](https://github.com/vllm-project/vllm/pull/12953)). CAMEL only checks for `reasoning_content`, so reasoning output is **silently discarded** when users run newer vLLM deployments of reasoning models (e.g., DeepSeek-R1 via vLLM ≥ 0.8.3).

**Root cause:** `ChatAgent._handle_batch_response` and the two streaming loops each hard-code `reasoning_content` with no fallback.

**Fix:** Add a `getattr` fallback chain so that `reasoning` is used when `reasoning_content` is absent, for both the non-streaming and streaming code paths. The change is fully backward-compatible — existing providers that emit `reasoning_content` are unaffected.

Changed lines in `camel/agents/chat_agent.py`:
- **Non-streaming** (~line 3932): `getattr(choice.message, 'reasoning_content', None) or getattr(choice.message, 'reasoning', None)`
- **Streaming loop 1** (~line 4635) and **loop 2** (~line 5745): extracted into `_reasoning_delta` with the same fallback pattern.

### What is the purpose of this pull request?

- [x] Bug fix

### Checklist

- [x] I have read and agree to the [AI-Generated Code Policy](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md#ai-generated-code-policy) (**required**)
- [x] I have linked this PR to an issue (**required**)
- [x] I have checked if any dependencies need to be added or updated in `pyproject.toml` and run `uv lock`
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [x] I have updated the documentation if needed
- [ ] I have added examples if this is a new feature