### PR TITLE
fix(toolkits): avoid re-entering agent in screenshot analysis

### DIFF
--- a/camel/toolkits/screenshot_toolkit.py
+++ b/camel/toolkits/screenshot_toolkit.py
@@ -14,7 +14,7 @@
 
 import os
 from pathlib import Path
-from typing import List, Optional
+from typing import TYPE_CHECKING, Any, List, Optional
 
 from PIL import Image
 
@@ -25,6 +25,9 @@ from camel.toolkits.base import RegisteredAgentToolkit
 from camel.utils import dependencies_required
 
 logger = get_logger(__name__)
+
+if TYPE_CHECKING:
+    from camel.agents import ChatAgent
 
 
 class ScreenshotToolkit(BaseToolkit, RegisteredAgentToolkit):
@@ -63,6 +66,38 @@ class ScreenshotToolkit(BaseToolkit, RegisteredAgentToolkit):
         self.ImageGrab = ImageGrab
         self.screenshots_dir = path
         self.screenshots_dir.mkdir(parents=True, exist_ok=True)
+        self._image_analysis_agent: Optional["ChatAgent"] = None
+        self._image_analysis_agent_model: Any = None
+        self._image_analysis_agent_language: Optional[str] = None
+
+    def _get_image_analysis_agent(self) -> Optional["ChatAgent"]:
+        r"""Get an isolated helper agent for screenshot image analysis."""
+        parent_agent = self.agent
+        if parent_agent is None:
+            return None
+
+        model = parent_agent.model_backend
+        output_language = parent_agent.output_language
+        if (
+            self._image_analysis_agent is not None
+            and self._image_analysis_agent_model is model
+            and self._image_analysis_agent_language == output_language
+        ):
+            return self._image_analysis_agent
+
+        from camel.agents import ChatAgent
+
+        self._image_analysis_agent = ChatAgent(
+            system_message=(
+                "You analyze screenshots and answer the user's prompt "
+                "using only the provided image."
+            ),
+            model=model,
+            output_language=output_language,
+        )
+        self._image_analysis_agent_model = model
+        self._image_analysis_agent_language = output_language
+        return self._image_analysis_agent
 
     def read_image(
         self,
@@ -86,7 +121,8 @@ class ScreenshotToolkit(BaseToolkit, RegisteredAgentToolkit):
             str: The response after analyzing the image, which could be a
                  description, an answer, or a confirmation of an action.
         """
-        if self.agent is None:
+        analysis_agent = self._get_image_analysis_agent()
+        if analysis_agent is None:
             logger.error(
                 "Cannot record screenshot in memory: No agent registered. "
                 "Please pass this toolkit to ChatAgent via "
@@ -116,13 +152,16 @@ class ScreenshotToolkit(BaseToolkit, RegisteredAgentToolkit):
                 image_list=[img],
             )
 
-            # Record the message in agent's memory
-            response = self.agent.step(message)
+            # Analyze with an isolated helper agent to avoid re-entering the
+            # parent agent while it is executing this toolkit's tool call.
+            response = analysis_agent.step(message)
             return response.msgs[0].content
 
         except Exception as e:
             logger.error(f"Error reading screenshot: {e}")
             return f"Error reading screenshot: {e}"
+        finally:
+            analysis_agent.reset()
 
     def take_screenshot_and_read_image(
         self,

--- a/camel/toolkits/screenshot_toolkit.py
+++ b/camel/toolkits/screenshot_toolkit.py
@@ -14,7 +14,7 @@
 
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, List, Optional
+from typing import List, Optional
 
 from PIL import Image
 
@@ -25,9 +25,6 @@ from camel.toolkits.base import RegisteredAgentToolkit
 from camel.utils import dependencies_required
 
 logger = get_logger(__name__)
-
-if TYPE_CHECKING:
-    from camel.agents import ChatAgent
 
 
 class ScreenshotToolkit(BaseToolkit, RegisteredAgentToolkit):
@@ -66,38 +63,6 @@ class ScreenshotToolkit(BaseToolkit, RegisteredAgentToolkit):
         self.ImageGrab = ImageGrab
         self.screenshots_dir = path
         self.screenshots_dir.mkdir(parents=True, exist_ok=True)
-        self._image_analysis_agent: Optional["ChatAgent"] = None
-        self._image_analysis_agent_model: Any = None
-        self._image_analysis_agent_language: Optional[str] = None
-
-    def _get_image_analysis_agent(self) -> Optional["ChatAgent"]:
-        r"""Get an isolated helper agent for screenshot image analysis."""
-        parent_agent = self.agent
-        if parent_agent is None:
-            return None
-
-        model = parent_agent.model_backend
-        output_language = parent_agent.output_language
-        if (
-            self._image_analysis_agent is not None
-            and self._image_analysis_agent_model is model
-            and self._image_analysis_agent_language == output_language
-        ):
-            return self._image_analysis_agent
-
-        from camel.agents import ChatAgent
-
-        self._image_analysis_agent = ChatAgent(
-            system_message=(
-                "You analyze screenshots and answer the user's prompt "
-                "using only the provided image."
-            ),
-            model=model,
-            output_language=output_language,
-        )
-        self._image_analysis_agent_model = model
-        self._image_analysis_agent_language = output_language
-        return self._image_analysis_agent
 
     def read_image(
         self,
@@ -121,8 +86,8 @@ class ScreenshotToolkit(BaseToolkit, RegisteredAgentToolkit):
             str: The response after analyzing the image, which could be a
                  description, an answer, or a confirmation of an action.
         """
-        analysis_agent = self._get_image_analysis_agent()
-        if analysis_agent is None:
+        parent_agent = self.agent
+        if parent_agent is None:
             logger.error(
                 "Cannot record screenshot in memory: No agent registered. "
                 "Please pass this toolkit to ChatAgent via "
@@ -133,6 +98,7 @@ class ScreenshotToolkit(BaseToolkit, RegisteredAgentToolkit):
                 "ChatAgent via toolkits_to_register_agent parameter."
             )
 
+        analysis_agent = None
         try:
             image_path = str(Path(image_path).absolute())
 
@@ -152,8 +118,19 @@ class ScreenshotToolkit(BaseToolkit, RegisteredAgentToolkit):
                 image_list=[img],
             )
 
