### PR TITLE
feat : add Anthropic thinking support

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -26,7 +26,7 @@ body:
     attributes:
       label: What version of camel are you using?
       description: Run command `python3 -c 'print(__import__("camel").__version__)'` in your shell and paste the output here.
-      placeholder: E.g., 0.2.91a3
+      placeholder: E.g., 0.2.91a4
     validations:
       required: true
 

--- a/camel/__init__.py
+++ b/camel/__init__.py
@@ -14,7 +14,7 @@
 
 from camel.logger import disable_logging, enable_logging, set_log_level
 
-__version__ = '0.2.91a3'
+__version__ = '0.2.91a4'
 
 __all__ = [
     '__version__',

--- a/camel/configs/anthropic_config.py
+++ b/camel/configs/anthropic_config.py
@@ -13,7 +13,7 @@
 # ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
 from __future__ import annotations
 
-from typing import List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from camel.configs.base_config import BaseConfig
 
@@ -63,6 +63,13 @@ class AnthropicConfig(BaseConfig):
         cache_control (Optional[Literal["5m", "1h"]], optional): The cache
             control TTL for prompt caching. Use '5m' for 5-minute cache or
             '1h' for 1-hour cache. (default: :obj:`None`)
+        thinking (dict, optional): Extended thinking configuration for Claude
+            models, such as :obj:`{"type": "enabled",
+            "budget_tokens": 1024}` or :obj:`{"type": "adaptive"}`.
+            (default: :obj:`None`)
+        output_config (dict, optional): Anthropic output configuration. This
+            can be used with adaptive thinking to set effort, or with
+            structured outputs. (default: :obj:`None`)
         extra_headers (Optional[dict], optional): Additional headers for the
             request. (default: :obj:`None`)
         extra_body (dict, optional): Extra body parameters to be passed to
@@ -78,6 +85,8 @@ class AnthropicConfig(BaseConfig):
     metadata: Optional[dict] = None
     tool_choice: Optional[dict] = None
     cache_control: Optional[Literal["5m", "1h"]] = None
+    thinking: Optional[Dict[str, Any]] = None
+    output_config: Optional[Dict[str, Any]] = None
     extra_headers: Optional[dict] = None
     extra_body: Optional[dict] = None
 

--- a/camel/models/anthropic_model.py
+++ b/camel/models/anthropic_model.py
@@ -195,6 +195,7 @@ class AnthropicModel(BaseModelBackend):
                 "type": "ephemeral",
                 "ttl": cache_control,
             }
+        self._tool_call_thinking_blocks: Dict[str, List[Dict[str, Any]]] = {}
 
     @property
     def token_counter(self) -> BaseTokenCounter:
@@ -216,6 +217,188 @@ class AnthropicModel(BaseModelBackend):
     def supports_tool_response_format(self) -> bool:
         r"""Anthropic JSON outputs are independent from strict tool use."""
         return True
+
+    @staticmethod
+    def _get_block_value(
+        block: Any,
+        key: str,
+        default: Any = None,
+    ) -> Any:
+        r"""Read a content block value from a dict or SDK object."""
+        if isinstance(block, dict):
+            return block.get(key, default)
+        return getattr(block, key, default)
+
+    @classmethod
+    def _content_block_to_dict(
+        cls,
+        block: Any,
+    ) -> Dict[str, Any]:
+        r"""Convert an Anthropic content block to a plain dictionary."""
+        if isinstance(block, dict):
+            return copy.deepcopy(block)
+
+        model_dump = getattr(block, "model_dump", None)
+        if callable(model_dump):
+            dumped = model_dump(exclude_none=True)
+            if isinstance(dumped, dict):
+                return dumped
+
+        block_type = cls._get_block_value(block, "type")
+        if not isinstance(block_type, str):
+            return {}
+
+        block_dict: Dict[str, Any] = {"type": block_type}
+        for key in ("thinking", "signature", "data"):
+            value = cls._get_block_value(block, key)
+            if value is not None:
+                block_dict[key] = value
+        return block_dict
+
+    @classmethod
+    def _extract_thinking_blocks_from_message(
+        cls,
+        message: OpenAIMessage,
+    ) -> List[Dict[str, Any]]:
+        r"""Extract raw Anthropic thinking blocks from an OpenAI message."""
+        raw_blocks = message.get("anthropic_thinking_blocks") or message.get(
+            "thinking_blocks"
+        )
+        if not isinstance(raw_blocks, list):
+            return []
+
+        thinking_blocks: List[Dict[str, Any]] = []
+        for block in raw_blocks:
+            block_dict = cls._content_block_to_dict(block)
+            if block_dict.get("type") in {"thinking", "redacted_thinking"}:
+                thinking_blocks.append(block_dict)
+        return thinking_blocks
+
+    @staticmethod
+    def _get_tool_call_id(tool_call: Any) -> Optional[str]:
+        r"""Extract an OpenAI-style tool call ID from a dict or SDK object."""
+        if isinstance(tool_call, dict):
+            tool_call_id = tool_call.get("id")
+        else:
+            tool_call_id = getattr(tool_call, "id", None)
+        return tool_call_id if isinstance(tool_call_id, str) else None
+
+    @classmethod
+    def _get_tool_call_extra_content(
+        cls,
+        tool_call: Any,
+    ) -> Optional[Dict[str, Any]]:
+        r"""Extract non-standard extra content from a tool call."""
+        if isinstance(tool_call, dict):
+            extra_content = tool_call.get("extra_content")
+        else:
+            extra_content = getattr(tool_call, "extra_content", None)
+        return extra_content if isinstance(extra_content, dict) else None
+
+    @classmethod
+    def _extract_thinking_blocks_from_tool_call(
+        cls,
+        tool_call: Any,
+    ) -> List[Dict[str, Any]]:
+        r"""Extract raw Anthropic thinking blocks from tool extra content."""
+        extra_content = cls._get_tool_call_extra_content(tool_call)
+        if not extra_content:
+            return []
+
+        raw_blocks = extra_content.get("anthropic_thinking_blocks")
+        if not isinstance(raw_blocks, list):
+            return []
+
+        thinking_blocks: List[Dict[str, Any]] = []
+        for block in raw_blocks:
+            block_dict = cls._content_block_to_dict(block)
+            if block_dict.get("type") in {"thinking", "redacted_thinking"}:
+                thinking_blocks.append(block_dict)
+        return thinking_blocks
+
+    def _get_cached_thinking_blocks_for_tool_calls(
+        self,
+        tool_calls: List[Any],
+    ) -> List[Dict[str, Any]]:
+        r"""Return cached thinking blocks for the first matching tool call."""
+        for tool_call in tool_calls:
+            thinking_blocks = self._extract_thinking_blocks_from_tool_call(
+                tool_call
+            )
+            if thinking_blocks:
+                return thinking_blocks
+
+            tool_call_id = self._get_tool_call_id(tool_call)
+            if tool_call_id in self._tool_call_thinking_blocks:
+                return copy.deepcopy(
+                    self._tool_call_thinking_blocks[tool_call_id]
+                )
+        return []
+
+    def _cache_thinking_blocks_for_tool_calls(
+        self,
+        thinking_blocks: List[Dict[str, Any]],
+        tool_calls: List[Any],
+    ) -> None:
+        r"""Cache raw thinking blocks for Anthropic tool-use continuation."""
+        if not thinking_blocks or not tool_calls:
+            return
+
+        for tool_call in tool_calls:
+            tool_call_id = self._get_tool_call_id(tool_call)
+            if tool_call_id:
+                self._tool_call_thinking_blocks[tool_call_id] = copy.deepcopy(
+                    thinking_blocks
+                )
+
+    @staticmethod
+    def _is_thinking_enabled(thinking: Any) -> bool:
+        r"""Return whether an Anthropic thinking config enables thinking."""
+        if thinking is None:
+            return False
+        if isinstance(thinking, dict):
+            return thinking.get("type") != "disabled"
+        return True
+
+    def _validate_tool_choice_for_thinking(
+        self,
+        thinking: Any,
+        tool_choice: Any,
+    ) -> None:
+        r"""Validate Anthropic's tool-choice limitation for thinking."""
+        if not self._is_thinking_enabled(thinking) or tool_choice is None:
+            return
+        if isinstance(tool_choice, dict) and tool_choice.get("type") in {
+            "auto",
+            "none",
+        }:
+            return
+        raise ValueError(
+            "Anthropic extended thinking with tools only supports "
+            "`tool_choice={'type': 'auto'}` or "
+            "`tool_choice={'type': 'none'}`."
+        )
+
+    def _build_request_output_config(
+        self,
+        response_format: Optional[Type[BaseModel]],
+        extra_body: Dict[str, Any],
+    ) -> Optional[Dict[str, Any]]:
+        r"""Build Anthropic output_config from config and response_format."""
+        output_config: Dict[str, Any] = {}
+
+        legacy_output_config = extra_body.pop("output_config", None)
+        if isinstance(legacy_output_config, dict):
+            output_config.update(copy.deepcopy(legacy_output_config))
+
+        configured_output_config = self.model_config_dict.get("output_config")
+        if isinstance(configured_output_config, dict):
+            output_config.update(copy.deepcopy(configured_output_config))
+
+        if response_format is not None:
+            output_config.update(self._build_output_config(response_format))
+
+        return output_config or None
 
     def _convert_openai_to_anthropic_messages(
         self,
@@ -271,6 +454,17 @@ class AnthropicModel(BaseModelBackend):
                 if msg.get("tool_calls"):
                     # Handle tool calls - Anthropic uses content blocks
                     content_blocks = []
+                    thinking_blocks = (
+                        self._extract_thinking_blocks_from_message(msg)
+                    )
+                    if not thinking_blocks:
+                        thinking_blocks = (
+                            self._get_cached_thinking_blocks_for_tool_calls(
+                                msg.get("tool_calls", [])  # type: ignore[arg-type]
+                            )
+                        )
+                    content_blocks.extend(thinking_blocks)
+
                     if content:
                         content_blocks.append(
                             {"type": "text", "text": str(content)}
@@ -429,58 +623,60 @@ class AnthropicModel(BaseModelBackend):
         # Extract message content
         content = ""
         tool_calls = None
+        reasoning_content = None
+        thinking_blocks: List[Dict[str, Any]] = []
 
         if hasattr(response, "content"):
             content_blocks = response.content
             if content_blocks:
                 # Extract text content and tool calls
                 text_parts = []
+                reasoning_parts = []
                 tool_calls_list = []
                 for block in content_blocks:
-                    if hasattr(block, "type"):
-                        if block.type == "text":
-                            if hasattr(block, "text"):
-                                text_parts.append(block.text)
-                        elif block.type == "tool_use":
-                            tool_input = (
-                                block.input if hasattr(block, "input") else {}
-                            )
-                            tool_name = getattr(block, "name", "")
-                            tool_calls_list.append(
-                                {
-                                    "id": block.id
-                                    if hasattr(block, "id")
-                                    else "",
-                                    "type": "function",
-                                    "function": {
-                                        "name": tool_name,
-                                        "arguments": json.dumps(tool_input)
-                                        if isinstance(tool_input, dict)
-                                        else str(tool_input),
-                                    },
-                                }
-                            )
-                    elif isinstance(block, dict):
-                        if block.get("type") == "text":
-                            text_parts.append(block.get("text", ""))
-                        elif block.get("type") == "tool_use":
-                            tool_input = block.get("input", {})
-                            tool_name = block.get("name", "")
-                            tool_calls_list.append(
-                                {
-                                    "id": block.get("id", ""),
-                                    "type": "function",
-                                    "function": {
-                                        "name": tool_name,
-                                        "arguments": json.dumps(tool_input)
-                                        if isinstance(tool_input, dict)
-                                        else str(tool_input),
-                                    },
-                                }
-                            )
+                    block_type = self._get_block_value(block, "type")
+                    if block_type == "text":
+                        text = self._get_block_value(block, "text", "")
+                        if isinstance(text, str):
+                            text_parts.append(text)
+                    elif block_type == "thinking":
+                        block_dict = self._content_block_to_dict(block)
+                        thinking_blocks.append(block_dict)
+                        thinking = block_dict.get("thinking")
+                        if isinstance(thinking, str) and thinking:
+                            reasoning_parts.append(thinking)
+                    elif block_type == "redacted_thinking":
+                        block_dict = self._content_block_to_dict(block)
+                        thinking_blocks.append(block_dict)
+                    elif block_type == "tool_use":
+                        tool_input = self._get_block_value(block, "input", {})
+                        tool_name = self._get_block_value(block, "name", "")
+                        tool_id = self._get_block_value(block, "id", "")
+                        tool_call = {
+                            "id": tool_id,
+                            "type": "function",
+                            "function": {
+                                "name": tool_name,
+                                "arguments": json.dumps(tool_input)
+                                if isinstance(tool_input, dict)
+                                else str(tool_input),
+                            },
+                        }
+                        if thinking_blocks:
+                            tool_call["extra_content"] = {
+                                "anthropic_thinking_blocks": copy.deepcopy(
+                                    thinking_blocks
+                                )
+                            }
+                        tool_calls_list.append(tool_call)
                 content = "".join(text_parts)
+                if reasoning_parts:
+                    reasoning_content = "\n".join(reasoning_parts)
                 if tool_calls_list:
                     tool_calls = tool_calls_list
+                    self._cache_thinking_blocks_for_tool_calls(
+                        thinking_blocks, tool_calls_list
+                    )
             else:
                 content = ""
         elif isinstance(response.content, str):
@@ -506,6 +702,10 @@ class AnthropicModel(BaseModelBackend):
             "role": "assistant",
             "content": content,
         }
+        if reasoning_content is not None:
+            message_dict["reasoning_content"] = reasoning_content
+        if thinking_blocks:
+            message_dict["anthropic_thinking_blocks"] = thinking_blocks
         if tool_calls:
             message_dict["tool_calls"] = tool_calls
 
@@ -536,6 +736,7 @@ class AnthropicModel(BaseModelBackend):
         model: str,
         tool_call_index: Dict[str, int],
         finish_reason_sent: bool = False,
+        thinking_state: Optional[Dict[str, Any]] = None,
     ) -> ChatCompletionChunk:
         r"""Convert Anthropic streaming chunk to OpenAI ChatCompletionChunk.
 
@@ -550,10 +751,13 @@ class AnthropicModel(BaseModelBackend):
             ChatCompletionChunk: Chunk in OpenAI format.
         """
         delta_content = ""
+        delta_reasoning = ""
         tool_calls = None
         finish_reason = None
         chunk_id = ""
         usage = None
+        if thinking_state is None:
+            thinking_state = {}
 
         if hasattr(chunk, "type"):
             chunk_type = chunk.type
@@ -582,10 +786,19 @@ class AnthropicModel(BaseModelBackend):
                 # Content block starting
                 if hasattr(chunk, "content_block"):
                     block = chunk.content_block
-                    if hasattr(block, "type") and block.type == "tool_use":
+                    block_type = self._get_block_value(block, "type")
+                    if block_type in {"thinking", "redacted_thinking"}:
+                        chunk_idx = getattr(chunk, "index", 0)
+                        current_blocks = thinking_state.setdefault(
+                            "current_blocks", {}
+                        )
+                        current_blocks[chunk_idx] = (
+                            self._content_block_to_dict(block)
+                        )
+                    elif block_type == "tool_use":
                         # Tool use block starting
