### PR TITLE
enhance: Support DeepSeek V4 thinking tool calls PR4026

### DIFF
--- a/camel/configs/deepseek_config.py
+++ b/camel/configs/deepseek_config.py
@@ -83,9 +83,10 @@ class DeepSeekConfig(BaseConfig):
         include_usage (bool, optional): When streaming, specifies whether to
             include usage information in `stream_options`.
             (default: :obj:`None`)
-        reasoning_effort (str, optional): Controls DeepSeek thinking effort,
-            such as :obj:`"low"`, :obj:`"medium"`, or :obj:`"high"`.
-            (default: :obj:`None`)
+        reasoning_effort (str, optional): Controls DeepSeek thinking effort.
+            Current DeepSeek values are :obj:`"high"` and :obj:`"max"`;
+            compatibility values such as :obj:`"low"`, :obj:`"medium"`,
+            and :obj:`"xhigh"` are mapped by DeepSeek. (default: :obj:`None`)
         thinking (dict, optional): DeepSeek thinking mode configuration,
             such as :obj:`{"type": "enabled"}` or
             :obj:`{"type": "disabled"}`. It will be moved into

--- a/camel/models/deepseek_model.py
+++ b/camel/models/deepseek_model.py
@@ -14,7 +14,19 @@
 
 import copy
 import os
-from typing import Any, Dict, List, Mapping, Optional, Type, Union, cast
+from typing import (
+    Any,
+    AsyncIterator,
+    Dict,
+    Iterator,
+    List,
+    Mapping,
+    Optional,
+    Set,
+    Type,
+    Union,
+    cast,
+)
 
 from openai import AsyncStream, Stream
 from pydantic import BaseModel
@@ -197,6 +209,133 @@ class DeepSeekModel(OpenAICompatibleModel):
                 if tool_call_id:
                     session_cache[tool_call_id] = reasoning_content
 
+    def _cache_reasoning_content(
+        self,
+        reasoning_content: Optional[str],
+        tool_call_ids: List[str],
+        content: Optional[str] = None,
+    ) -> None:
+        r"""Cache DeepSeek reasoning collected from a streamed response."""
+        if not reasoning_content:
+            return
+
+        session_id = self._get_reasoning_session_id()
+        if tool_call_ids:
+            session_cache = self._tool_call_reasoning_by_session.setdefault(
+                session_id, {}
+            )
+            for tool_call_id in tool_call_ids:
+                session_cache[tool_call_id] = reasoning_content
+
+        if content:
+            assistant_reasoning_cache = (
+                self._assistant_reasoning_by_session.setdefault(session_id, {})
+            )
+            assistant_reasoning_cache[content] = reasoning_content
+
+    def _collect_stream_reasoning(
+        self,
+        chunk: ChatCompletionChunk,
+        reasoning_parts: List[str],
+        content_parts: List[str],
+        tool_call_ids: Set[str],
+    ) -> None:
+        r"""Collect reasoning/content/tool ids from a streaming chunk."""
+        for choice in getattr(chunk, "choices", []) or []:
+            delta = getattr(choice, "delta", None)
+            if delta is None:
+                continue
+
+            reasoning_delta = getattr(delta, "reasoning_content", None)
+            if isinstance(reasoning_delta, str) and reasoning_delta:
+                reasoning_parts.append(reasoning_delta)
+
+            content_delta = getattr(delta, "content", None)
+            if isinstance(content_delta, str) and content_delta:
+                content_parts.append(content_delta)
+
+            tool_calls = getattr(delta, "tool_calls", None)
+            if not tool_calls:
+                continue
+
+            for tool_call in tool_calls:
+                tool_call_id = self._get_tool_call_id(tool_call)
+                if tool_call_id:
+                    tool_call_ids.add(tool_call_id)
+
+    @staticmethod
+    def _is_stream_response_complete(chunk: ChatCompletionChunk) -> bool:
+        r"""Return whether a streaming chunk completes one response."""
+        return any(
+            getattr(choice, "finish_reason", None)
+            for choice in getattr(chunk, "choices", []) or []
+        )
+
+    def _cache_collected_stream_reasoning(
+        self,
+        reasoning_parts: List[str],
+        content_parts: List[str],
+        tool_call_ids: Set[str],
+    ) -> None:
+        r"""Cache collected streaming reasoning once it is complete."""
+        self._cache_reasoning_content(
+            "".join(reasoning_parts) or None,
+            list(tool_call_ids),
+            "".join(content_parts) or None,
+        )
+
+    def _wrap_stream_reasoning_cache(
+        self, response: Stream[ChatCompletionChunk]
+    ) -> Iterator[ChatCompletionChunk]:
+        r"""Wrap a DeepSeek stream and cache reasoning after consumption."""
+        reasoning_parts: List[str] = []
+        content_parts: List[str] = []
+        tool_call_ids: Set[str] = set()
+        cached = False
+
+        try:
+            for chunk in response:
+                self._collect_stream_reasoning(
+                    chunk, reasoning_parts, content_parts, tool_call_ids
+                )
+                if self._is_stream_response_complete(chunk):
+                    self._cache_collected_stream_reasoning(
+                        reasoning_parts, content_parts, tool_call_ids
+                    )
+                    cached = True
+                yield chunk
+        finally:
+            if not cached:
+                self._cache_collected_stream_reasoning(
+                    reasoning_parts, content_parts, tool_call_ids
+                )
+
+    async def _wrap_async_stream_reasoning_cache(
+        self, response: AsyncStream[ChatCompletionChunk]
+    ) -> AsyncIterator[ChatCompletionChunk]:
+        r"""Wrap a DeepSeek async stream and cache reasoning after use."""
+        reasoning_parts: List[str] = []
+        content_parts: List[str] = []
+        tool_call_ids: Set[str] = set()
+        cached = False
+
+        try:
+            async for chunk in response:
+                self._collect_stream_reasoning(
+                    chunk, reasoning_parts, content_parts, tool_call_ids
+                )
+                if self._is_stream_response_complete(chunk):
+                    self._cache_collected_stream_reasoning(
+                        reasoning_parts, content_parts, tool_call_ids
+                    )
+                    cached = True
+                yield chunk
+        finally:
+            if not cached:
+                self._cache_collected_stream_reasoning(
+                    reasoning_parts, content_parts, tool_call_ids
+                )
+
     def _inject_tool_call_reasoning(
         self, messages: List[OpenAIMessage]
     ) -> List[OpenAIMessage]:
