### PR TITLE
Xai native fix

### DIFF
--- a/camel/models/openai_compatible_model.py
+++ b/camel/models/openai_compatible_model.py
@@ -586,6 +586,16 @@ class OpenAICompatibleModel(BaseModelBackend):
 
         if previous_response_id and last_message_count > 0:
             delta_messages = messages[last_message_count:]
+            # The first message in the delta may be an assistant message
+            # that echoes the previous response (already known to the
+            # server via previous_response_id).  Sending it again
+            # duplicates the assistant turn and causes the model to
+            # repeat tool calls infinitely.
+            if (
+                delta_messages
+                and delta_messages[0].get("role") == "assistant"
+            ):
+                delta_messages = delta_messages[1:]
             input_messages = (
                 delta_messages if delta_messages else [messages[-1]]
             )

--- a/camel/models/openai_compatible_model.py
+++ b/camel/models/openai_compatible_model.py
@@ -586,16 +586,15 @@ class OpenAICompatibleModel(BaseModelBackend):
 
         if previous_response_id and last_message_count > 0:
             delta_messages = messages[last_message_count:]
-            # The first message in the delta may be an assistant message
-            # that echoes the previous response (already known to the
-            # server via previous_response_id).  Sending it again
-            # duplicates the assistant turn and causes the model to
-            # repeat tool calls infinitely.
-            if (
-                delta_messages
-                and delta_messages[0].get("role") == "assistant"
-            ):
-                delta_messages = delta_messages[1:]
+            # Filter out ALL assistant messages from the delta.
+            # The server already knows every assistant turn via
+            # previous_response_id.  Only tool results and user
+            # messages are genuinely new.  ChatAgent's streaming
+            # path may also record duplicate assistant messages,
+            # so filtering by role is the safest approach.
+            delta_messages = [
+                m for m in delta_messages if m.get("role") != "assistant"
+            ]
             input_messages = (
                 delta_messages if delta_messages else [messages[-1]]
             )

--- a/camel/models/xai_model.py
+++ b/camel/models/xai_model.py
@@ -749,9 +749,16 @@ class XAIModel(BaseModelBackend):
 
         if self._previous_response_id and n >= self._last_message_count:
             delta = messages[self._last_message_count :]
-            # Must have at least the new user message
             if delta:
-                return delta
+                # The first message in the delta may be an assistant message
+                # that echoes the previous response (already known to the
+                # server via previous_response_id).  Sending it again
+                # duplicates the assistant turn on the server side and
+                # confuses the model into repeating tool calls infinitely.
+                if delta[0].get("role") == "assistant":
+                    delta = delta[1:]
+                if delta:
+                    return delta
 
         # Fallback: reset chain, send everything
         self._previous_response_id = None