-                        tool_id = getattr(block, "id", "")
-                        tool_name = getattr(block, "name", "")
+                        tool_id = self._get_block_value(block, "id", "")
+                        tool_name = self._get_block_value(block, "name", "")
                         # Assign index for this tool call
                         idx = len(
                             [
@@ -598,17 +811,29 @@ class AnthropicModel(BaseModelBackend):
                         # Also map by chunk.index for content_block_delta
                         chunk_idx = getattr(chunk, "index", 0)
                         tool_call_index[f"_chunk_{chunk_idx}"] = idx
-                        tool_calls = [
-                            {
-                                "index": idx,
-                                "id": tool_id,
-                                "type": "function",
-                                "function": {
-                                    "name": tool_name,
-                                    "arguments": "",
-                                },
+                        self._cache_thinking_blocks_for_tool_calls(
+                            thinking_state.get("thinking_blocks", []),
+                            [{"id": tool_id}],
+                        )
+                        tool_call_delta = {
+                            "index": idx,
+                            "id": tool_id,
+                            "type": "function",
+                            "function": {
+                                "name": tool_name,
+                                "arguments": "",
+                            },
+                        }
+                        thinking_blocks = thinking_state.get(
+                            "thinking_blocks", []
+                        )
+                        if thinking_blocks:
+                            tool_call_delta["extra_content"] = {
+                                "anthropic_thinking_blocks": copy.deepcopy(
+                                    thinking_blocks
+                                )
                             }
-                        ]
+                        tool_calls = [tool_call_delta]
                 if tool_calls is None:
                     return ChatCompletionChunk.construct(
                         id=chunk_id,
@@ -624,10 +849,32 @@ class AnthropicModel(BaseModelBackend):
                 if hasattr(chunk, "delta"):
                     delta_obj = chunk.delta
                     delta_type = getattr(delta_obj, "type", "")
-                    if delta_type == "text_delta" or hasattr(
-                        delta_obj, "text"
-                    ):
+                    if delta_type == "text_delta":
                         delta_content = getattr(delta_obj, "text", "")
+                    elif delta_type == "thinking_delta":
+                        delta_reasoning = getattr(delta_obj, "thinking", "")
+                        chunk_idx = getattr(chunk, "index", 0)
+                        current_blocks = thinking_state.setdefault(
+                            "current_blocks", {}
+                        )
+                        block = current_blocks.setdefault(
+                            chunk_idx,
+                            {"type": "thinking", "thinking": ""},
+                        )
+                        block["thinking"] = (
+                            block.get("thinking", "") + delta_reasoning
+                        )
+                    elif delta_type == "signature_delta":
+                        signature = getattr(delta_obj, "signature", "")
+                        chunk_idx = getattr(chunk, "index", 0)
+                        current_blocks = thinking_state.setdefault(
+                            "current_blocks", {}
+                        )
+                        block = current_blocks.setdefault(
+                            chunk_idx,
+                            {"type": "thinking", "thinking": ""},
+                        )
+                        block["signature"] = signature
                     elif delta_type == "input_json_delta":
                         # Tool input arguments delta
                         partial_json = getattr(delta_obj, "partial_json", "")
@@ -646,7 +893,18 @@ class AnthropicModel(BaseModelBackend):
                             }
                         ]
             elif chunk_type == "content_block_stop":
-                # Content block finished - skip
+                chunk_idx = getattr(chunk, "index", 0)
+                current_blocks = thinking_state.setdefault(
+                    "current_blocks", {}
+                )
+                block = current_blocks.pop(chunk_idx, None)
+                if isinstance(block, dict) and block.get("type") in {
+                    "thinking",
+                    "redacted_thinking",
+                }:
+                    thinking_state.setdefault("thinking_blocks", []).append(
+                        block
+                    )
                 return ChatCompletionChunk.construct(
                     id=chunk_id,
                     choices=[{"index": 0, "delta": {}, "finish_reason": None}],
@@ -692,6 +950,8 @@ class AnthropicModel(BaseModelBackend):
         delta: Dict[str, Any] = {}
         if delta_content:
             delta["content"] = delta_content
+        if delta_reasoning:
+            delta["reasoning_content"] = delta_reasoning
         if tool_calls:
             delta["tool_calls"] = tool_calls
 
@@ -844,17 +1104,21 @@ class AnthropicModel(BaseModelBackend):
         if extra_headers is not None:
             request_params["extra_headers"] = extra_headers
 
+        thinking = self.model_config_dict.get("thinking")
+        if thinking is not None:
+            request_params["thinking"] = copy.deepcopy(thinking)
+
         # Convert tools first so we know whether tools are present
         anthropic_tools = self._convert_openai_tools_to_anthropic(tools)
 
         extra_body = copy.deepcopy(
             self.model_config_dict.get("extra_body") or {}
         )
-        if response_format is not None:
-            extra_body.pop("output_config", None)
-            request_params["output_config"] = self._build_output_config(
-                response_format
-            )
+        output_config = self._build_request_output_config(
+            response_format, extra_body
+        )
+        if output_config:
+            request_params["output_config"] = output_config
         if extra_body:
             request_params["extra_body"] = extra_body
 
@@ -862,6 +1126,7 @@ class AnthropicModel(BaseModelBackend):
             request_params["tools"] = anthropic_tools
             tool_choice = self.model_config_dict.get("tool_choice")
             if tool_choice is not None:
+                self._validate_tool_choice_for_thinking(thinking, tool_choice)
                 request_params["tool_choice"] = tool_choice
 
         create_func = self._client.messages.create
@@ -984,17 +1249,21 @@ class AnthropicModel(BaseModelBackend):
         if extra_headers is not None:
             request_params["extra_headers"] = extra_headers
 
+        thinking = self.model_config_dict.get("thinking")
+        if thinking is not None:
+            request_params["thinking"] = copy.deepcopy(thinking)
+
         # Convert tools first so we know whether tools are present
         anthropic_tools = self._convert_openai_tools_to_anthropic(tools)
 
         extra_body = copy.deepcopy(
             self.model_config_dict.get("extra_body") or {}
         )
-        if response_format is not None:
-            extra_body.pop("output_config", None)
-            request_params["output_config"] = self._build_output_config(
-                response_format
-            )
+        output_config = self._build_request_output_config(
+            response_format, extra_body
+        )
+        if output_config:
+            request_params["output_config"] = output_config
         if extra_body:
             request_params["extra_body"] = extra_body
 
@@ -1002,6 +1271,7 @@ class AnthropicModel(BaseModelBackend):
             request_params["tools"] = anthropic_tools
             tool_choice = self.model_config_dict.get("tool_choice")
             if tool_choice is not None:
+                self._validate_tool_choice_for_thinking(thinking, tool_choice)
                 request_params["tool_choice"] = tool_choice
 
         create_func = self._async_client.messages.create
@@ -1043,6 +1313,7 @@ class AnthropicModel(BaseModelBackend):
 
         def _generate_chunks():
             tool_call_index: Dict[str, int] = {}
+            thinking_state: Dict[str, Any] = {}
             finish_reason_sent = False
             for chunk in stream:
                 converted = self._convert_anthropic_stream_to_openai_chunk(
@@ -1050,6 +1321,7 @@ class AnthropicModel(BaseModelBackend):
                     model,
                     tool_call_index,
                     finish_reason_sent,
+                    thinking_state,
                 )
                 # Track if we've sent a finish_reason to avoid duplicates
                 if converted.choices:
@@ -1082,6 +1354,7 @@ class AnthropicModel(BaseModelBackend):
 
         async def _generate_chunks():
             tool_call_index: Dict[str, int] = {}
+            thinking_state: Dict[str, Any] = {}
             finish_reason_sent = False
             async for chunk in stream:
                 converted = self._convert_anthropic_stream_to_openai_chunk(
@@ -1089,6 +1362,7 @@ class AnthropicModel(BaseModelBackend):
                     model,
                     tool_call_index,
                     finish_reason_sent,
+                    thinking_state,
                 )
                 # Track if we've sent a finish_reason to avoid duplicates
                 if converted.choices:

--- a/camel/models/anthropic_model.py
+++ b/camel/models/anthropic_model.py
@@ -379,6 +379,30 @@ class AnthropicModel(BaseModelBackend):
             "`tool_choice={'type': 'none'}`."
         )
 
+    def _validate_sampling_for_thinking(self, thinking: Any) -> None:
+        r"""Validate Anthropic sampling limitations for thinking."""
+        if not self._is_thinking_enabled(thinking):
+            return
+
+        if self.model_config_dict.get("temperature") is not None:
+            raise ValueError(
+                "Anthropic extended thinking is not compatible with "
+                "`temperature`."
+            )
+        if self.model_config_dict.get("top_k") is not None:
+            raise ValueError(
+                "Anthropic extended thinking is not compatible with `top_k`."
+            )
+
+        top_p = self.model_config_dict.get("top_p")
+        if top_p is None:
+            return
+        if not isinstance(top_p, (int, float)) or not 0.95 <= top_p <= 1:
+            raise ValueError(
+                "Anthropic extended thinking only supports `top_p` values "
+                "between 0.95 and 1."
+            )
+
     def _build_request_output_config(
         self,
         response_format: Optional[Type[BaseModel]],
@@ -1106,6 +1130,7 @@ class AnthropicModel(BaseModelBackend):
 
         thinking = self.model_config_dict.get("thinking")
         if thinking is not None:
+            self._validate_sampling_for_thinking(thinking)
             request_params["thinking"] = copy.deepcopy(thinking)
 
         # Convert tools first so we know whether tools are present
@@ -1251,6 +1276,7 @@ class AnthropicModel(BaseModelBackend):
 
         thinking = self.model_config_dict.get("thinking")
         if thinking is not None:
+            self._validate_sampling_for_thinking(thinking)
             request_params["thinking"] = copy.deepcopy(thinking)
 
         # Convert tools first so we know whether tools are present

--- a/camel/models/anthropic_model.py
+++ b/camel/models/anthropic_model.py
@@ -379,30 +379,6 @@ class AnthropicModel(BaseModelBackend):
             "`tool_choice={'type': 'none'}`."
         )
 
-    def _validate_sampling_for_thinking(self, thinking: Any) -> None:
-        r"""Validate Anthropic sampling limitations for thinking."""
-        if not self._is_thinking_enabled(thinking):
-            return
-
-        if self.model_config_dict.get("temperature") is not None:
-            raise ValueError(
-                "Anthropic extended thinking is not compatible with "
-                "`temperature`."
-            )
-        if self.model_config_dict.get("top_k") is not None:
-            raise ValueError(
-                "Anthropic extended thinking is not compatible with `top_k`."
-            )
-
-        top_p = self.model_config_dict.get("top_p")
-        if top_p is None:
-            return
-        if not isinstance(top_p, (int, float)) or not 0.95 <= top_p <= 1:
-            raise ValueError(
-                "Anthropic extended thinking only supports `top_p` values "
-                "between 0.95 and 1."
-            )
-
     def _build_request_output_config(
         self,
         response_format: Optional[Type[BaseModel]],
@@ -1130,7 +1106,6 @@ class AnthropicModel(BaseModelBackend):
 
         thinking = self.model_config_dict.get("thinking")
         if thinking is not None:
-            self._validate_sampling_for_thinking(thinking)
             request_params["thinking"] = copy.deepcopy(thinking)
 
         # Convert tools first so we know whether tools are present
@@ -1276,7 +1251,6 @@ class AnthropicModel(BaseModelBackend):
 
         thinking = self.model_config_dict.get("thinking")
         if thinking is not None:
-            self._validate_sampling_for_thinking(thinking)
             request_params["thinking"] = copy.deepcopy(thinking)
 
         # Convert tools first so we know whether tools are present

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ sys.path.insert(0, os.path.abspath('..'))
 project = 'CAMEL'
 copyright = '2024, CAMEL-AI.org'
 author = 'CAMEL-AI.org'
-release = '0.2.91a3'
+release = '0.2.91a4'
 
 html_favicon = (
     'https://raw.githubusercontent.com/camel-ai/camel/master/misc/favicon.png'

--- a/docs/mintlify/reference/camel.configs.anthropic_config.mdx
+++ b/docs/mintlify/reference/camel.configs.anthropic_config.mdx
@@ -24,5 +24,7 @@ See: https://docs.anthropic.com/en/api/messages
 - **metadata** (dict, optional): An object describing metadata about the request. Can include user_id as an external identifier for the user associated with the request. (default: :obj:`None`)
 - **tool_choice** (dict, optional): How the model should use the provided tools. The model can use a specific tool, any available tool, decide by itself, or not use tools at all. (default: :obj:`None`)
 - **cache_control** (`Optional[Literal["5m", "1h"]], optional`): The cache control TTL for prompt caching. Use '5m' for 5-minute cache or '1h' for 1-hour cache. (default: :obj:`None`)
+- **thinking** (dict, optional): Extended thinking configuration for Claude models, such as :obj:`{"type": "enabled", "budget_tokens": 1024}`, :obj:`{"type": "enabled", "budget_tokens": 1024, "display": "omitted"}`, or :obj:`{"type": "adaptive"}`. (default: :obj:`None`)
+- **output_config** (dict, optional): Anthropic output configuration. This can be used with adaptive thinking to set effort, or with structured outputs. (default: :obj:`None`)
 - **extra_headers** (Optional[dict], optional): Additional headers for the request. (default: :obj:`None`)
 - **extra_body** (dict, optional): Extra body parameters to be passed to the Anthropic API.

--- a/examples/models/anthropic_model_example.py
+++ b/examples/models/anthropic_model_example.py
@@ -10,277 +10,85 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
-
 from camel.agents import ChatAgent
 from camel.configs import AnthropicConfig
 from camel.models import ModelFactory
-from camel.toolkits import FunctionTool
+from camel.toolkits import MathToolkit
 from camel.types import ModelPlatformType, ModelType
 
-"""
-please set the below os environment:
-export ANTHROPIC_API_KEY=""
-"""
 
-model = ModelFactory.create(
-    model_platform=ModelPlatformType.ANTHROPIC,
-    model_type=ModelType.CLAUDE_HAIKU_4_5,
-    model_config_dict=AnthropicConfig(temperature=0.2).as_dict(),
+def create_anthropic_model(stream: bool = False):
+    r"""Create a Claude Opus 4.7 model with adaptive thinking enabled."""
+    model_config = AnthropicConfig(
+        max_tokens=16000,
+        stream=stream,
+        thinking={"type": "adaptive"},
+        output_config={"effort": "medium"},
+        tool_choice={"type": "auto"},
+    ).as_dict()
+
+    return ModelFactory.create(
+        model_platform=ModelPlatformType.ANTHROPIC,
+        model_type=ModelType.CLAUDE_OPUS_4_7,
+        model_config_dict=model_config,
+    )
+
+
+math_tools = MathToolkit().get_tools()
+
+camel_agent = ChatAgent(
+    system_message="You are a helpful assistant.",
+    model=create_anthropic_model(),
+    tools=math_tools,
 )
 
-# Define system message
-sys_msg = "You are a helpful assistant."
-
-# Set agent
-camel_agent = ChatAgent(system_message=sys_msg, model=model)
-
-user_msg = """Say hi to CAMEL AI, one open-source community dedicated to the
-    study of autonomous and communicative agents."""
-
-# Get response information
-response = camel_agent.step(user_msg)
-print(response.msgs[0].content)
-'''
-===============================================================================
-Hi CAMEL AI! I'm an AI assistant created by Anthropic. I'm happy to chat and help out however I can. Let me know if you have any questions or if there's anything I can assist with.
-===============================================================================
-'''  # noqa: E501
-
-model = ModelFactory.create(
-    model_platform=ModelPlatformType.ANTHROPIC,
-    model_type=ModelType.CLAUDE_3_7_SONNET,
+user_msg = (
+    "Use the math_multiply tool to calculate 3 * 7 * 11, then use the "
+    "result to explain why the Euclid-style number 4 * (3 * 7 * 11) - 1 "
+    "is congruent to 3 modulo 4."
 )
-
-camel_agent = ChatAgent(model=model)
-
-user_msg = """Write a bash script that takes a matrix represented as a string
-with format '[1,2],[3,4],[5,6]' and prints the transpose in the same format."""
 
 response = camel_agent.step(user_msg)
-print(response.msgs[0].content)
-'''
-===============================================================================
-Here's a bash script that takes a matrix represented as a string with the format '[1,2],[3,4],[5,6]' and prints its transpose in the same format:
+answer = response.msgs[0]
 
-```bash
-#!/bin/bash
+print("Answer:")
+print(answer.content)
 
-# Check if an argument is provided
-if [ $# -ne 1 ]; then
-    echo "Usage: $0 '[1,2],[3,4],[5,6]'"
-    exit 1
-fi
-
-matrix=$1
-
-# Remove any spaces from the input
-matrix=${matrix// /}
-
-# Extract rows using regex
-if [[ ! $matrix =~ ^\[([0-9,]+)\](,\[([0-9,]+)\])*$ ]]; then
-    echo "Invalid matrix format. Expected format: '[1,2],[3,4],[5,6]'"
-    exit 1
-fi
-
-# Split the matrix into rows
-IFS='],[' read -ra rows <<< "${matrix//[\[\]]/}"
-
-# Determine the number of columns from the first row
-IFS=',' read -ra first_row <<< "${rows[0]}"
-num_cols=${#first_row[@]}
-num_rows=${#rows[@]}
-
-# Initialize an empty array to store the transposed matrix
-declare -A transposed
-
-# Fill the transposed matrix
-for ((i=0; i<num_rows; i++)); do
-    IFS=',' read -ra row_values <<< "${rows[i]}"
-    for ((j=0; j<num_cols; j++)); do
-        transposed[$j,$i]=${row_values[j]}
-    done
-done
-
-# Build the output string
-result=""
-for ((i=0; i<num_cols; i++)); do
-    result+="["
-    for ((j=0; j<num_rows; j++)); do
-        result+="${transposed[$i,$j]}"
-        if ((j < num_rows-1)); then
-            result+=","
-        fi
-    done
-    result+="]"
-    if ((i < num_cols-1)); then
-        result+=","
-    fi
-done
-
-echo "$result"
-```
-
-Usage example:
-```
-$ ./transpose.sh '[1,2],[3,4],[5,6]'
-[1,3,5],[2,4,6]
-```
-
-The script works as follows:
-1. It checks if an input argument is provided
-2. It removes any spaces from the input
-3. It validates the input format
-4. It splits the matrix into rows
-5. It determines the number of columns and rows
-6. It creates a transposed matrix by swapping rows and columns
-7. It builds the output string in the required format
-8. It prints the transposed matrix
-
-The transpose operation converts rows into columns and vice versa, so a matrix like '[1,2],[3,4],[5,6]' (which represents a 3x2 matrix) becomes '[1,3,5],[2,4,6]' (a 2x3 matrix).
-'''  # noqa: E501
-
-
-def my_add(a: int, b: int) -> int:
-    """Add two numbers together and return the result."""
-    return a + b
-
-
-anthropic_model = ModelFactory.create(
-    model_platform=ModelPlatformType.ANTHROPIC,
-    model_type=ModelType.CLAUDE_HAIKU_4_5,
-    model_config_dict=AnthropicConfig(temperature=0.2).as_dict(),
-)
-
-anthropic_agent = ChatAgent(
-    model=anthropic_model,
-    tools=[FunctionTool(my_add)],
-)
-
-print("Testing Anthropic agent with tool calling:")
-user_msg = "Use the tool my_add to calculate 2 + 2"
-response = anthropic_agent.step(user_msg)
-print(response.msgs[0].content)
-"""
-===============================================================================
-The result of adding 2 and 2 is 4, as calculated by the my_add tool.
-===============================================================================
-"""
-
-# Check if tool was called
 if response.info and response.info.get("tool_calls"):
-    print("Tool was called successfully!")
-    print(f"Tool calls: {response.info['tool_calls']}")
-else:
-    print("No tool calls were made.")
+    print("\nTool calls:")
+    print(response.info["tool_calls"])
 
-"""
-===============================================================================
-Tool was called successfully!
-Tool calls: [ToolCallingRecord(tool_name='my_add', args={'a': 2, 'b': 2}, result=4, tool_call_id='toolu_019iGVdtjmzai2pwmCkX3f5T', images=None)]
-===============================================================================
-"""  # noqa: E501
+if answer.reasoning_content:
+    print("\nThinking summary:")
+    print(answer.reasoning_content)
 
-model = ModelFactory.create(
-    model_platform=ModelPlatformType.ANTHROPIC,
-    model_type=ModelType.CLAUDE_SONNET_4_5,
-    model_config_dict={
-        "extra_body": {"thinking": {"type": "enabled", "budget_tokens": 2000}}
-    },
+
+streaming_agent = ChatAgent(
+    system_message="You are a helpful assistant.",
+    model=create_anthropic_model(stream=True),
+    tools=math_tools,
+    stream_accumulate=False,
 )
 
-camel_agent = ChatAgent(model=model)
-
-user_msg = """Are there an infinite number of prime numbers such that n mod 4
-== 3?"""
-
-response = camel_agent.step(user_msg)
-print(response.msgs[0].content)
-
-"""
-===============================================================================
-Yes, there are infinitely many prime numbers that are congruent to 3 modulo 4.
-
-This can be proven using a clever argument similar to Euclid's proof of the
-infinitude of primes:
-
-**Proof:**
-
-Suppose there are only finitely many primes ≡ 3 (mod 4), say p₁, p₂, ..., pₖ.
-
-Consider the number:
-N = 4(p₁ · p₂ · ... · pₖ) - 1
-
-Note that N ≡ -1 ≡ 3 (mod 4).
-
-Now, N must have at least one prime divisor q where q ≡ 3 (mod 4). Why?
-Because:
-- The product of numbers that are ≡ 1 (mod 4) is also ≡ 1 (mod 4)
-- Since N ≡ 3 (mod 4), it cannot be factored solely into primes ≡ 1 (mod 4)
-- (Note: 2 ∤ N since N is odd)
-
-This prime divisor q cannot be any of p₁, p₂, ..., pₖ because:
-- q divides N = 4(p₁ · p₂ · ... · pₖ) - 1
-- If q = pᵢ for some i, then q would divide both N and 4(p₁ · p₂ · ... · pₖ)
-- Therefore q would divide their difference, which is 1 — a contradiction
-
-So we've found a new prime ≡ 3 (mod 4) not in our original list, contradicting
-our assumption.
-
-Therefore, there are infinitely many primes ≡ 3 (mod 4). ∎
-===============================================================================
-"""
-
-
-model = ModelFactory.create(
-    model_platform=ModelPlatformType.ANTHROPIC,
-    model_type=ModelType.CLAUDE_OPUS_4_1,
-    model_config_dict={
-        "extra_body": {"thinking": {"type": "enabled", "budget_tokens": 2000}}
-    },
+streaming_msg = (
+    "Use the math_add tool to calculate 12345 + 67890, then briefly explain "
+    "how the result was obtained."
 )
 
-camel_agent = ChatAgent(model=model)
+print("\nStreaming answer:")
+streaming_response = streaming_agent.step(streaming_msg)
 
-user_msg = """Are there an infinite number of prime numbers such that n mod 4
-== 3?"""
+for chunk_response in streaming_response:
+    if not chunk_response.msgs:
+        continue
 
-response = camel_agent.step(user_msg)
-print(response.msgs[0].content)
+    chunk = chunk_response.msgs[0]
+    if chunk.reasoning_content:
+        print(chunk.reasoning_content, end="", flush=True)
+    if chunk.content:
+        print(chunk.content, end="", flush=True)
 
-"""
-===============================================================================
-Yes, there are infinitely many primes congruent to 3 modulo 4.
-
-Here's a classic elementary proof by contradiction:
-
-**Proof:**
-
-Suppose there are only finitely many primes ≡ 3 (mod 4). Let's call them p₁, p₂, ..., pₖ.
-
-Consider the number:
-N = 4p₁p₂...pₖ - 1
-
-Note that N ≡ 3 (mod 4) since N = 4(p₁p₂...pₖ) - 1.
-
-Now, N must have prime factorization. Let's analyze the primes that divide N:
-
-1) N is odd (since N ≡ 3 (mod 4)), so 2 doesn't divide N.
-
-2) None of p₁, p₂, ..., pₖ divide N, because if pᵢ divided N, then pᵢ would divide N - 4p₁p₂...pₖ = -1, which is impossible.
-
-3) Every odd prime is either ≡ 1 (mod 4) or ≡ 3 (mod 4).
-
-4) The product of primes that are all ≡ 1 (mod 4) is also ≡ 1 (mod 4), since 1 * 1 * ... * 1 ≡ 1 (mod 4).
-
-5) Since N ≡ 3 (mod 4), at least one prime factor of N must be ≡ 3 (mod 4).
-
-6) But this prime cannot be any of p₁, p₂, ..., pₖ (from point 2), so there must be another prime ≡ 3 (mod 4).
-
-This contradicts our assumption that p₁, p₂, ..., pₖ were all such primes.
-
-Therefore, there are infinitely many primes ≡ 3 (mod 4).
-
-**Note:** This is actually a special case of Dirichlet's theorem on primes in arithmetic progressions, which states that for coprime integers a and d, there are infinitely many primes p such that p ≡ a (mod d).
-===============================================================================
-"""  # noqa: E501
+stream_tool_calls = streaming_response.info.get("tool_calls", [])
+if stream_tool_calls:
+    print("\n\nStreaming tool calls:")
+    print(stream_tool_calls)

--- a/examples/models/anthropic_model_example.py
+++ b/examples/models/anthropic_model_example.py
@@ -10,6 +10,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+
 from camel.agents import ChatAgent
 from camel.configs import AnthropicConfig
 from camel.models import ModelFactory

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "camel-ai"
-version = "0.2.91a3"
+version = "0.2.91a4"
 description = "Communicative Agents for AI Society Study"
 authors = [{ name = "CAMEL-AI.org" }]
 requires-python = ">=3.10,<3.15"

--- a/test/models/test_anthropic_model.py
+++ b/test/models/test_anthropic_model.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -112,6 +113,17 @@ def test_anthropic_model_cache_control_from_config():
         "type": "ephemeral",
         "ttl": "1h",
     }
+
+
+def test_anthropic_config_thinking_and_output_config():
+    """Test Anthropic thinking-related config fields."""
+    config = AnthropicConfig(
+        thinking={"type": "adaptive"},
+        output_config={"effort": "medium"},
+    ).as_dict()
+
+    assert config["thinking"] == {"type": "adaptive"}
+    assert config["output_config"] == {"effort": "medium"}
 
 
 def test_anthropic_model_stream_property():
@@ -226,7 +238,7 @@ def test_convert_openai_to_anthropic_system_message_list_content():
         {"role": "user", "content": "Hello"},
     ]
 
-    system_msg, anthropic_msgs = model._convert_openai_to_anthropic_messages(
+    system_msg, _anthropic_msgs = model._convert_openai_to_anthropic_messages(
         messages
     )
 
@@ -301,12 +313,10 @@ def test_convert_anthropic_response_text_only():
         api_key="dummy_api_key",
     )
 
-    # Create mock response
     mock_response = MagicMock()
-    mock_text_block = MagicMock()
-    mock_text_block.type = "text"
-    mock_text_block.text = "Hello, how can I help?"
-    mock_response.content = [mock_text_block]
+    mock_response.content = [
+        SimpleNamespace(type="text", text="Hello, how can I help?")
+    ]
     mock_response.stop_reason = "end_turn"
     mock_response.id = "msg_123"
     mock_response.usage = MagicMock()
@@ -368,19 +378,16 @@ def test_convert_anthropic_response_with_tool_use():
         api_key="dummy_api_key",
     )
 
-    # Create mock response with tool use
     mock_response = MagicMock()
-    mock_text_block = MagicMock()
-    mock_text_block.type = "text"
-    mock_text_block.text = "I'll search for that."
-
-    mock_tool_block = MagicMock()
-    mock_tool_block.type = "tool_use"
-    mock_tool_block.id = "tool_123"
-    mock_tool_block.name = "search"
-    mock_tool_block.input = {"query": "test"}
-
-    mock_response.content = [mock_text_block, mock_tool_block]
+    mock_response.content = [
+        SimpleNamespace(type="text", text="I'll search for that."),
+        SimpleNamespace(
+            type="tool_use",
+            id="tool_123",
+            name="search",
+            input={"query": "test"},
+        ),
+    ]
     mock_response.stop_reason = "tool_use"
     mock_response.id = "msg_123"
     mock_response.usage = MagicMock()
@@ -398,6 +405,114 @@ def test_convert_anthropic_response_with_tool_use():
     assert tool_calls[0].id == "tool_123"
     assert tool_calls[0].type == "function"
     assert tool_calls[0].function.name == "search"
+
+
+def test_convert_anthropic_response_with_thinking_blocks():
+    """Test conversion of Anthropic thinking blocks."""
+    model = AnthropicModel(
+        ModelType.CLAUDE_HAIKU_4_5,
+        api_key="dummy_api_key",
+    )
+
+    mock_response = MagicMock()
+    mock_response.content = [
+        {
+            "type": "thinking",
+            "thinking": "I should inspect the data first.",
+            "signature": "sig_123",
+        },
+        {"type": "redacted_thinking", "data": "opaque"},
+        {"type": "text", "text": "The answer is 42."},
+        {
+            "type": "tool_use",
+            "id": "tool_123",
+            "name": "search",
+            "input": {"query": "test"},
+        },
+    ]
+    mock_response.stop_reason = "tool_use"
+    mock_response.id = "msg_thinking"
+    mock_response.usage = MagicMock()
+    mock_response.usage.input_tokens = 10
+    mock_response.usage.output_tokens = 5
+
+    result = model._convert_anthropic_to_openai_response(
+        mock_response, "claude-haiku-4-5"
+    )
+
+    message = result.choices[0].message
+    assert message.content == "The answer is 42."
+    assert message.reasoning_content == "I should inspect the data first."
+    assert message.anthropic_thinking_blocks == [
+        {
+            "type": "thinking",
+            "thinking": "I should inspect the data first.",
+            "signature": "sig_123",
+        },
+        {"type": "redacted_thinking", "data": "opaque"},
+    ]
+    assert model._tool_call_thinking_blocks["tool_123"] == [
+        {
+            "type": "thinking",
+            "thinking": "I should inspect the data first.",
+            "signature": "sig_123",
+        },
+        {"type": "redacted_thinking", "data": "opaque"},
+    ]
+    assert message.tool_calls[0].extra_content == {
+        "anthropic_thinking_blocks": [
+            {
+                "type": "thinking",
+                "thinking": "I should inspect the data first.",
+                "signature": "sig_123",
+            },
+            {"type": "redacted_thinking", "data": "opaque"},
+        ]
+    }
+
+
+def test_convert_openai_to_anthropic_reuses_tool_call_thinking_blocks():
+    """Test tool-use continuation includes tool call thinking blocks."""
+    model = AnthropicModel(
+        ModelType.CLAUDE_HAIKU_4_5,
+        api_key="dummy_api_key",
+    )
+
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_123",
+                    "function": {
+                        "name": "search",
+                        "arguments": '{"query": "test"}',
+                    },
+                    "extra_content": {
+                        "anthropic_thinking_blocks": [
+                            {
+                                "type": "thinking",
+                                "thinking": "Need this tool.",
+                                "signature": "sig_123",
+                            }
+                        ]
+                    },
+                }
+            ],
+        }
+    ]
+
+    _, anthropic_msgs = model._convert_openai_to_anthropic_messages(messages)
+
+    content = anthropic_msgs[0]["content"]
+    assert content[0] == {
+        "type": "thinking",
+        "thinking": "Need this tool.",
+        "signature": "sig_123",
+    }
+    assert content[1]["type"] == "tool_use"
+    assert content[1]["id"] == "call_123"
 
 
 def test_convert_anthropic_response_stop_reasons():
@@ -577,6 +692,122 @@ def test_convert_stream_chunk_content_block_delta_text():
     assert result.choices[0].delta.content == "Hello"
 
 
+def test_convert_stream_chunk_content_block_delta_thinking():
+    """Test conversion of thinking_delta chunks."""
+    model = AnthropicModel(
+        ModelType.CLAUDE_HAIKU_4_5,
+        api_key="dummy_api_key",
+    )
+
+    thinking_state = {}
+
+    mock_chunk = SimpleNamespace(
+        type="content_block_delta",
+        index=0,
+        delta=SimpleNamespace(
+            type="thinking_delta",
+            thinking="Let me reason.",
+        ),
+    )
+
+    tool_call_index = {}
+    result = model._convert_anthropic_stream_to_openai_chunk(
+        mock_chunk,
+        "claude-haiku-4-5",
+        tool_call_index,
+        thinking_state=thinking_state,
+    )
+
+    assert result.choices[0].delta.reasoning_content == "Let me reason."
+
+    mock_signature_chunk = SimpleNamespace(
+        type="content_block_delta",
+        index=0,
+        delta=SimpleNamespace(
+            type="signature_delta",
+            signature="sig_123",
+        ),
+    )
+
+    model._convert_anthropic_stream_to_openai_chunk(
+        mock_signature_chunk,
+        "claude-haiku-4-5",
+        tool_call_index,
+        thinking_state=thinking_state,
+    )
+
+    mock_stop_chunk = SimpleNamespace(type="content_block_stop", index=0)
+
+    model._convert_anthropic_stream_to_openai_chunk(
+        mock_stop_chunk,
+        "claude-haiku-4-5",
+        tool_call_index,
+        thinking_state=thinking_state,
+    )
+
+    assert thinking_state["thinking_blocks"] == [
+        {
+            "type": "thinking",
+            "thinking": "Let me reason.",
+            "signature": "sig_123",
+        }
+    ]
+
+
+def test_convert_stream_tool_use_start_includes_thinking_blocks():
+    """Test streamed tool calls carry thinking blocks in extra_content."""
+    model = AnthropicModel(
+        ModelType.CLAUDE_HAIKU_4_5,
+        api_key="dummy_api_key",
+    )
+
+    mock_chunk = SimpleNamespace(
+        type="content_block_start",
+        index=1,
+        content_block=SimpleNamespace(
+            type="tool_use",
+            id="tool_123",
+            name="search",
+        ),
+    )
+
+    thinking_state = {
+        "thinking_blocks": [
+            {
+                "type": "thinking",
+                "thinking": "Use a search tool.",
+                "signature": "sig_123",
+            }
+        ]
+    }
+    tool_call_index = {}
+
+    result = model._convert_anthropic_stream_to_openai_chunk(
+        mock_chunk,
+        "claude-haiku-4-5",
+        tool_call_index,
+        thinking_state=thinking_state,
+    )
+
+    tool_call = result.choices[0].delta.tool_calls[0]
+    assert tool_call.extra_content == {
+        "anthropic_thinking_blocks": [
+            {
+                "type": "thinking",
+                "thinking": "Use a search tool.",
+                "signature": "sig_123",
+            }
+        ]
+    }
+    assert model._tool_call_thinking_blocks["tool_123"] == [
+        {
+            "type": "thinking",
+            "thinking": "Use a search tool.",
+            "signature": "sig_123",
+        }
+    ]
+
+
 def test_convert_stream_chunk_tool_use_start():
     """Test conversion of tool_use content_block_start chunk."""
     model = AnthropicModel(
@@ -584,12 +815,14 @@ def test_convert_stream_chunk_tool_use_start():
         api_key="dummy_api_key",
     )
 
-    mock_chunk = MagicMock()
-    mock_chunk.type = "content_block_start"
-    mock_chunk.content_block = MagicMock()
-    mock_chunk.content_block.type = "tool_use"
-    mock_chunk.content_block.id = "tool_123"
-    mock_chunk.content_block.name = "search"
+    mock_chunk = SimpleNamespace(
+        type="content_block_start",
+        content_block=SimpleNamespace(
+            type="tool_use",
+            id="tool_123",
+            name="search",
+        ),
+    )
 
     tool_call_index = {}
     result = model._convert_anthropic_stream_to_openai_chunk(
@@ -704,6 +937,8 @@ def test_run_passes_output_config_tool_choice_and_extra_fields():
     config = AnthropicConfig(
         max_tokens=128,
         tool_choice={"type": "auto"},
+        thinking={"type": "adaptive"},
+        output_config={"effort": "medium"},
         extra_headers={"x-test-header": "1"},
         extra_body={
             "existing": True,
@@ -746,12 +981,51 @@ def test_run_passes_output_config_tool_choice_and_extra_fields():
     request_kwargs = mock_client.messages.create.call_args.kwargs
 
     assert request_kwargs["tool_choice"] == {"type": "auto"}
+    assert request_kwargs["thinking"] == {"type": "adaptive"}
     assert request_kwargs["extra_headers"] == {"x-test-header": "1"}
     assert request_kwargs["extra_body"]["existing"] is True
     assert "output_config" not in request_kwargs["extra_body"]
+    assert request_kwargs["output_config"]["effort"] == "medium"
     assert request_kwargs["output_config"]["format"]["type"] == "json_schema"
     assert request_kwargs["tools"][0]["strict"] is True
     assert result.choices[0].message.content == '{"city":"Kyoto"}'
+
+
+def test_run_rejects_forced_tool_choice_with_thinking():
+    """Test Anthropic thinking rejects forced tool_choice with tools."""
+    mock_client = MagicMock()
+    mock_async_client = MagicMock()
+
+    config = AnthropicConfig(
+        max_tokens=128,
+        tool_choice={"type": "any"},
+        thinking={"type": "enabled", "budget_tokens": 1024},
+    ).as_dict()
+
+    model = AnthropicModel(
+        ModelType.CLAUDE_HAIKU_4_5,
+        model_config_dict=config,
+        api_key="dummy_api_key",
+        client=mock_client,
+        async_client=mock_async_client,
+    )
+
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get weather",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+
+    with pytest.raises(ValueError, match="extended thinking with tools"):
+        model._run(
+            messages=[{"role": "user", "content": "Plan a trip"}],
+            tools=tools,
+        )
 
 
 @pytest.mark.asyncio
@@ -772,6 +1046,8 @@ async def test_arun_passes_output_config_tool_choice_and_extra_fields():
     config = AnthropicConfig(
         max_tokens=128,
         tool_choice={"type": "auto"},
+        thinking={"type": "adaptive"},
+        output_config={"effort": "low"},
         extra_headers={"x-test-header": "1"},
         extra_body={"existing": True},
     ).as_dict()
@@ -814,8 +1090,10 @@ async def test_arun_passes_output_config_tool_choice_and_extra_fields():
     request_kwargs = mock_async_client.messages.create.call_args.kwargs
 
     assert request_kwargs["tool_choice"] == {"type": "auto"}
+    assert request_kwargs["thinking"] == {"type": "adaptive"}
     assert request_kwargs["extra_headers"] == {"x-test-header": "1"}
     assert request_kwargs["extra_body"]["existing"] is True
+    assert request_kwargs["output_config"]["effort"] == "low"
     assert request_kwargs["output_config"]["format"]["type"] == "json_schema"
     output_schema = request_kwargs["output_config"]["format"]["schema"]
     assert output_schema["additionalProperties"] is False

--- a/uv.lock
+++ b/uv.lock
@@ -762,35 +762,35 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.42.96"
+version = "1.43.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a6/2d/69fb3acd50bab83fb295c167d33c4b653faeb5fb0f42bfca4d9b69d6fb68/boto3-1.42.96.tar.gz", hash = "sha256:b38a9e4a3fbbee9017252576f1379780d0a5814768676c08df2f539d31fcdd68", size = 113203, upload-time = "2026-04-24T19:47:18.677Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/65/47670987f2f9e181397872c7ee6415b7b95156d711b7eab6c55f66e575bc/boto3-1.43.0.tar.gz", hash = "sha256:80d44a943ef90aba7958ab31d30c155c198acc8a9581b5846b3878b2c8951086", size = 113143, upload-time = "2026-04-29T22:07:49.084Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/9d/b3f617d011c42eb804d993103b8fa9acdce153e181a3042f58bfe33d7cb4/boto3-1.42.96-py3-none-any.whl", hash = "sha256:2f4566da2c209a98bdbfc874d813ef231c84ad24e4f815e9bc91de5f63351a24", size = 140557, upload-time = "2026-04-24T19:47:15.824Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/a0/3e6a0b1c1ea6bec76f71473727ef27abf3cd40e9709b3ebcbfbcfaae6f79/boto3-1.43.0-py3-none-any.whl", hash = "sha256:8ebe03754a4b73a5cb6ec2f14cca03ac33bd4760d0adea53da4724845130258b", size = 140497, upload-time = "2026-04-29T22:07:46.216Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.42.96"
+version = "1.43.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/61/77/2c333622a1d47cf5bf73cdcab0cb6c92addafbef2ec05f81b9f75687d9e5/botocore-1.42.96.tar.gz", hash = "sha256:75b3b841ffacaa944f645196655a21ca777591dd8911e732bfb6614545af0250", size = 15263344, upload-time = "2026-04-24T19:47:05.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/79/2f4be1896db3db7ccf44504253a175d56b6bd6b669619edc5147d1aa21ea/botocore-1.43.0.tar.gz", hash = "sha256:e933b31a2d644253e1d029d7d39e99ba41b87e29300534f189744cc438cdf928", size = 15286817, upload-time = "2026-04-29T22:07:31.723Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/56/152c3a859ca1b9d77ed16deac3cf81682013677c68cf5715698781fc81bd/botocore-1.42.96-py3-none-any.whl", hash = "sha256:db2c3e2006628be6fde81a24124a6563c363d6982fb92728837cf174bad9d98a", size = 14945920, upload-time = "2026-04-24T19:47:00.323Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/4b/afc1fef8a43bafb139f57f73bbd70df82807af5934321e8112ae50668827/botocore-1.43.0-py3-none-any.whl", hash = "sha256:cc5b15eaec3c6eac05d8012cb5ef17ebe891beb88a16ca13c374bfaece1241e6", size = 14970102, upload-time = "2026-04-29T22:07:27Z" },
 ]
 
 [[package]]
 name = "build"
-version = "1.4.4"
+version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "(python_full_version >= '3.13' and os_name == 'nt' and sys_platform == 'darwin') or (python_full_version >= '3.13' and os_name == 'nt' and sys_platform == 'linux') or (os_name == 'nt' and platform_machine != 'aarch64' and sys_platform == 'linux') or (os_name == 'nt' and sys_platform != 'darwin' and sys_platform != 'linux')" },
@@ -799,9 +799,9 @@ dependencies = [
     { name = "pyproject-hooks" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/02/ec/bf5ae0a7e5ab57abe8aabdd0759c971883895d1a20c49ae99f8146840c3c/build-1.4.4.tar.gz", hash = "sha256:f832ae053061f3fb524af812dc94b8b84bac6880cd587630e3b5d91a6a9c1703", size = 89220, upload-time = "2026-04-22T20:53:44.807Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/e0/df5e171f685f82f37b12e1f208064e24244911079d7b767447d1af7e0d70/build-1.5.0.tar.gz", hash = "sha256:302c22c3ba2a0fd5f3911918651341ebb3896176cbdec15bd421f80b1afc7647", size = 89796, upload-time = "2026-04-30T03:18:25.17Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/88/6764e7a109dd84294850741501145da90d13cdeac9d4e614929464a37420/build-1.4.4-py3-none-any.whl", hash = "sha256:8c3f48a6090b39edec1a273d2d57949aaf13723b01e02f9d518396887519f64d", size = 25921, upload-time = "2026-04-22T20:53:43.251Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl", hash = "sha256:13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f", size = 26018, upload-time = "2026-04-30T03:18:23.644Z" },
 ]
 
 [[package]]
@@ -815,7 +815,7 @@ wheels = [
 
 [[package]]
 name = "camel-ai"
-version = "0.2.91a3"
+version = "0.2.91a4"
 source = { editable = "." }
 dependencies = [
     { name = "astor" },
@@ -2519,15 +2519,15 @@ wheels = [
 
 [[package]]
 name = "cssutils"
-version = "2.14.0"
+version = "2.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "encutils" },
     { name = "more-itertools" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/40/73/4ced8c775cd5f64876f0d5b9dfae354dc96e50273c3d904f070965a27ec9/cssutils-2.14.0.tar.gz", hash = "sha256:c33256f0cbc215ad405b647117ace63c9e22af96fe42dcb7861742a591e6464c", size = 714703, upload-time = "2026-04-19T23:51:18.609Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/00/7e89107ea389e952eea73b1b90ac6633e15a519c4a518ee90bb93a2f83dc/cssutils-2.15.0.tar.gz", hash = "sha256:e9739237f3915037dacba787c4b58f280e3ec5d9864953e185bf23d40ff7d021", size = 716080, upload-time = "2026-04-27T20:40:35.615Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/67/d1/b5e96174be14e4657e5dd148a52af48fc42d3fab35b2cd56202b6473ee2e/cssutils-2.14.0-py3-none-any.whl", hash = "sha256:79ad979e4a383f39f0b3f0ca82ee3f1b01065da9fa02701b63bfed38ac76eb91", size = 180097, upload-time = "2026-04-19T23:51:17.172Z" },
+    { url = "https://files.pythonhosted.org/packages/01/bf/5669e08a6f53e0d4b4648a989e77163ad36d4718195319c8c5af08ded654/cssutils-2.15.0-py3-none-any.whl", hash = "sha256:207faa466810a1aef109261673f2458356d0839ddedaebc0ee553376290fb6a9", size = 180638, upload-time = "2026-04-27T20:40:34.178Z" },
 ]
 
 [[package]]
@@ -2623,7 +2623,7 @@ wheels = [
 
 [[package]]
 name = "daytona-api-client"
-version = "0.169.0"
+version = "0.170.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -2631,14 +2631,14 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/40/e9a68fce710f8141f892630b083cbfce01b6b172e48f52496f975b1bcf68/daytona_api_client-0.169.0.tar.gz", hash = "sha256:876aead483bd217667ae7c3e32677b413c75197bfa99be8f11ce51ccfa3be3df", size = 148544, upload-time = "2026-04-24T08:16:12.997Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/f6/a1ca54b2f9bc265fb08f53a93b34b73080b348bc18e28bd584f0af039be5/daytona_api_client-0.170.0.tar.gz", hash = "sha256:1a7361f678802c46209e56d22814e2fc2364091499ca0b2e300f78f120d5871c", size = 147529, upload-time = "2026-04-29T08:41:30.731Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/7b/4809b6b298195942484b4c495bf569c9d1c80cd252e9d3d16dc0f6f65ff6/daytona_api_client-0.169.0-py3-none-any.whl", hash = "sha256:f69d390b7f3b49dd2696fc6724ac3adeddac82720b4dc7a062a13868dfbe5d5c", size = 409335, upload-time = "2026-04-24T08:16:11.166Z" },
+    { url = "https://files.pythonhosted.org/packages/41/14/541add72a780ea603b4025dcdcdb1d6165da139202d8393c92ac8198a5d7/daytona_api_client-0.170.0-py3-none-any.whl", hash = "sha256:5f27e94594b89a618266e47e255526b0a57eacd7230c5097f24fb9bd35149869", size = 407332, upload-time = "2026-04-29T08:41:28.777Z" },
 ]
 
 [[package]]
 name = "daytona-api-client-async"
-version = "0.169.0"
+version = "0.170.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -2646,16 +2646,15 @@ dependencies = [
     { name = "pydantic" },
     { name = "python-dateutil" },
     { name = "typing-extensions" },
-    { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/89/66/b781e326d793d0b7866f9eb0ee9c33d51ac603ce29a3a5e60b03df2d02a4/daytona_api_client_async-0.169.0.tar.gz", hash = "sha256:d3ce3039b3edf13344a0da5745fb9d698ef8f52fbc51644d81c979b8829a2181", size = 148764, upload-time = "2026-04-24T08:16:47.055Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/3e/203905997ee86b4d0c4c4a2c4ff31cae7e2502bfc9a65e6036660aadc56c/daytona_api_client_async-0.170.0.tar.gz", hash = "sha256:2703972dcafa4c8a25d7dea07cae9ad96300d80ace994ffe5cedc1bfbde76aea", size = 148006, upload-time = "2026-04-29T08:42:18.87Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/40/2e0809fd85a5ab8245e6852503195b40bfd1a9b4ba1cc5e2329ff94b944f/daytona_api_client_async-0.169.0-py3-none-any.whl", hash = "sha256:72f50e94104880c0280b3f1bc7c254f704dfd45dedf442fa2b2d7a6288e95016", size = 412424, upload-time = "2026-04-24T08:16:45.115Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/be/11f1cd5b1ac9c266d2f9443c25a3295081fc35b2586336913136bccd92c8/daytona_api_client_async-0.170.0-py3-none-any.whl", hash = "sha256:a1b3f0a132ad9b215cff3ca2cc231cec4215618a49931a111d861e5a93fc237d", size = 410576, upload-time = "2026-04-29T08:42:17.2Z" },
 ]
 
 [[package]]
 name = "daytona-sdk"
-version = "0.169.0"
+version = "0.170.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -2677,14 +2676,14 @@ dependencies = [
     { name = "urllib3" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/32/d7/bc5db302576609dd6d90ce4346c74609a0b6edb76eb441930a729bf9f148/daytona_sdk-0.169.0.tar.gz", hash = "sha256:43d5acd8b6eddeedd7441da7799e2eb531b651d999226040ba84eb7ac6d0b962", size = 122830, upload-time = "2026-04-24T08:17:27.982Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/38/b37ce4065f8faee26b334ebcc98d56fc6e043a96cc85627342fd3fe8fa04/daytona_sdk-0.170.0.tar.gz", hash = "sha256:f25ff034a77e6b77bc4ba5b7aee9f1d39d1643941004aa8b152a0388fd186a83", size = 123247, upload-time = "2026-04-29T10:21:38.128Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/64/c7162fe471e9674fca6d57432c1d00300baafe8a962819d2c9a875de12b1/daytona_sdk-0.169.0-py3-none-any.whl", hash = "sha256:e9abc16fa8b56b272471da576d4af82593e286834ab2d834bc614a6a741123b9", size = 152349, upload-time = "2026-04-24T08:17:26.009Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/e9/e253a8ccaf32d9120145d86f5ff18e919d2c57bc9d260ee9ab38500cfc6e/daytona_sdk-0.170.0-py3-none-any.whl", hash = "sha256:d026c69a0b43aefbfe05fbe4b91ff989bed038fe59351c825cfe26d003618db1", size = 152756, upload-time = "2026-04-29T10:21:36.219Z" },
 ]
 
 [[package]]
 name = "daytona-toolbox-api-client"
-version = "0.169.0"
+version = "0.170.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -2692,14 +2691,14 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c3/18/8ae3c031d1ea27bd02a88def50c0aa3ba21c7a77e5820cc31fed40cad28f/daytona_toolbox_api_client-0.169.0.tar.gz", hash = "sha256:352fb946a504858dc551584ed557a60eb2c5c6e339ae8c5ff6b80a820f99439b", size = 69737, upload-time = "2026-04-24T08:16:20.63Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/98/6b6d8b5e63049e041ce81993c0705de736a263a7633018d4b10a6a258371/daytona_toolbox_api_client-0.170.0.tar.gz", hash = "sha256:ec95a6dd8f79566fefb07acc50cf15b06c05a60c5bf112163e2416d6af3b5e24", size = 73947, upload-time = "2026-04-29T08:41:55.523Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/92/357e1fb494d8b04d99f999bd0048a2d3cf12b3562c3b8974b7b7bef90e7b/daytona_toolbox_api_client-0.169.0-py3-none-any.whl", hash = "sha256:b800986b08d903e0252ab8a2d346f238e405de7030ff82b82014185ddc3e15a9", size = 187620, upload-time = "2026-04-24T08:16:18.886Z" },
+    { url = "https://files.pythonhosted.org/packages/61/23/da82071a42d7ef82e9aa40fa32bbd9955d02709315e1627988ec3d667a7b/daytona_toolbox_api_client-0.170.0-py3-none-any.whl", hash = "sha256:215b8acbe6b1096e27e852ecfc4b56ab1ad65ba923896fca46ccdd82aeb7c467", size = 191409, upload-time = "2026-04-29T08:41:53.79Z" },
 ]
 
 [[package]]
 name = "daytona-toolbox-api-client-async"
-version = "0.169.0"
+version = "0.170.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -2707,11 +2706,10 @@ dependencies = [
     { name = "pydantic" },
     { name = "python-dateutil" },
     { name = "typing-extensions" },
-    { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c3/ee/40139eaf32d31f0e7e8662841d08026fce4e05935c18532f44dd9e858552/daytona_toolbox_api_client_async-0.169.0.tar.gz", hash = "sha256:0c78be8c4f8acee54f6ec1c7f94a0d128f8a03930122dc8d6145a024592e86b2", size = 66812, upload-time = "2026-04-24T08:16:36.385Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/2a/390ce2b25069fe4df554fea391470f15763f21028b8bfc395cb908f71452/daytona_toolbox_api_client_async-0.170.0.tar.gz", hash = "sha256:e2e2a5b9a5aed3bb406221238949cf8bd3a98226c9fb4fc4ae1aec82193682da", size = 67524, upload-time = "2026-04-29T08:42:16.177Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/1a/748d844f7ba52190db9af447c501abf69402333e79857de2d9b972e001a4/daytona_toolbox_api_client_async-0.169.0-py3-none-any.whl", hash = "sha256:565cbdb56895c149b0782a1b165ba029cc5bc35309cc6586253eda54b3ac335c", size = 189045, upload-time = "2026-04-24T08:16:35.185Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/4a/7107d7b1ad5b6288330f15bd7074a952b7dba51fb9885e16132c68b10dc6/daytona_toolbox_api_client_async-0.170.0-py3-none-any.whl", hash = "sha256:56c198098fc04ef7fd9358b1128337a03ab31adf408fb6f5cfa49fdfe33b4f17", size = 189537, upload-time = "2026-04-29T08:42:14.96Z" },
 ]
 
 [[package]]
@@ -3786,7 +3784,7 @@ wheels = [
 
 [[package]]
 name = "google-genai"
-version = "1.73.1"
+version = "1.74.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -3800,9 +3798,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/d8/40f5f107e5a2976bbac52d421f04d14fc221b55a8f05e66be44b2f739fe6/google_genai-1.73.1.tar.gz", hash = "sha256:b637e3a3b9e2eccc46f27136d470165803de84eca52abfed2e7352081a4d5a15", size = 530998, upload-time = "2026-04-14T21:06:19.153Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/c8/4a8f1de0a3268d526a345b8c74456b3e1e6ffd200982626326cf7ca83e5b/google_genai-1.74.0.tar.gz", hash = "sha256:c4c473cebdeb6e5adbb0639326de66a3a85a2209e0d32de7d66bf05c698abae8", size = 536772, upload-time = "2026-04-29T22:16:35.881Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/af/508e0528015240d710c6763f7c89ff44fab9a94a80b4377e265d692cbfd6/google_genai-1.73.1-py3-none-any.whl", hash = "sha256:af2d2287d25e42a187de19811ef33beb2e347c7e2bdb4dc8c467d78254e43a2c", size = 783595, upload-time = "2026-04-14T21:06:17.464Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/2b/539c328b66f7bfef2df869371a1789361228e5a7694ba02a642608367b46/google_genai-1.74.0-py3-none-any.whl", hash = "sha256:87d0b311c67d4b2a0ca741e9fc6891330c29defae81d46d8db41079aa1a3d80a", size = 790433, upload-time = "2026-04-29T22:16:33.979Z" },
 ]
 
 [[package]]
@@ -3891,68 +3889,68 @@ wheels = [
 
 [[package]]
 name = "greenlet"
-version = "3.4.0"
+version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/86/94/a5935717b307d7c71fe877b52b884c6af707d2d2090db118a03fbd799369/greenlet-3.4.0.tar.gz", hash = "sha256:f50a96b64dafd6169e595a5c56c9146ef80333e67d4476a65a9c55f400fc22ff", size = 195913, upload-time = "2026-04-08T17:08:00.863Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/3f/dbf99fb14bfeb88c28f16729215478c0e265cacd6dc22270c8f31bb6892f/greenlet-3.5.0.tar.gz", hash = "sha256:d419647372241bc68e957bf38d5c1f98852155e4146bd1e4121adea81f4f01e4", size = 196995, upload-time = "2026-04-27T13:37:15.544Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/bc/e30e1e3d5e8860b0e0ce4d2b16b2681b77fd13542fc0d72f7e3c22d16eff/greenlet-3.4.0-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:d18eae9a7fb0f499efcd146b8c9750a2e1f6e0e93b5a382b3481875354a430e6", size = 284315, upload-time = "2026-04-08T17:02:52.322Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/cc/e023ae1967d2a26737387cac083e99e47f65f58868bd155c4c80c01ec4e0/greenlet-3.4.0-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:636d2f95c309e35f650e421c23297d5011716be15d966e6328b367c9fc513a82", size = 601916, upload-time = "2026-04-08T16:24:35.533Z" },
-    { url = "https://files.pythonhosted.org/packages/67/32/5be1677954b6d8810b33abe94e3eb88726311c58fa777dc97e390f7caf5a/greenlet-3.4.0-cp310-cp310-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:234582c20af9742583c3b2ddfbdbb58a756cfff803763ffaae1ac7990a9fac31", size = 616399, upload-time = "2026-04-08T16:30:54.536Z" },
-    { url = "https://files.pythonhosted.org/packages/82/0a/3a4af092b09ea02bcda30f33fd7db397619132fe52c6ece24b9363130d34/greenlet-3.4.0-cp310-cp310-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ac6a5f618be581e1e0713aecec8e54093c235e5fa17d6d8eb7ffc487e2300508", size = 621077, upload-time = "2026-04-08T16:40:34.946Z" },
-    { url = "https://files.pythonhosted.org/packages/74/bf/2d58d5ea515704f83e34699128c9072a34bea27d2b6a556e102105fe62a5/greenlet-3.4.0-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:523677e69cd4711b5a014e37bc1fb3a29947c3e3a5bb6a527e1cc50312e5a398", size = 611978, upload-time = "2026-04-08T15:56:31.335Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/39/3786520a7d5e33ee87b3da2531f589a3882abf686a42a3773183a41ef010/greenlet-3.4.0-cp310-cp310-manylinux_2_39_riscv64.whl", hash = "sha256:d336d46878e486de7d9458653c722875547ac8d36a1cff9ffaf4a74a3c1f62eb", size = 416893, upload-time = "2026-04-08T16:43:02.392Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/69/6525049b6c179d8a923256304d8387b8bdd4acab1acf0407852463c6d514/greenlet-3.4.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b45e45fe47a19051a396abb22e19e7836a59ee6c5a90f3be427343c37908d65b", size = 1571957, upload-time = "2026-04-08T16:26:17.041Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/6c/bbfb798b05fec736a0d24dc23e81b45bcee87f45a83cfb39db031853bddc/greenlet-3.4.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5434271357be07f3ad0936c312645853b7e689e679e29310e2de09a9ea6c3adf", size = 1637223, upload-time = "2026-04-08T15:57:27.556Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/7d/981fe0e7c07bd9d5e7eb18decb8590a11e3955878291f7a7de2e9c668eb7/greenlet-3.4.0-cp310-cp310-win_amd64.whl", hash = "sha256:a19093fbad824ed7c0f355b5ff4214bffda5f1a7f35f29b31fcaa240cc0135ab", size = 237902, upload-time = "2026-04-08T17:03:14.16Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/c6/dba32cab7e3a625b011aa5647486e2d28423a48845a2998c126dd69c85e1/greenlet-3.4.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:805bebb4945094acbab757d34d6e1098be6de8966009ab9ca54f06ff492def58", size = 285504, upload-time = "2026-04-08T15:52:14.071Z" },
-    { url = "https://files.pythonhosted.org/packages/54/f4/7cb5c2b1feb9a1f50e038be79980dfa969aa91979e5e3a18fdbcfad2c517/greenlet-3.4.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:439fc2f12b9b512d9dfa681c5afe5f6b3232c708d13e6f02c845e0d9f4c2d8c6", size = 605476, upload-time = "2026-04-08T16:24:37.064Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/af/b66ab0b2f9a4c5a867c136bf66d9599f34f21a1bcca26a2884a29c450bd9/greenlet-3.4.0-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a70ed1cb0295bee1df57b63bf7f46b4e56a5c93709eea769c1fec1bb23a95875", size = 618336, upload-time = "2026-04-08T16:30:56.59Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/31/56c43d2b5de476f77d36ceeec436328533bff960a4cba9a07616e93063ab/greenlet-3.4.0-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8c5696c42e6bb5cfb7c6ff4453789081c66b9b91f061e5e9367fa15792644e76", size = 625045, upload-time = "2026-04-08T16:40:37.111Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/5c/8c5633ece6ba611d64bf2770219a98dd439921d6424e4e8cf16b0ac74ea5/greenlet-3.4.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c660bce1940a1acae5f51f0a064f1bc785d07ea16efcb4bc708090afc4d69e83", size = 613515, upload-time = "2026-04-08T15:56:32.478Z" },
-    { url = "https://files.pythonhosted.org/packages/80/ca/704d4e2c90acb8bdf7ae593f5cbc95f58e82de95cc540fb75631c1054533/greenlet-3.4.0-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:89995ce5ddcd2896d89615116dd39b9703bfa0c07b583b85b89bf1b5d6eddf81", size = 419745, upload-time = "2026-04-08T16:43:04.022Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/df/950d15bca0d90a0e7395eb777903060504cdb509b7b705631e8fb69ff415/greenlet-3.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ee407d4d1ca9dc632265aee1c8732c4a2d60adff848057cdebfe5fe94eb2c8a2", size = 1574623, upload-time = "2026-04-08T16:26:18.596Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/e7/0839afab829fcb7333c9ff6d80c040949510055d2d4d63251f0d1c7c804e/greenlet-3.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:956215d5e355fffa7c021d168728321fd4d31fd730ac609b1653b450f6a4bc71", size = 1639579, upload-time = "2026-04-08T15:57:29.231Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/2b/b4482401e9bcaf9f5c97f67ead38db89c19520ff6d0d6699979c6efcc200/greenlet-3.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:5cb614ace7c27571270354e9c9f696554d073f8aa9319079dcba466bbdead711", size = 238233, upload-time = "2026-04-08T17:02:54.286Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/4d/d8123a4e0bcd583d5cfc8ddae0bbe29c67aab96711be331a7cc935a35966/greenlet-3.4.0-cp311-cp311-win_arm64.whl", hash = "sha256:04403ac74fe295a361f650818de93be11b5038a78f49ccfb64d3b1be8fbf1267", size = 235045, upload-time = "2026-04-08T17:04:05.072Z" },
-    { url = "https://files.pythonhosted.org/packages/65/8b/3669ad3b3f247a791b2b4aceb3aa5a31f5f6817bf547e4e1ff712338145a/greenlet-3.4.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:1a54a921561dd9518d31d2d3db4d7f80e589083063ab4d3e2e950756ef809e1a", size = 286902, upload-time = "2026-04-08T15:52:12.138Z" },
-    { url = "https://files.pythonhosted.org/packages/38/3e/3c0e19b82900873e2d8469b590a6c4b3dfd2b316d0591f1c26b38a4879a5/greenlet-3.4.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16dec271460a9a2b154e3b1c2fa1050ce6280878430320e85e08c166772e3f97", size = 606099, upload-time = "2026-04-08T16:24:38.408Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/33/99fef65e7754fc76a4ed14794074c38c9ed3394a5bd129d7f61b705f3168/greenlet-3.4.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:90036ce224ed6fe75508c1907a77e4540176dcf0744473627785dd519c6f9996", size = 618837, upload-time = "2026-04-08T16:30:58.298Z" },
-    { url = "https://files.pythonhosted.org/packages/44/57/eae2cac10421feae6c0987e3dc106c6d86262b1cb379e171b017aba893a6/greenlet-3.4.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6f0def07ec9a71d72315cf26c061aceee53b306c36ed38c35caba952ea1b319d", size = 624901, upload-time = "2026-04-08T16:40:38.981Z" },
-    { url = "https://files.pythonhosted.org/packages/36/f7/229f3aed6948faa20e0616a0b8568da22e365ede6a54d7d369058b128afd/greenlet-3.4.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a1c4f6b453006efb8310affb2d132832e9bbb4fc01ce6df6b70d810d38f1f6dc", size = 615062, upload-time = "2026-04-08T15:56:33.766Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/8a/0e73c9b94f31d1cc257fe79a0eff621674141cdae7d6d00f40de378a1e42/greenlet-3.4.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:0e1254cf0cbaa17b04320c3a78575f29f3c161ef38f59c977108f19ffddaf077", size = 423927, upload-time = "2026-04-08T16:43:05.293Z" },
-    { url = "https://files.pythonhosted.org/packages/08/97/d988180011aa40135c46cd0d0cf01dd97f7162bae14139b4a3ef54889ba5/greenlet-3.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9b2d9a138ffa0e306d0e2b72976d2fb10b97e690d40ab36a472acaab0838e2de", size = 1573511, upload-time = "2026-04-08T16:26:20.058Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/0f/a5a26fe152fb3d12e6a474181f6e9848283504d0afd095f353d85726374b/greenlet-3.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8424683caf46eb0eb6f626cb95e008e8cc30d0cb675bdfa48200925c79b38a08", size = 1640396, upload-time = "2026-04-08T15:57:30.88Z" },
-    { url = "https://files.pythonhosted.org/packages/42/cf/bb2c32d9a100e36ee9f6e38fad6b1e082b8184010cb06259b49e1266ca01/greenlet-3.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:a0a53fb071531d003b075c444014ff8f8b1a9898d36bb88abd9ac7b3524648a2", size = 238892, upload-time = "2026-04-08T17:03:10.094Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/47/6c41314bac56e71436ce551c7fbe3cc830ed857e6aa9708dbb9c65142eb6/greenlet-3.4.0-cp312-cp312-win_arm64.whl", hash = "sha256:f38b81880ba28f232f1f675893a39cf7b6db25b31cc0a09bb50787ecf957e85e", size = 235599, upload-time = "2026-04-08T15:52:54.3Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/75/7e9cd1126a1e1f0cd67b0eda02e5221b28488d352684704a78ed505bd719/greenlet-3.4.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:43748988b097f9c6f09364f260741aa73c80747f63389824435c7a50bfdfd5c1", size = 285856, upload-time = "2026-04-08T15:52:45.82Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/c4/3e2df392e5cb199527c4d9dbcaa75c14edcc394b45040f0189f649631e3c/greenlet-3.4.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5566e4e2cd7a880e8c27618e3eab20f3494452d12fd5129edef7b2f7aa9a36d1", size = 610208, upload-time = "2026-04-08T16:24:39.674Z" },
-    { url = "https://files.pythonhosted.org/packages/da/af/750cdfda1d1bd30a6c28080245be8d0346e669a98fdbae7f4102aa95fff3/greenlet-3.4.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1054c5a3c78e2ab599d452f23f7adafef55062a783a8e241d24f3b633ba6ff82", size = 621269, upload-time = "2026-04-08T16:30:59.767Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/93/c8c508d68ba93232784bbc1b5474d92371f2897dfc6bc281b419f2e0d492/greenlet-3.4.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:98eedd1803353daf1cd9ef23eef23eda5a4d22f99b1f998d273a8b78b70dd47f", size = 628455, upload-time = "2026-04-08T16:40:40.698Z" },
-    { url = "https://files.pythonhosted.org/packages/54/78/0cbc693622cd54ebe25207efbb3a0eb07c2639cb8594f6e3aaaa0bb077a8/greenlet-3.4.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f82cb6cddc27dd81c96b1506f4aa7def15070c3b2a67d4e46fd19016aacce6cf", size = 617549, upload-time = "2026-04-08T15:56:34.893Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/46/cfaaa0ade435a60550fd83d07dfd5c41f873a01da17ede5c4cade0b9bab8/greenlet-3.4.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:b7857e2202aae67bc5725e0c1f6403c20a8ff46094ece015e7d474f5f7020b55", size = 426238, upload-time = "2026-04-08T16:43:06.865Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/c0/8966767de01343c1ff47e8b855dc78e7d1a8ed2b7b9c83576a57e289f81d/greenlet-3.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:227a46251ecba4ff46ae742bc5ce95c91d5aceb4b02f885487aff269c127a729", size = 1575310, upload-time = "2026-04-08T16:26:21.671Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/38/bcdc71ba05e9a5fda87f63ffc2abcd1f15693b659346df994a48c968003d/greenlet-3.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5b99e87be7eba788dd5b75ba1cde5639edffdec5f91fe0d734a249535ec3408c", size = 1640435, upload-time = "2026-04-08T15:57:32.572Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/c2/19b664b7173b9e4ef5f77e8cef9f14c20ec7fce7920dc1ccd7afd955d093/greenlet-3.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:849f8bc17acd6295fcb5de8e46d55cc0e52381c56eaf50a2afd258e97bc65940", size = 238760, upload-time = "2026-04-08T17:04:03.878Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/96/795619651d39c7fbd809a522f881aa6f0ead504cc8201c3a5b789dfaef99/greenlet-3.4.0-cp313-cp313-win_arm64.whl", hash = "sha256:9390ad88b652b1903814eaabd629ca184db15e0eeb6fe8a390bbf8b9106ae15a", size = 235498, upload-time = "2026-04-08T17:05:00.584Z" },
-    { url = "https://files.pythonhosted.org/packages/78/02/bde66806e8f169cf90b14d02c500c44cdbe02c8e224c9c67bafd1b8cadd1/greenlet-3.4.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:10a07aca6babdd18c16a3f4f8880acfffc2b88dfe431ad6aa5f5740759d7d75e", size = 286291, upload-time = "2026-04-08T17:09:34.307Z" },
-    { url = "https://files.pythonhosted.org/packages/05/1f/39da1c336a87d47c58352fb8a78541ce63d63ae57c5b9dae1fe02801bbc2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:076e21040b3a917d3ce4ad68fb5c3c6b32f1405616c4a57aa83120979649bd3d", size = 656749, upload-time = "2026-04-08T16:24:41.721Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/6c/90ee29a4ee27af7aa2e2ec408799eeb69ee3fcc5abcecac6ddd07a5cd0f2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e82689eea4a237e530bb5cb41b180ef81fa2160e1f89422a67be7d90da67f615", size = 669084, upload-time = "2026-04-08T16:31:01.372Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/4a/74078d3936712cff6d3c91a930016f476ce4198d84e224fe6d81d3e02880/greenlet-3.4.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:06c2d3b89e0c62ba50bd7adf491b14f39da9e7e701647cb7b9ff4c99bee04b19", size = 673405, upload-time = "2026-04-08T16:40:42.527Z" },
-    { url = "https://files.pythonhosted.org/packages/07/49/d4cad6e5381a50947bb973d2f6cf6592621451b09368b8c20d9b8af49c5b/greenlet-3.4.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4df3b0b2289ec686d3c821a5fee44259c05cfe824dd5e6e12c8e5f5df23085cf", size = 665621, upload-time = "2026-04-08T15:56:35.995Z" },
-    { url = "https://files.pythonhosted.org/packages/79/3e/df8a83ab894751bc31e1106fdfaa80ca9753222f106b04de93faaa55feb7/greenlet-3.4.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:070b8bac2ff3b4d9e0ff36a0d19e42103331d9737e8504747cd1e659f76297bd", size = 471670, upload-time = "2026-04-08T16:43:08.512Z" },
-    { url = "https://files.pythonhosted.org/packages/37/31/d1edd54f424761b5d47718822f506b435b6aab2f3f93b465441143ea5119/greenlet-3.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8bff29d586ea415688f4cec96a591fcc3bf762d046a796cdadc1fdb6e7f2d5bf", size = 1622259, upload-time = "2026-04-08T16:26:23.201Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/c6/6d3f9cdcb21c4e12a79cb332579f1c6aa1af78eb68059c5a957c7812d95e/greenlet-3.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8a569c2fb840c53c13a2b8967c63621fafbd1a0e015b9c82f408c33d626a2fda", size = 1686916, upload-time = "2026-04-08T15:57:34.282Z" },
-    { url = "https://files.pythonhosted.org/packages/63/45/c1ca4a1ad975de4727e52d3ffe641ae23e1d7a8ffaa8ff7a0477e1827b92/greenlet-3.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:207ba5b97ea8b0b60eb43ffcacf26969dd83726095161d676aac03ff913ee50d", size = 239821, upload-time = "2026-04-08T17:03:48.423Z" },
-    { url = "https://files.pythonhosted.org/packages/71/c4/6f621023364d7e85a4769c014c8982f98053246d142420e0328980933ceb/greenlet-3.4.0-cp314-cp314-win_arm64.whl", hash = "sha256:f8296d4e2b92af34ebde81085a01690f26a51eb9ac09a0fcadb331eb36dbc802", size = 236932, upload-time = "2026-04-08T17:04:33.551Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/8f/18d72b629783f5e8d045a76f5325c1e938e659a9e4da79c7dcd10169a48d/greenlet-3.4.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:d70012e51df2dbbccfaf63a40aaf9b40c8bed37c3e3a38751c926301ce538ece", size = 294681, upload-time = "2026-04-08T15:52:35.778Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/ad/5fa86ec46769c4153820d58a04062285b3b9e10ba3d461ee257b68dcbf53/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a58bec0751f43068cd40cff31bb3ca02ad6000b3a51ca81367af4eb5abc480c8", size = 658899, upload-time = "2026-04-08T16:24:43.32Z" },
-    { url = "https://files.pythonhosted.org/packages/43/f0/4e8174ca0e87ae748c409f055a1ba161038c43cc0a5a6f1433a26ac2e5bf/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:05fa0803561028f4b2e3b490ee41216a842eaee11aed004cc343a996d9523aa2", size = 665284, upload-time = "2026-04-08T16:31:02.833Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/92/466b0d9afd44b8af623139a3599d651c7564fa4152f25f117e1ee5949ffb/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c4cd56a9eb7a6444edbc19062f7b6fbc8f287c663b946e3171d899693b1c19fa", size = 665872, upload-time = "2026-04-08T16:40:43.912Z" },
-    { url = "https://files.pythonhosted.org/packages/19/da/991cf7cd33662e2df92a1274b7eb4d61769294d38a1bba8a45f31364845e/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e60d38719cb80b3ab5e85f9f1aed4960acfde09868af6762ccb27b260d68f4ed", size = 661861, upload-time = "2026-04-08T15:56:37.269Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/14/3395a7ef3e260de0325152ddfe19dffb3e49fe10873b94654352b53ad48e/greenlet-3.4.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:1f85f204c4d54134ae850d401fa435c89cd667d5ce9dc567571776b45941af72", size = 489237, upload-time = "2026-04-08T16:43:09.993Z" },
-    { url = "https://files.pythonhosted.org/packages/36/c5/6c2c708e14db3d9caea4b459d8464f58c32047451142fe2cfd90e7458f41/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7f50c804733b43eded05ae694691c9aa68bca7d0a867d67d4a3f514742a2d53f", size = 1622182, upload-time = "2026-04-08T16:26:24.777Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/4c/50c5fed19378e11a29fabab1f6be39ea95358f4a0a07e115a51ca93385d8/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2d4f0635dc4aa638cda4b2f5a07ae9a2cff9280327b581a3fcb6f317b4fbc38a", size = 1685050, upload-time = "2026-04-08T15:57:36.453Z" },
-    { url = "https://files.pythonhosted.org/packages/db/72/85ae954d734703ab48e622c59d4ce35d77ce840c265814af9c078cacc7aa/greenlet-3.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1a4a48f24681300c640f143ba7c404270e1ebbbcf34331d7104a4ff40f8ea705", size = 245554, upload-time = "2026-04-08T17:03:50.044Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/03/84359833f7e1d49a883e92777637c592306030e30cee5e2b1e6476f95c88/greenlet-3.5.0-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:29ea813b2e1f45fa9649a17853b2b5465c4072fbcb072e5af6cd3a288216574a", size = 283502, upload-time = "2026-04-27T12:20:55.213Z" },
+    { url = "https://files.pythonhosted.org/packages/25/ce/6f9f008266273aa14a2e011945797ac5802b97b8b40efe7afe1ee6c1afc9/greenlet-3.5.0-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:804a70b328e706b785c6ef16187051c394a63dd1a906d89be24b6ad77759f13f", size = 600508, upload-time = "2026-04-27T12:52:37.876Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/6d/b0f3272c2368ea2c1aa19a5ad70db0be8f8dff6e6d3d1eb82efa00cbcf19/greenlet-3.5.0-cp310-cp310-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:884f649de075b84739713d41dd4dfd41e2b910bfb769c4a3ea02ec1da52cd9bb", size = 613283, upload-time = "2026-04-27T12:59:37.957Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/ae/1db979ff6ae7958d80b288f63d5f6c30df96682700ea9fc340ce994d94a1/greenlet-3.5.0-cp310-cp310-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4d0eadc7e4d9ffb2af4247b606cae307be8e448911e5a0d0b16d72fc3d224cfd", size = 619894, upload-time = "2026-04-27T13:02:35.13Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/ac/0b509b6fb93551ce5a01612ee1acda7f7dda4bbb66c99aeb2ab403d205dc/greenlet-3.5.0-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b28037cb07768933c54d81bfe47a85f9f402f57d7d69743b991a713b63954eb", size = 613418, upload-time = "2026-04-27T12:25:23.852Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/94/b0590e3d1978f02419f30502341c40d72f77eb0a2198119fe27df47714ee/greenlet-3.5.0-cp310-cp310-manylinux_2_39_riscv64.whl", hash = "sha256:f8c30c2225f40dd76c50790f0eb3b5c7c18431efb299e2782083e1981feed243", size = 415681, upload-time = "2026-04-27T13:05:11.494Z" },
+    { url = "https://files.pythonhosted.org/packages/03/03/2b2b680ec87aaa97998fb5b8d76658d4d3560386864f17efab33ba7c2e24/greenlet-3.5.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cda05425526240807408156b6960a17a79a0c760b813573b67027823be760977", size = 1572229, upload-time = "2026-04-27T12:53:23.509Z" },
+    { url = "https://files.pythonhosted.org/packages/61/e4/42b259e7a19aff1a270a4bd82caf6353109ed6860c9454e18f37162b83ae/greenlet-3.5.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:9c615f869163e14bb1ced20322d8038fb680b08236521ac3f30cd4c1288785a0", size = 1639886, upload-time = "2026-04-27T12:25:22.325Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/b4/733ca47b883b67c57f90d3ecb21055c9ec753597d10754ac201644061f9d/greenlet-3.5.0-cp310-cp310-win_amd64.whl", hash = "sha256:ba8f0bdc2fae6ce915dfd0c16d2d00bca7e4247c1eae4416e06430e522137858", size = 237795, upload-time = "2026-04-27T12:21:40.118Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/0f/a91f143f356523ff682309732b175765a9bc2836fd7c081c2c67fedc1ad4/greenlet-3.5.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:8f1cc966c126639cd152fdaa52624d2655f492faa79e013fea161de3e6dda082", size = 284726, upload-time = "2026-04-27T12:20:51.402Z" },
+    { url = "https://files.pythonhosted.org/packages/95/82/800646c7ffc5dbabd75ddd2f6b519bb898c0c9c969e5d0473bfe5d20bcce/greenlet-3.5.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:362624e6a8e5bca3b8233e45eef33903a100e9539a2b995c364d595dbc4018b3", size = 604264, upload-time = "2026-04-27T12:52:39.494Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/ac/354867c0bba812fc33b15bc55aedafedd0aee3c7dd91dfca22444157dc0c/greenlet-3.5.0-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5ecd83806b0f4c2f53b1018e0005cd82269ea01d42befc0368730028d850ed1c", size = 616099, upload-time = "2026-04-27T12:59:39.623Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ab/192090c4a5b30df148c22bf4b8895457d739a7c7c5a7b9c41e5dd7f537f2/greenlet-3.5.0-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fa94cb2288681e3a11645958f1871d48ee9211bd2f66628fdace505927d6e564", size = 623976, upload-time = "2026-04-27T13:02:37.363Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b0/815bece7399e01cadb69014219eebd0042339875c59a59b0820a46ece356/greenlet-3.5.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0ff251e9a0279522e62f6176412869395a64ddf2b5c5f782ff609a8216a4e662", size = 615198, upload-time = "2026-04-27T12:25:25.928Z" },
+    { url = "https://files.pythonhosted.org/packages/24/11/05eb2b9b188c6df7d68a89c99134d644a7af616a40b9808e8e6ced315d5d/greenlet-3.5.0-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:64d6ac45f7271f48e45f67c95b54ef73534c52ec041fcda8edf520c6d811f4bc", size = 418379, upload-time = "2026-04-27T13:05:12.755Z" },
+    { url = "https://files.pythonhosted.org/packages/10/80/3b2c0a895d6698f6ddb31b07942ebfa982f3e30888bc5546a5b5990de8b2/greenlet-3.5.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6d874e79afd41a96e11ff4c5d0bc90a80973e476fda1c2c64985667397df432b", size = 1574927, upload-time = "2026-04-27T12:53:25.81Z" },
+    { url = "https://files.pythonhosted.org/packages/44/0e/f354af514a4c61454dbc68e44d47544a5a4d6317e30b77ddfa3a09f4c5f3/greenlet-3.5.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0ed006e4b86c59de7467eb2601cd1b77b5a7d657d1ee55e30fe30d76451edba4", size = 1642683, upload-time = "2026-04-27T12:25:23.9Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/6a/87f38255201e993a1915265ebb80cd7c2c78b04a45744995abbf6b259fd8/greenlet-3.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:703cb211b820dbffbbc55a16bfc6e4583a6e6e990f33a119d2cc8b83211119c8", size = 238115, upload-time = "2026-04-27T12:21:48.845Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f8/450fe3c5938fa737ea4d22699772e6e34e8e24431a47bf4e8a1ceed4a98e/greenlet-3.5.0-cp311-cp311-win_arm64.whl", hash = "sha256:6c18dfb59c70f5a94acd271c72e90128c3c776e41e5f07767908c8c1b74ad339", size = 235017, upload-time = "2026-04-27T12:22:26.768Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/32/f2ce6d4cac3e55bc6173f92dbe627e782e1850f89d986c3606feb63aafa7/greenlet-3.5.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:db2910d3c809444e0a20147361f343fe2798e106af8d9d8506f5305302655a9f", size = 286228, upload-time = "2026-04-27T12:20:34.421Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/aa/caed9e5adf742315fc7be2a84196373aab4816e540e38ba0d76cb7584d68/greenlet-3.5.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ec9ea74e7268ace7f9aab1b1a4e730193fc661b39a993cd91c606c32d4a3628", size = 601775, upload-time = "2026-04-27T12:52:41.045Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/af/90ae08497400a941595d12774447f752d3dfe0fbb012e35b76bc5c0ff37e/greenlet-3.5.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54d243512da35485fc7a6bf3c178fdda6327a9d6506fcdd62b1abd1e41b2927b", size = 614436, upload-time = "2026-04-27T12:59:41.595Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e9/4eeadf8cb3403ac274245ba75f07844abc7fa5f6787583fc9156ba741e0f/greenlet-3.5.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:41353ec2ecedf7aa8f682753a41919f8718031a6edac46b8d3dc7ed9e1ceb136", size = 620610, upload-time = "2026-04-27T13:02:39.194Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/e0/2e13df68f367e2f9960616927d60857dd7e56aaadd59a47c644216b2f920/greenlet-3.5.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d280a7f5c331622c69f97eb167f33577ff2d1df282c41cd15907fc0a3ca198c", size = 611388, upload-time = "2026-04-27T12:25:28.008Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ef/f913b3c0eb7d26d86a2401c5e1546c9d46b657efee724b06f6f4ac5d8824/greenlet-3.5.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:58c1c374fe2b3d852f9b6b11a7dff4c85404e51b9a596fd9e89cf904eb09866d", size = 422775, upload-time = "2026-04-27T13:05:14.261Z" },
+    { url = "https://files.pythonhosted.org/packages/82/f7/393c64055132ac0d488ef6be549253b7e6274194863967ddc0bc8f5b87b8/greenlet-3.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1eb67d5adefb5bd2e182d42678a328979a209e4e82eb93575708185d31d1f588", size = 1570768, upload-time = "2026-04-27T12:53:28.099Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/4b/eaf7735253522cf56d1b74d672a58f54fc114702ceaf05def59aae72f6e1/greenlet-3.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2628d6c86f6cb0cb45e0c3c54058bbec559f57eaae699447748cb3928150577e", size = 1635983, upload-time = "2026-04-27T12:25:26.903Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/4fb3a0805bd5165da5ebf858da7cc01cce8061674106d2cf5bdab32cbfde/greenlet-3.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:d4d9f0624c775f2dfc56ba54d515a8c771044346852a918b405914f6b19d7fd8", size = 238840, upload-time = "2026-04-27T12:23:54.806Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/cb/baa584cb00532126ffe12d9787db0a60c5a4f55c27bfe2666df5d4c30a32/greenlet-3.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:83ed9f27f1680b50e89f40f6df348a290ea234b249a4003d366663a12eab94f2", size = 235615, upload-time = "2026-04-27T12:21:38.57Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/58/fc576f99037ce19c5aa16628e4c3226b6d1419f72a62c79f5f40576e6eb3/greenlet-3.5.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:5a5ed18de6a0f6cc7087f1563f6bd93fc7df1c19165ca01e9bde5a5dc281d106", size = 285066, upload-time = "2026-04-27T12:23:05.033Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/ba/b28ddbe6bfad6a8ac196ef0e8cff37bc65b79735995b9e410923fffeeb70/greenlet-3.5.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a717fbc46d8a354fa675f7c1e813485b6ba3885f9bef0cd56e5ba27d758ff5b", size = 604414, upload-time = "2026-04-27T12:52:42.358Z" },
+    { url = "https://files.pythonhosted.org/packages/09/06/4b69f8f0b67603a8be2790e55107a190b376f2627fe0eaf5695d85ffb3cd/greenlet-3.5.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ddc090c5c1792b10246a78e8c2163ebbe04cf877f9d785c230a7b27b39ad038e", size = 617349, upload-time = "2026-04-27T12:59:43.32Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/15/a643b4ecd09969e30b8a150d5919960caae0abe4f5af75ab040b1ab85e78/greenlet-3.5.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4964101b8585c144cbda5532b1aa644255126c08a265dae90c16e7a0e63aaa9d", size = 623234, upload-time = "2026-04-27T13:02:40.611Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/17/a3918541fd0ddefe024a69de6d16aa7b46d36ac19562adaa63c7fa180eff/greenlet-3.5.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2094acd54b272cb6eae8c03dd87b3fa1820a4cef18d6889c378d503500a1dc13", size = 613927, upload-time = "2026-04-27T12:25:30.28Z" },
+    { url = "https://files.pythonhosted.org/packages/77/18/3b13d5ef1275b0ffaf933b05efa21408ac4ca95823c7411d79682e4fdcff/greenlet-3.5.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:7022615368890680e67b9965d33f5773aade330d5343bbe25560135aaa849eae", size = 425243, upload-time = "2026-04-27T13:05:15.689Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/e1/bd0af6213c7dd33175d8a462d4c1fe1175124ebed4855bc1475a5b5242c2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5e05ba267789ea87b5a155cf0e810b1ab88bf18e9e8740813945ceb8ee4350ba", size = 1570893, upload-time = "2026-04-27T12:53:29.483Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/2a/0789702f864f5382cb476b93d7a9c823c10472658102ccd65f415747d2e2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0ecec963079cd58cbd14723582384f11f166fd58883c15dcbfb342e0bc9b5846", size = 1636060, upload-time = "2026-04-27T12:25:28.845Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/8f/22bf9df92bbff0eb07842b60f7e63bf7675a9742df628437a9f02d09137f/greenlet-3.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:728d9667d8f2f586644b748dbd9bb67e50d6a9381767d1357714ea6825bb3bf5", size = 238740, upload-time = "2026-04-27T12:24:01.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/b7/9c5c3d653bd4ff614277c049ac676422e2c557db47b4fe43e6313fc005dc/greenlet-3.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:47422135b1d308c14b2c6e758beedb1acd33bb91679f5670edf77bf46244722b", size = 235525, upload-time = "2026-04-27T12:23:12.308Z" },
+    { url = "https://files.pythonhosted.org/packages/94/5e/a70f31e3e8d961c4ce589c15b28e4225d63704e431a23932a3808cbcc867/greenlet-3.5.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:f35807464c4c58c55f0d31dfa83c541a5615d825c2fe3d2b95360cf7c4e3c0a8", size = 285564, upload-time = "2026-04-27T12:23:08.555Z" },
+    { url = "https://files.pythonhosted.org/packages/af/a6/046c0a28e21833e4086918218cfb3d8bed51c075a1b700f20b9d7861c0f4/greenlet-3.5.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55fa7ea52771be44af0de27d8b80c02cd18c2c3cddde6c847ecebdf72418b6a1", size = 651166, upload-time = "2026-04-27T12:52:43.644Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f8/4af27f71c5ff32a7fbc516adb46370d9c4ae2bc7bd3dc7d066ac542b4b15/greenlet-3.5.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a97e4821aa710603f94de0da25f25096454d78ffdace5dc77f3a006bc01abba3", size = 663792, upload-time = "2026-04-27T12:59:44.93Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/89/2dadb89793c37ee8b4c237857188293e9060dc085f19845c292e00f8e091/greenlet-3.5.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bf2d8a80bec89ab46221ae45c5373d5ba0bd36c19aa8508e85c6cd7e5106cd37", size = 668086, upload-time = "2026-04-27T13:02:42.314Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/59/1bd6d7428d6ed9106efbb8c52310c60fd04f6672490f452aeaa3829aa436/greenlet-3.5.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f52a464e4ed91780bdfbbdd2b97197f3accaa629b98c200f4dffada759f3ae7", size = 660933, upload-time = "2026-04-27T12:25:33.276Z" },
+    { url = "https://files.pythonhosted.org/packages/82/35/75722be7e26a2af4cbd2dc35b0ed382dacf9394b7e75551f76ed1abe87f2/greenlet-3.5.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:1bae92a1dd94c5f9d9493c3a212dd874c202442047cf96446412c862feca83a2", size = 470799, upload-time = "2026-04-27T13:05:17.094Z" },
+    { url = "https://files.pythonhosted.org/packages/83/e4/b903e5a5fae1e8a28cdd32a0cfbfd560b668c25b692f67768822ddc5f40f/greenlet-3.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:762612baf1161ccb8437c0161c668a688223cba28e1bf038f4eb47b13e39ccdf", size = 1618401, upload-time = "2026-04-27T12:53:31.062Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/e3/5ec408a329acb854fb607a122e1ee5fb3ff649f9a97952948a90803c0d8e/greenlet-3.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:57a43c6079a89713522bc4bcb9f75070ecf5d3dbad7792bfe42239362cbf2a16", size = 1682038, upload-time = "2026-04-27T12:25:31.838Z" },
+    { url = "https://files.pythonhosted.org/packages/91/20/6b165108058767ee643c55c5c4904d591a830ee2b3c7dbd359828fbc829f/greenlet-3.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:3bc59be3945ae9750b9e7d45067d01ae3fe90ea5f9ade99239dabdd6e28a5033", size = 239835, upload-time = "2026-04-27T12:24:54.136Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/62/1c498375cee177b55d980c1db319f26470e5309e54698c8f8fc06c0fd539/greenlet-3.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:a96fcee45e03fe30a62669fd16ab5c9d3c172660d3085605cb1e2d1280d3c988", size = 236862, upload-time = "2026-04-27T12:23:24.957Z" },
+    { url = "https://files.pythonhosted.org/packages/78/a8/4522939255bb5409af4e87132f915446bf3622c2c292d14d3c38d128ae82/greenlet-3.5.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:a10a732421ab4fec934783ce3e54763470d0181db6e3468f9103a275c3ed1853", size = 293614, upload-time = "2026-04-27T12:24:12.874Z" },
+    { url = "https://files.pythonhosted.org/packages/15/5e/8744c52e2c027b5a8772a01561934c8835f869733e101f62075c60430340/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fc391b1566f2907d17aaebe78f8855dc45675159a775fcf9e61f8ee0078e87f", size = 650723, upload-time = "2026-04-27T12:52:45.412Z" },
+    { url = "https://files.pythonhosted.org/packages/00/ef/7b4c39c03cf46ceca512c5d3f914afd85aa30b2cc9a93015b0dd73e4be6c/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:680bd0e7ad5e8daa8a4aa89f68fd6adc834b8a8036dc256533f7e08f4a4b01f7", size = 656529, upload-time = "2026-04-27T12:59:46.295Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/5c/0602239503b124b70e39355cbdb39361ecfe65b87a5f2f63752c32f5286f/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1aa4ce8debcd4ea7fb2e150f3036588c41493d1d52c43538924ae1819003f4ce", size = 657015, upload-time = "2026-04-27T13:02:43.973Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b5/c7768f352f5c010f92064d0063f987e7dc0cd290a6d92a34109015ce4aa1/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddb36c7d6c9c0a65f18c7258634e0c416c6ab59caac8c987b96f80c2ebda0112", size = 654364, upload-time = "2026-04-27T12:25:35.64Z" },
+    { url = "https://files.pythonhosted.org/packages/38/51/8699f865f125dc952384cb432b0f7138aa4d8f2969a7d12d0df5b94d054d/greenlet-3.5.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:728a73687e39ae9ca34e4694cbf2f049d3fbc7174639468d0f67200a97d8f9e2", size = 488275, upload-time = "2026-04-27T13:05:18.28Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/d0/079ebe12e4b1fc758857ce5be1a5e73f06870f2101e52611d1e71925ce54/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e5ddf316ced87539144621453c3aef229575825fe60c604e62bedc4003f372b2", size = 1614204, upload-time = "2026-04-27T12:53:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/89/6c2fb63df3596552d20e58fb4d96669243388cf680cff222758812c7bfaa/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4a448128607be0de65342dc9b31be7f948ef4cc0bc8832069350abefd310a8f2", size = 1675480, upload-time = "2026-04-27T12:25:34.168Z" },
+    { url = "https://files.pythonhosted.org/packages/15/32/77ee8a6c1564fc345a491a4e85b3bf360e4cf26eac98c4532d2fdb96e01f/greenlet-3.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d60097128cb0a1cab9ea541186ea13cd7b847b8449a7787c2e2350da0cb82d86", size = 245324, upload-time = "2026-04-27T12:24:40.295Z" },
 ]
 
 [[package]]
@@ -5789,7 +5787,7 @@ wheels = [
 
 [[package]]
 name = "mem0ai"
-version = "2.0.0"
+version = "2.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "openai" },
@@ -5800,9 +5798,9 @@ dependencies = [
     { name = "qdrant-client" },
     { name = "sqlalchemy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a8/41/4b786308d595ff5dc958b9916c0a5ae19af6337c7c09c4f22075400440d5/mem0ai-2.0.0.tar.gz", hash = "sha256:69a029d6e36d6f9cd30a3f2baab68b8e94e984ee91737ed5b6d78bc61df41cd8", size = 210776, upload-time = "2026-04-16T11:51:02.135Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/03/3dc535b98310912e4f10083acdbbca2c5e2dfccb3921230a460464f9f4d0/mem0ai-2.0.1.tar.gz", hash = "sha256:070dbc3f1f332c8908379b42a81ab3a96ab169f2f9fa537e6ac719df02478f9c", size = 211820, upload-time = "2026-04-25T17:39:06.744Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ff/83/433c9e433aa8eede63bc1538bf97a43af3b6eb9cd4cd78ae53dcd484b5e4/mem0ai-2.0.0-py3-none-any.whl", hash = "sha256:77b185d9a490358e806497c42164ab2464109ff44fde10e5fc834996b0011649", size = 298513, upload-time = "2026-04-16T11:51:00.233Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/96/e6153262f1464f4d412208732fea31496d9983ade155dd2c5c5492f8f8a4/mem0ai-2.0.1-py3-none-any.whl", hash = "sha256:63da5f50ad0c2514e27c2f380ef03f2ceea47c97873096ddfd997785b58043ec", size = 299461, upload-time = "2026-04-25T17:39:04.143Z" },
 ]
 
 [[package]]
@@ -6839,7 +6837,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.32.0"
+version = "2.33.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -6851,9 +6849,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ed/59/bdcc6b759b8c42dd73afaf5bf8f902c04b37987a5514dbc1c64dba390fef/openai-2.32.0.tar.gz", hash = "sha256:c54b27a9e4cb8d51f0dd94972ffd1a04437efeb259a9e60d8922b8bd26fe55e0", size = 693286, upload-time = "2026-04-15T22:28:19.434Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/ee/d056c82f63c05f06baac0cffb4a90952d8274f90c49dfe244f20497b9bbd/openai-2.33.0.tar.gz", hash = "sha256:f850c435e2a4685bba3295bd54912dd26315d9c1b7733068186134d6e0599f9a", size = 693254, upload-time = "2026-04-28T14:04:42.428Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/c1/d6e64ccd0536bf616556f0cad2b6d94a8125f508d25cfd814b1d2db4e2f1/openai-2.32.0-py3-none-any.whl", hash = "sha256:4dcc9badeb4bf54ad0d187453742f290226d30150890b7890711bda4f32f192f", size = 1162570, upload-time = "2026-04-15T22:28:17.714Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/32/37734d769bc8b42e4938785313cc05aade6cb0fa72479d3220a0d61a4e78/openai-2.33.0-py3-none-any.whl", hash = "sha256:03ac37d70e8c9e3a8124214e3afa785e2cbc12e627fbd98177a086ef2fd87ad5", size = 1162695, upload-time = "2026-04-28T14:04:40.482Z" },
 ]
 
 [[package]]