@@ -266,6 +405,11 @@ class DeepSeekModel(OpenAICompatibleModel):
     def postprocess_response(self, response: Any) -> Any:
         r"""Postprocess responses and cache DeepSeek tool-call reasoning."""
         response = super().postprocess_response(response)
+        if isinstance(response, Stream):
+            return self._wrap_stream_reasoning_cache(response)
+        if isinstance(response, AsyncStream):
+            return self._wrap_async_stream_reasoning_cache(response)
+
         self._cache_tool_call_reasoning(response)
         return response
 
@@ -322,13 +466,8 @@ class DeepSeekModel(OpenAICompatibleModel):
                     )
                     request_config.pop(param, None)
 
-        # Remove strict from each tool's function parameters since DeepSeek
-        # does not support them
         if tools:
             tools = copy.deepcopy(tools)
-            for tool in tools:
-                function_dict = tool.get('function', {})
-                function_dict.pop("strict", None)
             request_config["tools"] = tools
         elif response_format:
             try_modify_message_with_format(messages[-1], response_format)
@@ -366,6 +505,10 @@ class DeepSeekModel(OpenAICompatibleModel):
             model=self.model_type,
             **request_config,
         )
+        if isinstance(response, Stream):
+            return self._wrap_stream_reasoning_cache(  # type: ignore[return-value]
+                response
+            )
 
         return response
 
@@ -398,5 +541,9 @@ class DeepSeekModel(OpenAICompatibleModel):
             model=self.model_type,
             **request_config,
         )
+        if isinstance(response, AsyncStream):
+            return self._wrap_async_stream_reasoning_cache(  # type: ignore[return-value]
+                response
+            )
 
         return response

--- a/camel/types/enums.py
+++ b/camel/types/enums.py
@@ -1699,11 +1699,6 @@ class ModelType(UnifiedModelType, Enum):
         }:
             return 1_000_000
         elif self in {
-            ModelType.DEEPSEEK_V4_FLASH,
-            ModelType.DEEPSEEK_V4_PRO,
-        }:
-            return 1_000_000
-        elif self in {
             ModelType.QWEN_LONG,
             ModelType.TOGETHER_LLAMA_4_SCOUT,
         }:

--- a/test/models/test_deepseek_model.py
+++ b/test/models/test_deepseek_model.py
@@ -17,6 +17,15 @@ from typing import Literal
 
 import pytest
 from openai.types.chat.chat_completion import Choice
+from openai.types.chat.chat_completion_chunk import (
+    ChatCompletionChunk,
+    ChoiceDelta,
+    ChoiceDeltaToolCall,
+    ChoiceDeltaToolCallFunction,
+)
+from openai.types.chat.chat_completion_chunk import (
+    Choice as ChunkChoice,
+)
 from openai.types.chat.chat_completion_message import ChatCompletionMessage
 from openai.types.chat.chat_completion_message_function_tool_call import (
     ChatCompletionMessageFunctionToolCall,
@@ -42,7 +51,7 @@ from camel.utils import OpenAITokenCounter
 )
 def test_deepseek_model(model_type):
     model_config_dict = DeepSeekConfig().as_dict()