--- a/camel/models/xai_model.py
+++ b/camel/models/xai_model.py
@@ -523,6 +523,7 @@ class XAIModel(BaseModelBackend):
         """
         chunk_id = ""
         model = str(self.model_type)
+        tool_calls_emitted = False
         for response, chunk in stream_iter:
             chunk_id = chunk_id or (response.id if response.id else "")
 
@@ -533,11 +534,19 @@ class XAIModel(BaseModelBackend):
             ):
                 finish_reason = self._map_finish_reason(response.finish_reason)
 
-            delta_tc = (
-                self._build_delta_tool_calls(chunk.tool_calls)
-                if chunk.tool_calls
-                else None
-            )
+            # Emit tool calls only once, from the accumulated response,
+            # when the stream signals completion.  xAI gRPC streaming
+            # may repeat the full tool_calls list on every chunk (unlike
+            # OpenAI SSE incremental deltas), so emitting per-chunk
+            # causes ChatAgent to accumulate duplicates.
+            delta_tc = None
+            if (
+                finish_reason
+                and not tool_calls_emitted
+                and response.tool_calls
+            ):
+                delta_tc = self._build_delta_tool_calls(response.tool_calls)
+                tool_calls_emitted = True
 
             yield self._make_chunk(
                 chunk_id=chunk_id,
@@ -562,12 +571,13 @@ class XAIModel(BaseModelBackend):
                 u = response.usage
                 from openai.types.completion_usage import CompletionUsage
 
+                # Do NOT include finish_reason here — it was already
+                # sent on the final streaming chunk.  A second
+                # finish_reason triggers ChatAgent to re-execute the
+                # same tool calls.
                 yield self._make_chunk(
                     chunk_id=chunk_id,
                     model=model,
-                    finish_reason=self._map_finish_reason(
-                        response.finish_reason
-                    ),
                     usage=CompletionUsage(
                         prompt_tokens=u.prompt_tokens,
                         completion_tokens=u.completion_tokens,
@@ -593,6 +603,7 @@ class XAIModel(BaseModelBackend):
         chunk_id = ""
         model = str(self.model_type)
         response = None
+        tool_calls_emitted = False
         async for resp, chunk in stream_iter:
             response = resp
             chunk_id = chunk_id or (response.id if response.id else "")
@@ -604,11 +615,14 @@ class XAIModel(BaseModelBackend):
             ):
                 finish_reason = self._map_finish_reason(response.finish_reason)
 
-            delta_tc = (
-                self._build_delta_tool_calls(chunk.tool_calls)
-                if chunk.tool_calls
-                else None
-            )
+            delta_tc = None
+            if (
+                finish_reason
+                and not tool_calls_emitted
+                and response.tool_calls
+            ):
+                delta_tc = self._build_delta_tool_calls(response.tool_calls)
+                tool_calls_emitted = True
 
             yield self._make_chunk(
                 chunk_id=chunk_id,
@@ -635,9 +649,6 @@ class XAIModel(BaseModelBackend):
                 yield self._make_chunk(
                     chunk_id=chunk_id,
                     model=model,
-                    finish_reason=self._map_finish_reason(
-                        response.finish_reason
-                    ),
                     usage=CompletionUsage(
                         prompt_tokens=u.prompt_tokens,
                         completion_tokens=u.completion_tokens,
@@ -750,13 +761,15 @@ class XAIModel(BaseModelBackend):
         if self._previous_response_id and n >= self._last_message_count:
             delta = messages[self._last_message_count :]
             if delta:
-                # The first message in the delta may be an assistant message
-                # that echoes the previous response (already known to the
-                # server via previous_response_id).  Sending it again
-                # duplicates the assistant turn on the server side and
-                # confuses the model into repeating tool calls infinitely.
-                if delta[0].get("role") == "assistant":
-                    delta = delta[1:]
+                # Filter out ALL assistant messages from the delta.
+                # The server already knows every assistant turn via
+                # previous_response_id.  Only tool results and user
+                # messages are genuinely new.  ChatAgent's streaming
+                # path may also record duplicate assistant messages,
+                # so filtering by role is the safest approach.
+                delta = [
+                    m for m in delta if m.get("role") != "assistant"
+                ]
                 if delta:
                     return delta
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Related Issue

<!-- REQUIRED: Link to the issue this PR resolves. PRs without a linked issue will be closed. -->
<!-- Example: Closes #123 or Fixes #456 -->

Closes #

### Description

Fix infinite tool-calling loops in xAI native SDK and OpenAI-compatible Responses API backends.

  Root cause

  Three independent bugs caused the model to repeat tool calls indefinitely:

  1. Conversation chaining sent duplicate assistant messages — When using previous_response_id, delta messages included assistant turns the server already knew about, causing the model to re-issue the same tool
  calls.
  2. gRPC streaming emitted tool calls on every chunk — Unlike OpenAI SSE (incremental deltas), xAI gRPC streams carry the full tool_calls list on each chunk, leading to duplicate accumulation in ChatAgent.
  3. Post-stream usage chunk carried a redundant finish_reason — ChatAgent saw two finish_reason signals per stream and executed tools twice.

  Changes

  - xai_model.py: Filter assistant messages from chaining deltas; emit tool calls only once on stream completion; drop finish_reason from the usage-only chunk.
  - openai_compatible_model.py: Same delta filtering for the Responses API chaining path.

<!-- REQUIRED: Describe what this PR does and why. PRs without a description will not be reviewed. -->

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Checklist

- [x] I have read and agree to the [AI-Generated Code Policy](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md#ai-generated-code-policy) (**required**)
- [x] I have linked this PR to an issue (**required**)
- [ ] I have checked if any dependencies need to be added or updated in `pyproject.toml` and run `uv lock`
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed
- [ ] I have added examples if this is a new feature

If you are unsure about any of these, don't hesitate to ask. We are here to help!