@@ -7459,11 +7457,11 @@ wheels = [
 
 [[package]]
 name = "pathspec"
-version = "1.1.0"
+version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2e/17/9c3094b822982b9f1ea666d8580ce59000f61f87c1663556fb72031ad9ec/pathspec-1.1.0.tar.gz", hash = "sha256:f5d7c555da02fd8dde3e4a2354b6aba817a89112fa8f333f7917a2a4834dd080", size = 133918, upload-time = "2026-04-23T01:46:22.298Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/c9/8eed0486f074e9f1ca7f8ce5ad663e65f12fdab344028d658fa1b03d35e0/pathspec-1.1.0-py3-none-any.whl", hash = "sha256:574b128f7456bd899045ccd142dd446af7e6cfd0072d63ad73fbc55fbb4aaa42", size = 56264, upload-time = "2026-04-23T01:46:20.606Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
 ]
 
 [[package]]
@@ -7633,21 +7631,21 @@ wheels = [
 
 [[package]]
 name = "playwright"
-version = "1.58.0"
+version = "1.59.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "greenlet" },
     { name = "pyee" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/c9/9c6061d5703267f1baae6a4647bfd1862e386fbfdb97d889f6f6ae9e3f64/playwright-1.58.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:96e3204aac292ee639edbfdef6298b4be2ea0a55a16b7068df91adac077cc606", size = 42251098, upload-time = "2026-01-30T15:09:24.028Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/40/59d34a756e02f8c670f0fee987d46f7ee53d05447d43cd114ca015cb168c/playwright-1.58.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:70c763694739d28df71ed578b9c8202bb83e8fe8fb9268c04dd13afe36301f71", size = 41039625, upload-time = "2026-01-30T15:09:27.558Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/ee/3ce6209c9c74a650aac9028c621f357a34ea5cd4d950700f8e2c4b7fe2c4/playwright-1.58.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:185e0132578733d02802dfddfbbc35f42be23a45ff49ccae5081f25952238117", size = 42251098, upload-time = "2026-01-30T15:09:30.461Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/af/009958cbf23fac551a940d34e3206e6c7eed2b8c940d0c3afd1feb0b0589/playwright-1.58.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:c95568ba1eda83812598c1dc9be60b4406dffd60b149bc1536180ad108723d6b", size = 46235268, upload-time = "2026-01-30T15:09:33.787Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/a6/0e66ad04b6d3440dae73efb39540c5685c5fc95b17c8b29340b62abbd952/playwright-1.58.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f9999948f1ab541d98812de25e3a8c410776aa516d948807140aff797b4bffa", size = 45964214, upload-time = "2026-01-30T15:09:36.751Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/4b/236e60ab9f6d62ed0fd32150d61f1f494cefbf02304c0061e78ed80c1c32/playwright-1.58.0-py3-none-win32.whl", hash = "sha256:1e03be090e75a0fabbdaeab65ce17c308c425d879fa48bb1d7986f96bfad0b99", size = 36815998, upload-time = "2026-01-30T15:09:39.627Z" },
-    { url = "https://files.pythonhosted.org/packages/41/f8/5ec599c5e59d2f2f336a05b4f318e733077cd5044f24adb6f86900c3e6a7/playwright-1.58.0-py3-none-win_amd64.whl", hash = "sha256:a2bf639d0ce33b3ba38de777e08697b0d8f3dc07ab6802e4ac53fb65e3907af8", size = 36816005, upload-time = "2026-01-30T15:09:42.449Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/c4/cc0229fea55c87d6c9c67fe44a21e2cd28d1d558a5478ed4d617e9fb0c93/playwright-1.58.0-py3-none-win_arm64.whl", hash = "sha256:32ffe5c303901a13a0ecab91d1c3f74baf73b84f4bedbb6b935f5bc11cc98e1b", size = 33085919, upload-time = "2026-01-30T15:09:45.71Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/48/abab23f40643b4de8f2665816f0a1bf0994eeecda39d6d62f0f292b2ad01/playwright-1.59.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:bfc6940100b57423175c819ce2422ec5880d55fa2769987f62ab7a1f5fe6783e", size = 43156922, upload-time = "2026-04-29T08:11:08.921Z" },
+    { url = "https://files.pythonhosted.org/packages/08/71/5e4d98b2ce3641b4343623c6450ff33b9de1c979d12a957505e392338b07/playwright-1.59.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:af068143a0c045ec11608b67d6c42e58db7e9cf65a742dd21fddedc1a9802c47", size = 41947177, upload-time = "2026-04-29T08:11:12.867Z" },
+    { url = "https://files.pythonhosted.org/packages/80/91/fd219aa78ca03d37e93aaedaed4e224131e3090a9264f9bb773c8271d67e/playwright-1.59.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:4a4a2d4842b0e4120de3fa48636e4b69085a05b81d8a35ad4353f530ade72ed6", size = 43156922, upload-time = "2026-04-29T08:11:16.595Z" },
+    { url = "https://files.pythonhosted.org/packages/73/0c/1e513d37c5be07d12829ebce93dbfe7baee230084cb66966c423432799c4/playwright-1.59.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:c5792aad9e22b91a09264b9edbc18553cf05ea5a39404d65dc19a012c6b2e51d", size = 47151793, upload-time = "2026-04-29T08:11:19.979Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/2d/15f72288cb65d690134e18fefb9483cc4976f7579b580648c45e494481a7/playwright-1.59.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c881a19377d2b900af855fb525b5f22a27bf3cfbecba6d1edb36766d56cb100", size = 46877615, upload-time = "2026-04-29T08:11:23.863Z" },
+    { url = "https://files.pythonhosted.org/packages/72/a1/717ac5bc99f387c0f60def91271ea4262125c0815d764a5d1776a272275c/playwright-1.59.0-py3-none-win32.whl", hash = "sha256:6989c476be2b9cd3e24a18cc9dcf202e266fb3d91e3e5395cd668c54ea54b119", size = 37713698, upload-time = "2026-04-29T08:11:27.251Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/a5/4e630ee05d8b46b840f943268e86d6063703e8dadb2d3eb405c7b9b2e48c/playwright-1.59.0-py3-none-win_amd64.whl", hash = "sha256:d5a5cc064b82ca92996080025710844e417f44df8fda9001102c28f44174171c", size = 37713704, upload-time = "2026-04-29T08:11:30.41Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/0c/3ece41761ba13c8321009aefcaec7a016eb42799c42eef5e03ace7f2de5b/playwright-1.59.0-py3-none-win_arm64.whl", hash = "sha256:93581ad515728cadc8af39b288a5633ba6d36e7d72048e79d890ce01ea2156f9", size = 33956745, upload-time = "2026-04-29T08:11:34.738Z" },
 ]
 
 [[package]]
@@ -7673,18 +7671,17 @@ wheels = [
 
 [[package]]
 name = "posthog"
-version = "7.13.1"
+version = "7.13.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "backoff" },
     { name = "distro" },
-    { name = "python-dateutil" },
     { name = "requests" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2a/09/ecc82b5ba5876164a3807adcc5101466da1e4416600075bdbd2071327457/posthog-7.13.1.tar.gz", hash = "sha256:5e53c57db076807530bbec5634c96673ceae8e8e58b99c983af26f02bb4759aa", size = 194124, upload-time = "2026-04-24T19:08:32.56Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/54/9c117beaa96519077cae355263712d705e560e8ee7ca4a35373438d1f4d2/posthog-7.13.2.tar.gz", hash = "sha256:a9fc322518bc7f42e24501a0df1072aa60bad6fba759cbe388d167b7e054b052", size = 195555, upload-time = "2026-04-30T09:01:26.08Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/bf/eafd5e7508b03264b7deb4db6563c4a2830de7114e01ccbf369756b779d1/posthog-7.13.1-py3-none-any.whl", hash = "sha256:fc0f4b4a8878957e1ea8d319b2e4038b66a19625837f59b020cddaaf59fce982", size = 228291, upload-time = "2026-04-24T19:08:30.822Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/8b/ec789af64ef3d85816a5c4ac8fe1e3c74d6e3bb9675c1325e3b1de4ddb14/posthog-7.13.2-py3-none-any.whl", hash = "sha256:e8ea9a7fa740b453533a76c0f3300b16120a3c27c19ab417cf0e69bb8c210fb6", size = 229762, upload-time = "2026-04-30T09:01:24.144Z" },
 ]
 
 [[package]]
@@ -8900,11 +8897,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.26"
+version = "0.0.27"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/9b/f23807317a113dc36e74e75eb265a02dd1a4d9082abc3c1064acd22997c4/python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602", size = 44043, upload-time = "2026-04-27T10:51:26.649Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+    { url = "https://files.pythonhosted.org/packages/99/78/4126abcbdbd3c559d43e0db7f7b9173fc6befe45d39a2856cc0b8ec2a5a6/python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645", size = 29254, upload-time = "2026-04-27T10:51:24.997Z" },
 ]
 
 [[package]]
@@ -9563,15 +9560,15 @@ wheels = [
 
 [[package]]
 name = "reportlab"
-version = "4.4.10"
+version = "4.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "charset-normalizer" },
     { name = "pillow" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/48/57/28bfbf0a775b618b6e4d854ef8dd3f5c8988e5d614d8898703502a35f61c/reportlab-4.4.10.tar.gz", hash = "sha256:5cbbb34ac3546039d0086deb2938cdec06b12da3cdb836e813258eb33cd28487", size = 3714962, upload-time = "2026-02-12T10:45:21.325Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dd/23/b8a8b9a5e596ce3de71237c8d6c6a976c763e930878b16340aff3d67ed53/reportlab-4.5.0.tar.gz", hash = "sha256:e595932789ab7a107ba253e83f7815622708a9fd49920d0d6a909880eb66ac75", size = 3914127, upload-time = "2026-04-29T09:12:26.785Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/2e/e1798b8b248e1517e74c6cdf10dd6edd485044e7edf46b5f11ffcc5a0add/reportlab-4.4.10-py3-none-any.whl", hash = "sha256:5abc815746ae2bc44e7ff25db96814f921349ca814c992c7eac3c26029bf7c24", size = 1955400, upload-time = "2026-02-12T10:45:18.828Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/13/bc43591a54dd38ac5c19e7e849f0311d879737a0d07e032e5be79849a5fb/reportlab-4.5.0-py3-none-any.whl", hash = "sha256:b8cc8996947d84e805368b47b2376070966f091d029351a0d8a1f238984c2c7f", size = 1957238, upload-time = "2026-04-29T09:12:22.904Z" },
 ]
 
 [[package]]
@@ -9881,14 +9878,14 @@ wheels = [
 
 [[package]]
 name = "s3transfer"
-version = "0.16.1"
+version = "0.17.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/46/29/af14f4ef3c11a50435308660e2cc68761c9a7742475e0585cd4396b91777/s3transfer-0.16.1.tar.gz", hash = "sha256:8e424355754b9ccb32467bdc568edf55be82692ef2002d934b1311dbb3b9e524", size = 154801, upload-time = "2026-04-22T20:36:06.475Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/ec/7c692cde9125b77e84b307354d4fb705f98b8ccad59a036d5957ca75bfc3/s3transfer-0.17.0.tar.gz", hash = "sha256:9edeb6d1c3c2f89d6050348548834ad8289610d886e5bf7b7207728bd43ce33a", size = 155337, upload-time = "2026-04-29T22:07:36.33Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/19/90d7d4ed51932c022d53f1d02d564b62d10e272692a1f9b76425c1ad2a02/s3transfer-0.16.1-py3-none-any.whl", hash = "sha256:61bcd00ccb83b21a0fe7e91a553fff9729d46c83b4e0106e7c314a733891f7c2", size = 86825, upload-time = "2026-04-22T20:36:04.992Z" },
+    { url = "https://files.pythonhosted.org/packages/87/72/c6c32d2b657fa3dad1de340254e14390b1e334ce38268b7ad51abda3c8c2/s3transfer-0.17.0-py3-none-any.whl", hash = "sha256:ce3801712acf4ad3e89fb9990df97b4972e93f4b3b0004d214be5bce12814c20", size = 86811, upload-time = "2026-04-29T22:07:34.966Z" },
 ]
 
 [[package]]
@@ -10822,15 +10819,15 @@ wheels = [
 
 [[package]]
 name = "sse-starlette"
-version = "3.3.4"
+version = "3.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "starlette" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/8c/f9290339ef6d79badbc010f067cd769d6601ec11a57d78569c683fb4dd87/sse_starlette-3.3.4.tar.gz", hash = "sha256:aaf92fc067af8a5427192895ac028e947b484ac01edbc3caf00e7e7137c7bef1", size = 32427, upload-time = "2026-03-29T09:00:23.307Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/9a/f35932a8c0eb6b2287b66fa65a0321df8c84e4e355a659c1841a37c39fdb/sse_starlette-3.4.1.tar.gz", hash = "sha256:f780bebcf6c8997fe514e3bd8e8c648d8284976b391c8bed0bcb1f611632b555", size = 35127, upload-time = "2026-04-26T13:32:32.292Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/7f/3de5402f39890ac5660b86bcf5c03f9d855dad5c4ed764866d7b592b46fd/sse_starlette-3.3.4-py3-none-any.whl", hash = "sha256:84bb06e58939a8b38d8341f1bc9792f06c2b53f48c608dd207582b664fc8f3c1", size = 14330, upload-time = "2026-03-29T09:00:21.846Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/07/45c21ed03d708c477367305726b89919b020a3a2a01f72aaf5ad941caf35/sse_starlette-3.4.1-py3-none-any.whl", hash = "sha256:6b43cf21f1d574d582a6e1b0cfbde1c94dc86a32a701a7168c99c4475c6bd1d0", size = 16487, upload-time = "2026-04-26T13:32:30.819Z" },
 ]
 
 [[package]]