-    model = DeepSeekModel(model_type, model_config_dict)
+    model = DeepSeekModel(model_type, model_config_dict, api_key="test")
     assert model.model_type == model_type
     assert model.model_config_dict == model_config_dict
     assert isinstance(model.token_counter, OpenAITokenCounter)
@@ -65,6 +74,7 @@ def test_deepseek_model_create(model_type: ModelType):
         model_platform=ModelPlatformType.DEEPSEEK,
         model_type=model_type,
         model_config_dict=DeepSeekConfig(temperature=1.3).as_dict(),
+        api_key="test",
     )
     assert model.model_type == model_type
 
@@ -116,7 +126,7 @@ def test_deepseek_prepare_request_moves_thinking_to_extra_body():
     assert "thinking" not in request_config
     assert request_config["extra_body"]["thinking"] == {"type": "disabled"}
     assert request_config["reasoning_effort"] == "high"
-    assert "strict" not in request_config["tools"][0]["function"]
+    assert request_config["tools"][0]["function"]["strict"] is True
     assert tools[0]["function"]["strict"] is True
 
 
@@ -144,6 +154,29 @@ def _make_chat_completion(
             prompt_tokens=20,
             total_tokens=30,
         ),
+    )
+
+
+def _make_chat_completion_chunk(
+    delta: ChoiceDelta,
+    finish_reason: Literal[
+        "stop", "length", "tool_calls", "content_filter", "function_call"
+    ]
+    | None = None,
+) -> ChatCompletionChunk:
+    return ChatCompletionChunk(
+        id="mock_chunk_id",
+        choices=[
+            ChunkChoice(
+                delta=delta,
+                finish_reason=finish_reason,
+                index=0,
+                logprobs=None,
+            )
+        ],
+        created=123456789,
+        model="deepseek-v4-pro",
+        object="chat.completion.chunk",
     )
 
 
@@ -191,6 +224,77 @@ def test_deepseek_model_injects_tool_call_reasoning_content():
     assert messages[1]["reasoning_content"] == (
         "Need the date before answering."
     )
+
+
+def test_deepseek_model_run_caches_streaming_tool_call_reasoning(
+    monkeypatch,
+):
+    model = DeepSeekModel(
+        ModelType.DEEPSEEK_V4_PRO,
+        DeepSeekConfig(stream=True).as_dict(),
+        api_key="test",
+    )
+    reasoning_delta = ChoiceDelta(content=None, role="assistant")
+    reasoning_delta.reasoning_content = "Need a streamed tool result."
+    tool_delta = ChoiceDelta(
+        content=None,
+        tool_calls=[
+            ChoiceDeltaToolCall(
+                index=0,
+                id="call_stream_run_123",
+                type="function",
+                function=ChoiceDeltaToolCallFunction(
+                    name="get_date", arguments="{}"
+                ),
+            )
+        ],
+    )
+    chunks = [
+        _make_chat_completion_chunk(reasoning_delta),
+        _make_chat_completion_chunk(tool_delta, finish_reason="tool_calls"),
+    ]
+
+    class FakeStream:
+        def __iter__(self):
+            return iter(chunks)
+
+    monkeypatch.setattr("camel.models.deepseek_model.Stream", FakeStream)
+
+    def fake_call_client(call, *args, **kwargs):
+        return FakeStream()
+
+    monkeypatch.setattr(model, "_call_client", fake_call_client)
+
+    response = model.run(messages=[{"role": "user", "content": "hello"}])
+    response_iter = iter(response)
+    next(response_iter)
+    next(response_iter)
+
+    messages = model.preprocess_messages(
+        [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_stream_run_123",
+                        "type": "function",
+                        "function": {
+                            "name": "get_date",
+                            "arguments": "{}",
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_stream_run_123",
+                "content": "2026",
+            },
+        ]
+    )
+
+    assert messages[0]["reasoning_content"] == "Need a streamed tool result."
 
 
 def test_deepseek_model_injects_final_reasoning_after_tool_turn():


### PR DESCRIPTION
  DeepSeek thinking-mode tool calls require assistant `reasoning_content` to be included in later requests. Non-
  streaming responses already handled this, but streaming responses did not, which could lead to DeepSeek API 400
  errors during multi-step tool use.
  
 **Changes:**
  - Cache and replay DeepSeek `reasoning_content` for streaming thinking-mode tool calls.
  - Preserve DeepSeek tool schema `strict` instead of removing it.
  - Update DeepSeek V4 reasoning docs/tests and remove a duplicate V4 token-limit branch.