### PR TITLE
Add OSOP workflow example — society of mind pattern in portable format

### DIFF
--- a/examples/osop/README.md
+++ b/examples/osop/README.md
@@ -1,0 +1,36 @@
+# OSOP Workflow Example — CAMEL Society of Mind
+
+This directory contains a portable workflow definition for CAMEL's **Society of Mind** multi-agent pattern, written in [OSOP](https://github.com/osop-org/osop-spec) format.
+
+## What is OSOP?
+
+**OSOP** (Open Standard for Orchestration Protocols) is a YAML-based workflow standard that describes multi-step processes — including AI agent pipelines — in a portable, tool-agnostic format. Think of it as "OpenAPI for workflows."
+
+- Any tool can read and render an `.osop` file
+- Workflows become shareable, diffable, and version-controllable
+- No vendor lock-in: the same workflow runs across different orchestration engines
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `society-of-mind.osop` | CAMEL's role-playing multi-agent debate pattern — task specifier, assistant, user, and critic agents collaborating through structured dialogue |
+
+## How to use
+
+You can read the `.osop` file as plain YAML. To validate or visualize it:
+
+```bash
+# Validate the workflow
+pip install osop
+osop validate society-of-mind.osop
+
+# Generate a visual report
+npx osop-report society-of-mind.osop -o report.html
+```
+
+## Learn more
+
+- [OSOP Spec](https://github.com/osop-org/osop-spec) — Full specification
+- [OSOP Examples](https://github.com/osop-org/osop-examples) — 30+ workflow templates
+- [CAMEL Documentation](https://docs.camel-ai.org/) — CAMEL framework docs

--- a/examples/osop/society-of-mind.osop
+++ b/examples/osop/society-of-mind.osop
@@ -1,0 +1,73 @@
+# CAMEL Society of Mind — Multi-Agent Debate in OSOP Format
+osop_version: "1.0"
+id: camel-society-of-mind
+name: CAMEL Society of Mind
+description: Role-playing multi-agent conversation where AI agents take on defined roles to collaboratively solve problems through structured dialogue.
+tags: [camel, multi-agent, role-playing, debate]
+
+nodes:
+  - id: task-specifier
+    type: agent
+    subtype: coordinator
+    name: Task Specifier
+    purpose: Refine the user's request into a concrete, well-defined task with clear deliverables.
+    runtime:
+      provider: openai
+      model: gpt-4o
+      config:
+        temperature: 0.3
+
+  - id: ai-assistant
+    type: agent
+    subtype: worker
+    name: AI Assistant
+    purpose: Work on the task from the assistant's perspective, providing solutions and implementations.
+    runtime:
+      provider: openai
+      model: gpt-4o
+      config:
+        system_prompt: You are a helpful AI assistant working to solve the assigned task.
+
+  - id: ai-user
+    type: agent
+    subtype: worker
+    name: AI User
+    purpose: Evaluate the assistant's work from the user's perspective, asking questions and requesting improvements.
+    runtime:
+      provider: openai
+      model: gpt-4o
+      config:
+        system_prompt: You are a critical user evaluating the assistant's output.
+
+  - id: critic
+    type: agent
+    subtype: worker
+    name: Critic Agent
+    purpose: Provide objective assessment of the conversation quality and solution completeness.
+    runtime:
+      provider: openai
+      model: gpt-4o
+
+  - id: output
+    type: system
+    name: Final Output
+    description: Compile the final solution from the multi-agent conversation.
+
+edges:
+  - from: task-specifier
+    to: ai-assistant
+    mode: sequential
+  - from: ai-assistant
+    to: ai-user
+    mode: sequential
+  - from: ai-user
+    to: ai-assistant
+    mode: loop
+    label: Continue conversation until task complete
+  - from: ai-user
+    to: critic
+    mode: conditional
+    condition: conversation_rounds >= 3
+  - from: critic
+    to: output
+    mode: sequential


### PR DESCRIPTION
## Summary

- Adds an OSOP (Open Standard for Orchestration Protocols) workflow example under `examples/osop/`
- The example models CAMEL's **Society of Mind** multi-agent debate pattern: task specifier, AI assistant, AI user, and critic agents collaborating through structured role-playing dialogue
- Includes a README explaining the OSOP format and how to validate/visualize the workflow

## What is OSOP?

OSOP is a portable YAML-based workflow standard — think "OpenAPI for workflows." It lets you describe multi-step processes (including multi-agent AI pipelines) in a tool-agnostic format that any orchestration engine can read.

- [OSOP Spec](https://github.com/osop-org/osop-spec)
- [OSOP Examples](https://github.com/osop-org/osop-examples)

## Why this PR?

This is a non-invasive, additive-only contribution. The `.osop` file provides a portable representation of CAMEL's core role-playing pattern that can be shared, diffed, and rendered by any OSOP-compatible tool — useful for documentation, onboarding, and cross-tool interoperability.

No existing files are modified.