@@ -11431,7 +11428,7 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.24.2"
+version = "0.25.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -11439,9 +11436,9 @@ dependencies = [
     { name = "rich" },
     { name = "shellingham" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/83/b8/9ebb531b6c2d377af08ac6746a5df3425b21853a5d2260876919b58a2a4a/typer-0.24.2.tar.gz", hash = "sha256:ec070dcfca1408e85ee203c6365001e818c3b7fffe686fd07ff2d68095ca0480", size = 119849, upload-time = "2026-04-22T17:45:34.413Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/27/ede8cec7596e0041ba7e7b80b47d132562f56ff454313a16f6084e555c9f/typer-0.25.0.tar.gz", hash = "sha256:123eaf9f19bb40fd268310e12a542c0c6b4fab9c98d9d23342a01ff95e3ce930", size = 120150, upload-time = "2026-04-26T08:46:14.767Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/d1/9484b497e0a0410b901c12b8251c3e746e1e863f7d28419ffe06f7892fda/typer-0.24.2-py3-none-any.whl", hash = "sha256:b618bc3d721f9a8d30f3e05565be26416d06e9bcc29d49bc491dc26aba674fa8", size = 55977, upload-time = "2026-04-22T17:45:33.055Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/72/193d4e586ec5a4db834a36bbeb47641a62f951f114ffd0fe5b1b46e8d56f/typer-0.25.0-py3-none-any.whl", hash = "sha256:ac01b48823d3db9a83c9e164338057eadbb1c9957a2a6b4eeb486669c560b5dc", size = 55993, upload-time = "2026-04-26T08:46:15.889Z" },
 ]
 
 [[package]]