-            # Analyze with an isolated helper agent to avoid re-entering the
-            # parent agent while it is executing this toolkit's tool call.
+            from camel.agents import ChatAgent
+
+            # Use an isolated helper agent to avoid re-entering the parent
+            # agent while it is executing this toolkit's tool call.
+            analysis_agent = ChatAgent(
+                system_message=(
+                    "You analyze screenshots and answer the user's prompt "
+                    "using only the provided image."
+                ),
+                model=parent_agent.model_backend,
+                output_language=parent_agent.output_language,
+            )
+
             response = analysis_agent.step(message)
             return response.msgs[0].content
 
@@ -161,7 +138,8 @@ class ScreenshotToolkit(BaseToolkit, RegisteredAgentToolkit):
             logger.error(f"Error reading screenshot: {e}")
             return f"Error reading screenshot: {e}"
         finally:
-            analysis_agent.reset()
+            if analysis_agent is not None:
+                analysis_agent.reset()
 
     def take_screenshot_and_read_image(
         self,

--- a/test/toolkits/test_screenshot_toolkit.py
+++ b/test/toolkits/test_screenshot_toolkit.py
@@ -37,7 +37,9 @@ def test_read_image_uses_helper_agent_instead_of_registered_parent_agent(
     toolkit = ScreenshotToolkit(working_directory=str(tmp_path))
     toolkit.register_agent(parent_agent)
 
-    with patch("camel.agents.ChatAgent", return_value=helper_agent):
+    with patch(
+        "camel.agents.ChatAgent", return_value=helper_agent
+    ) as chat_agent:
         result = toolkit.read_image(str(image_path), "read it")
 
     assert result == "visible text"
@@ -45,9 +47,14 @@ def test_read_image_uses_helper_agent_instead_of_registered_parent_agent(
     helper_agent.step.assert_called_once()
     helper_agent.reset.assert_called_once()
 
+    chat_agent.assert_called_once()
+    _, kwargs = chat_agent.call_args
+    assert kwargs["model"] is parent_agent.model_backend
+    assert kwargs["output_language"] == "Chinese"
 
-def test_read_image_reuses_helper_agent_for_same_parent_agent(tmp_path):
-    r"""Test image reading reuses a reset helper agent for stable config."""
+
+def test_read_image_creates_isolated_helper_agent_for_each_read(tmp_path):
+    r"""Test each image read gets a fresh helper agent."""
     first_path = tmp_path / "first.png"
     second_path = tmp_path / "second.png"
     Image.new("RGB", (1, 1)).save(first_path)
@@ -57,18 +64,21 @@ def test_read_image_reuses_helper_agent_for_same_parent_agent(tmp_path):
     parent_agent.model_backend = MagicMock()
     parent_agent.output_language = None
 
-    helper_agent = MagicMock()
-    helper_agent.step.return_value.msgs = [MagicMock(content="ok")]
+    first_helper = MagicMock()
+    first_helper.step.return_value.msgs = [MagicMock(content="first")]
+    second_helper = MagicMock()
+    second_helper.step.return_value.msgs = [MagicMock(content="second")]
 
     toolkit = ScreenshotToolkit(working_directory=str(tmp_path))
     toolkit.register_agent(parent_agent)
 
     with patch(
         "camel.agents.ChatAgent",
-        return_value=helper_agent,
-    ) as mock_chat_agent:
-        assert toolkit.read_image(str(first_path)) == "ok"
-        assert toolkit.read_image(str(second_path)) == "ok"
+        side_effect=[first_helper, second_helper],
+    ) as chat_agent:
+        assert toolkit.read_image(str(first_path)) == "first"
+        assert toolkit.read_image(str(second_path)) == "second"
 
-    assert mock_chat_agent.call_count == 1
-    assert helper_agent.reset.call_count == 2
+    assert chat_agent.call_count == 2
+    first_helper.reset.assert_called_once()
+    second_helper.reset.assert_called_once()

--- a/test/toolkits/test_screenshot_toolkit.py
+++ b/test/toolkits/test_screenshot_toolkit.py
@@ -1,0 +1,74 @@
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+
+from unittest.mock import MagicMock, patch
+
+from PIL import Image
+
+from camel.toolkits.screenshot_toolkit import ScreenshotToolkit
+
+
+def test_read_image_uses_helper_agent_instead_of_registered_parent_agent(
+    tmp_path,
+):
+    r"""Test image reading avoids re-entering the registered parent agent."""
+    image_path = tmp_path / "screenshot.png"
+    Image.new("RGB", (1, 1)).save(image_path)
+
+    parent_agent = MagicMock()
+    parent_agent.model_backend = MagicMock()
+    parent_agent.output_language = "Chinese"
+    parent_agent.step.side_effect = AssertionError("parent re-entered")
+
+    helper_agent = MagicMock()
+    helper_agent.step.return_value.msgs = [MagicMock(content="visible text")]
+
+    toolkit = ScreenshotToolkit(working_directory=str(tmp_path))
+    toolkit.register_agent(parent_agent)
+
+    with patch("camel.agents.ChatAgent", return_value=helper_agent):
+        result = toolkit.read_image(str(image_path), "read it")
+
+    assert result == "visible text"
+    parent_agent.step.assert_not_called()
+    helper_agent.step.assert_called_once()
+    helper_agent.reset.assert_called_once()
+
+
+def test_read_image_reuses_helper_agent_for_same_parent_agent(tmp_path):
+    r"""Test image reading reuses a reset helper agent for stable config."""
+    first_path = tmp_path / "first.png"
+    second_path = tmp_path / "second.png"
+    Image.new("RGB", (1, 1)).save(first_path)
+    Image.new("RGB", (1, 1)).save(second_path)
+
+    parent_agent = MagicMock()
+    parent_agent.model_backend = MagicMock()
+    parent_agent.output_language = None
+
+    helper_agent = MagicMock()
+    helper_agent.step.return_value.msgs = [MagicMock(content="ok")]
+
+    toolkit = ScreenshotToolkit(working_directory=str(tmp_path))
+    toolkit.register_agent(parent_agent)
+
+    with patch(
+        "camel.agents.ChatAgent",
+        return_value=helper_agent,
+    ) as mock_chat_agent:
+        assert toolkit.read_image(str(first_path)) == "ok"
+        assert toolkit.read_image(str(second_path)) == "ok"
+
+    assert mock_chat_agent.call_count == 1
+    assert helper_agent.reset.call_count == 2


### PR DESCRIPTION
Fixes #3869

## Summary
- Avoid re-entering the registered parent agent from `ScreenshotToolkit.read_image()` while a tool call is already in progress.
- Use an isolated helper `ChatAgent` for screenshot image analysis, reusing the parent agent's model and output language.
- Add regression coverage that verifies the parent agent is not called and the helper agent is reused/reset between image reads.

## Root Cause
`ScreenshotToolkit.read_image()` called `self.agent.step(...)` directly. When the toolkit is registered to the same agent that is currently executing the tool call, this re-enters the parent agent mid tool-call flow and can break the message protocol chain.

## Validation
- `uv run --extra dev pytest test/toolkits/test_screenshot_toolkit.py -q`
- `uv run --extra dev pytest test/toolkits/test_screenshot_toolkit.py test/toolkits/test_image_analysis_toolkiy.py -q`
- `uv run --extra dev ruff check camel/toolkits/screenshot_toolkit.py test/toolkits/test_screenshot_toolkit.py`
- `uv run --extra dev ruff format --check camel/toolkits/screenshot_toolkit.py test/toolkits/test_screenshot_toolkit.py`