@@ -11750,7 +11747,7 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "21.2.4"
+version = "21.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
@@ -11759,9 +11756,9 @@ dependencies = [
     { name = "python-discovery" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0c/98/3a7e644e19cb26133488caff231be390579860bbbb3da35913c49a1d0a46/virtualenv-21.2.4.tar.gz", hash = "sha256:b294ef68192638004d72524ce7ef303e9d0cf5a44c95ce2e54a7500a6381cada", size = 5850742, upload-time = "2026-04-14T22:15:31.438Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/8b/6331f7a7fe70131c301106ec1e7cf23e2501bf7d4ca3636805801ca191bb/virtualenv-21.3.0.tar.gz", hash = "sha256:733750db978ec95c2d8eb4feadaa57091002bce404cb39ba69899cf7bd28944e", size = 7614069, upload-time = "2026-04-27T17:05:58.927Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/8d/edd0bd910ff803c308ee9a6b7778621af0d10252219ad9f19ef4d4982a61/virtualenv-21.2.4-py3-none-any.whl", hash = "sha256:29d21e941795206138d0f22f4e45ff7050e5da6c6472299fb7103318763861ac", size = 5831232, upload-time = "2026-04-14T22:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/eb/03bfb1299d4c4510329e470f13f9a4ce793df7fcb5a2fd3510f911066f61/virtualenv-21.3.0-py3-none-any.whl", hash = "sha256:4d28ee41f6d9ec8f1f00cd472b9ffbcedda1b3d3b9a575b5c94a2d004fd51bd7", size = 7594690, upload-time = "2026-04-27T17:05:55.468Z" },
 ]
 
 [[package]]
@@ -12101,7 +12098,7 @@ wheels = [
 
 [[package]]
 name = "xai-sdk"
-version = "1.11.0"
+version = "1.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -12113,9 +12110,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/49/32/bb8385f7a3b05ce406b689aa000c9a34289caa1526f1c093a1cefc0d9695/xai_sdk-1.11.0.tar.gz", hash = "sha256:ca87a830d310fb8e06fba44fb2a8c5cdf0d9f716b61126eddd51b7f416a63932", size = 404313, upload-time = "2026-03-27T18:23:10.091Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/39/93b95ba32a99ebe7c14d0e646ee3b507a8b0977674857395717c89ee0e55/xai_sdk-1.12.0.tar.gz", hash = "sha256:d9c33432ff5463a8f9ff0d8c31abec9b243f9e9906541476f383a07b8bd44753", size = 412578, upload-time = "2026-04-29T18:42:52.401Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/76/86d9a3589c725ce825d2ed3e7cb3ecf7f956d3fd015353d52197bb341bcd/xai_sdk-1.11.0-py3-none-any.whl", hash = "sha256:fe58ce6d8f8115ae8bd57ded57bcd847d0bb7cb28bb7b236abefd4626df1ed8d", size = 251388, upload-time = "2026-03-27T18:23:08.573Z" },
+    { url = "https://files.pythonhosted.org/packages/75/b7/929830ed33c623235d08b26a51b3c3c90c99beed3f47cf2910a6e4521c99/xai_sdk-1.12.0-py3-none-any.whl", hash = "sha256:f28f876d1d7ba2d266bcd1fdf9e8f79f75458ef52d60605fb99b576547848e6a", size = 256549, upload-time = "2026-04-29T18:42:50.781Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add Anthropic extended thinking request support through thinking and output_config.
- Convert thinking, redacted thinking, and streaming thinking deltas into OpenAI-compatible response fields.
- Preserve Anthropic thinking blocks across tool-use continuations.
- Update Anthropic config docs, focused tests, and the Opus 4.7 example with tool calling and streaming.

## Validation
- uv run pytest test/models/test_anthropic_model.py
- uv run ruff check camel/models/anthropic_model.py camel/configs/anthropic_config.py test/models/test_anthropic_model.py examples/models/anthropic_model_example.py
- uv run ruff format --check camel/models/anthropic_model.py camel/configs/anthropic_config.py test/models/test_anthropic_model.py examples/models/anthropic_model_example.py
- uv run mypy camel/models/anthropic_model.py camel/configs/anthropic_config.py
- uv run python -m py_compile examples/models/anthropic_model_example.py

Closes #4032