### PR TITLE
feat(toolkits): add Perplexity search toolkit

### DIFF
--- a/camel/toolkits/search_toolkit.py
+++ b/camel/toolkits/search_toolkit.py
@@ -34,7 +34,8 @@ class SearchToolkit(BaseToolkit):
     r"""A class representing a toolkit for web search.
 
     This class provides methods for searching information on the web using
-    search engines like Google, DuckDuckGo, Wikipedia and Wolfram Alpha, Brave.
+    search engines like Google, DuckDuckGo, Wikipedia and Wolfram Alpha, Brave,
+    Perplexity.
     """
 
     def __init__(
@@ -1665,6 +1666,111 @@ class SearchToolkit(BaseToolkit):
         except Exception as e:
             return {"error": f"Unexpected error during Querit search: {e!s}"}
 
+    @api_keys_required([(None, 'PERPLEXITY_API_KEY')])
+    def search_perplexity(
+        self,
+        query: str,
+        max_results: int = 10,
+        max_tokens_per_page: Optional[int] = None,
+        country: Optional[str] = None,
+        search_recency_filter: Optional[
+            Literal["hour", "day", "week", "month", "year"]
+        ] = None,
+        search_domain_filter: Optional[List[str]] = None,
+        search_language_filter: Optional[List[str]] = None,
+        last_updated_after_filter: Optional[str] = None,
+        last_updated_before_filter: Optional[str] = None,
+        search_after_date_filter: Optional[str] = None,
+        search_before_date_filter: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        r"""Use Perplexity Search API to retrieve web search results.
+
+        See https://docs.perplexity.ai/api-reference/search-post for details.
+
+        Args:
+            query (str): The search query string.
+            max_results (int): Maximum number of results to return. Must be
+                between 1 and 20. (default: :obj:`10`)
+            max_tokens_per_page (Optional[int]): Maximum number of tokens to
+                include from each result page (between 1 and 1,000,000).
+                (default: :obj:`None`)
+            country (Optional[str]): ISO 3166-1 alpha-2 country code used to
+                bias results to a specific country. (default: :obj:`None`)
+            search_recency_filter (Optional[Literal["hour", "day", "week", "month", "year"]]):
+                Filter results by recency. (default: :obj:`None`)
+            search_domain_filter (Optional[List[str]]): Up to 20 domains to
+                restrict the search to. (default: :obj:`None`)
+            search_language_filter (Optional[List[str]]): ISO 639-1 language
+                codes to restrict the search to. (default: :obj:`None`)
+            last_updated_after_filter (Optional[str]): Only include results
+                last updated after this date (format: ``MM/DD/YYYY``).
+                (default: :obj:`None`)
+            last_updated_before_filter (Optional[str]): Only include results
+                last updated before this date (format: ``MM/DD/YYYY``).
+                (default: :obj:`None`)
+            search_after_date_filter (Optional[str]): Only include results
+                published after this date (format: ``MM/DD/YYYY``).
+                (default: :obj:`None`)
+            search_before_date_filter (Optional[str]): Only include results
+                published before this date (format: ``MM/DD/YYYY``).
+                (default: :obj:`None`)
+
+        Returns:
+            Dict[str, Any]: The Perplexity Search API response. On success,
+                contains a ``results`` list (each entry includes ``title``,
+                ``url``, ``snippet``, ``date``, ``last_updated``) along with
+                ``id`` and ``server_time`` fields. On failure, returns a
+                dictionary with an ``error`` key.
+        """
+        from camel import __version__ as camel_version
+
+        PERPLEXITY_API_KEY = os.getenv("PERPLEXITY_API_KEY")
+
+        url = "https://api.perplexity.ai/search"
+        headers = {
+            "Authorization": f"Bearer {PERPLEXITY_API_KEY}",
+            "Content-Type": "application/json",
+            "X-Pplx-Integration": f"camel-ai/{camel_version}",
+        }
+
+        payload: Dict[str, Any] = {
+            "query": query,
+            "max_results": max_results,
+        }
+        optional_params: Dict[str, Any] = {
+            "max_tokens_per_page": max_tokens_per_page,
+            "country": country,
+            "search_recency_filter": search_recency_filter,
+            "search_domain_filter": search_domain_filter,
+            "search_language_filter": search_language_filter,
+            "last_updated_after_filter": last_updated_after_filter,
+            "last_updated_before_filter": last_updated_before_filter,
+            "search_after_date_filter": search_after_date_filter,
+            "search_before_date_filter": search_before_date_filter,
+        }
+        for key, value in optional_params.items():
+            if value is not None:
+                payload[key] = value
+
+        try:
+            response = requests.post(
+                url, headers=headers, json=payload, timeout=self.timeout
+            )
+            if response.status_code != 200:
+                return {
+                    "error": (
+                        f"Perplexity API failed with status "
+                        f"{response.status_code}: {response.text}"
+                    )
+                }
+            return response.json()
+        except requests.exceptions.RequestException as e:
+            return {"error": f"Perplexity search request failed: {e!s}"}
+        except Exception as e:
+            return {
+                "error": f"Unexpected error during Perplexity search: {e!s}"
+            }
+
     def get_tools(self) -> List[FunctionTool]:
         r"""Returns a list of FunctionTool objects representing the
         functions in the toolkit.
@@ -1689,6 +1795,7 @@ class SearchToolkit(BaseToolkit):
             FunctionTool(self.search_metaso),
             FunctionTool(self.search_serpapi),
             FunctionTool(self.search_querit),
+            FunctionTool(self.search_perplexity),
         ]
 
     # Deprecated method alias for backward compatibility

--- a/docs/mintlify/reference/camel.toolkits.search_toolkit.mdx
+++ b/docs/mintlify/reference/camel.toolkits.search_toolkit.mdx
@@ -11,7 +11,8 @@ class SearchToolkit(BaseToolkit):
 A class representing a toolkit for web search.
 
 This class provides methods for searching information on the web using
-search engines like Google, DuckDuckGo, Wikipedia and Wolfram Alpha, Brave.
+search engines like Google, DuckDuckGo, Wikipedia and Wolfram Alpha, Brave,
+Perplexity.
 
 <a id="camel.toolkits.search_toolkit.SearchToolkit.__init__"></a>
 
@@ -599,6 +600,49 @@ such as site names, favicons, and page ages.
 - 'search_id': A unique request reference ID.
 - 'took': The server-side response time.
 - or 'error': An error message if something went wrong.
+
+<a id="camel.toolkits.search_toolkit.SearchToolkit.search_perplexity"></a>
+
+### search_perplexity
+
+```python
+def search_perplexity(
+    self,
+    query: str,
+    max_results: int = 10,
+    max_tokens_per_page: Optional[int] = None,
+    country: Optional[str] = None,
+    search_recency_filter: Optional[Literal['hour', 'day', 'week', 'month', 'year']] = None,
+    search_domain_filter: Optional[List[str]] = None,
+    search_language_filter: Optional[List[str]] = None,
+    last_updated_after_filter: Optional[str] = None,
+    last_updated_before_filter: Optional[str] = None,
+    search_after_date_filter: Optional[str] = None,
+    search_before_date_filter: Optional[str] = None,
+) -> Dict[str, Any]:
+```
+
+Use Perplexity Search API to retrieve web search results.
+
+See https://docs.perplexity.ai/api-reference/search-post for details.
+
+**Parameters:**
+
+- **query** (str): The search query string.
+- **max_results** (int): Maximum number of results to return. Must be between 1 and 20. (default: :obj:`10`)
+- **max_tokens_per_page** (Optional[int]): Maximum number of tokens to include from each result page (between 1 and 1,000,000). (default: :obj:`None`)
+- **country** (Optional[str]): ISO 3166-1 alpha-2 country code used to bias results to a specific country. (default: :obj:`None`)
+- **search_recency_filter** (Optional[Literal['hour', 'day', 'week', 'month', 'year']]): Filter results by recency. (default: :obj:`None`)
+- **search_domain_filter** (Optional[List[str]]): Up to 20 domains to restrict the search to. (default: :obj:`None`)
+- **search_language_filter** (Optional[List[str]]): ISO 639-1 language codes to restrict the search to. (default: :obj:`None`)
+- **last_updated_after_filter** (Optional[str]): Only include results last updated after this date (format: `MM/DD/YYYY`). (default: :obj:`None`)
+- **last_updated_before_filter** (Optional[str]): Only include results last updated before this date (format: `MM/DD/YYYY`). (default: :obj:`None`)
+- **search_after_date_filter** (Optional[str]): Only include results published after this date (format: `MM/DD/YYYY`). (default: :obj:`None`)
+- **search_before_date_filter** (Optional[str]): Only include results published before this date (format: `MM/DD/YYYY`). (default: :obj:`None`)
+
+**Returns:**
+
+  Dict[str, Any]: The Perplexity Search API response. On success, contains a `results` list (each entry includes `title`, `url`, `snippet`, `date`, `last_updated`) along with `id` and `server_time` fields. On failure, returns a dictionary with an `error` key.
 
 <a id="camel.toolkits.search_toolkit.SearchToolkit.get_tools"></a>
 

--- a/docs/reference/camel.toolkits.search_toolkit.md
+++ b/docs/reference/camel.toolkits.search_toolkit.md
@@ -12,7 +12,7 @@ A class representing a toolkit for web search.
 
 This class provides methods for searching information on the web using
 search engines like Google, DuckDuckGo, Wikipedia and Wolfram Alpha, Brave,
-Querit.
+Perplexity.
 
 <a id="camel.toolkits.search_toolkit.SearchToolkit.__init__"></a>
 
@@ -597,6 +597,49 @@ such as site names, favicons, and page ages.
 - 'search_id' (int): A unique request reference ID.
 - 'took' (str): The server-side response time.
 - or 'error' (str): An error message if something went wrong.
+
+<a id="camel.toolkits.search_toolkit.SearchToolkit.search_perplexity"></a>
+
+### search_perplexity
+
+```python
+def search_perplexity(
+    self,
+    query: str,
+    max_results: int = 10,
+    max_tokens_per_page: Optional[int] = None,
+    country: Optional[str] = None,
+    search_recency_filter: Optional[Literal['hour', 'day', 'week', 'month', 'year']] = None,
+    search_domain_filter: Optional[List[str]] = None,
+    search_language_filter: Optional[List[str]] = None,
+    last_updated_after_filter: Optional[str] = None,
+    last_updated_before_filter: Optional[str] = None,
+    search_after_date_filter: Optional[str] = None,
+    search_before_date_filter: Optional[str] = None,
+) -> Dict[str, Any]:
+```
+
+Use Perplexity Search API to retrieve web search results.
+
+See https://docs.perplexity.ai/api-reference/search-post for details.
+
+**Parameters:**
+
+- **query** (str): The search query string.
+- **max_results** (int): Maximum number of results to return. Must be between 1 and 20. (default: :obj:`10`)
+- **max_tokens_per_page** (Optional[int]): Maximum number of tokens to include from each result page (between 1 and 1,000,000). (default: :obj:`None`)
+- **country** (Optional[str]): ISO 3166-1 alpha-2 country code used to bias results to a specific country. (default: :obj:`None`)
+- **search_recency_filter** (Optional[Literal['hour', 'day', 'week', 'month', 'year']]): Filter results by recency. (default: :obj:`None`)
+- **search_domain_filter** (Optional[List[str]]): Up to 20 domains to restrict the search to. (default: :obj:`None`)
+- **search_language_filter** (Optional[List[str]]): ISO 639-1 language codes to restrict the search to. (default: :obj:`None`)
+- **last_updated_after_filter** (Optional[str]): Only include results last updated after this date (format: `MM/DD/YYYY`). (default: :obj:`None`)
+- **last_updated_before_filter** (Optional[str]): Only include results last updated before this date (format: `MM/DD/YYYY`). (default: :obj:`None`)
+- **search_after_date_filter** (Optional[str]): Only include results published after this date (format: `MM/DD/YYYY`). (default: :obj:`None`)
+- **search_before_date_filter** (Optional[str]): Only include results published before this date (format: `MM/DD/YYYY`). (default: :obj:`None`)
+
+**Returns:**
+
+  Dict[str, Any]: The Perplexity Search API response. On success, contains a `results` list (each entry includes `title`, `url`, `snippet`, `date`, `last_updated`) along with `id` and `server_time` fields. On failure, returns a dictionary with an `error` key.
 
 <a id="camel.toolkits.search_toolkit.SearchToolkit.get_tools"></a>
 

--- a/examples/toolkits/search_perplexity_toolkit.py
+++ b/examples/toolkits/search_perplexity_toolkit.py
@@ -1,0 +1,78 @@
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+
+"""
+Perplexity Search - Real API Call Examples
+
+Before running, set your API key:
+    export PERPLEXITY_API_KEY="your_api_key_here"
+
+Get your key at: https://www.perplexity.ai/account/api
+"""
+
+import os
+from typing import Any
+
+from camel.toolkits import SearchToolkit
+
+if not os.getenv("PERPLEXITY_API_KEY"):
+    raise EnvironmentError(
+        "PERPLEXITY_API_KEY is not set.\n"
+        "Run: export PERPLEXITY_API_KEY='your_key_here'\n"
+        "Get your key at: https://www.perplexity.ai/account/api"
+    )
+
+
+def print_results(response: dict[str, Any]) -> None:
+    r"""Print Perplexity search results in a readable format."""
+    if error := response.get("error"):
+        print(f"Error: {error}")
+        return
+
+    print(f"Search ID   : {response.get('id')}")
+    print(f"Server time : {response.get('server_time')}")
+    for index, item in enumerate(response.get("results", []), start=1):
+        print(f"\n[{index}] {item.get('title')}")
+        print(f"    URL          : {item.get('url')}")
+        print(f"    Snippet      : {item.get('snippet')}")
+        print(f"    Date         : {item.get('date')}")
+        print(f"    Last updated : {item.get('last_updated')}")
+
+
+def main() -> None:
+    r"""Run Perplexity search toolkit examples."""
+    toolkit = SearchToolkit()
+
+    print("=" * 60)
+    print("Example 1: Basic search")
+    print("=" * 60)
+    basic_result = toolkit.search_perplexity(
+        query="CAMEL-AI multi-agent framework",
+    )
+    print_results(basic_result)
+
+    print("\n" + "=" * 60)
+    print("Example 2: Search with recency and country filters")
+    print("=" * 60)
+    filtered_result = toolkit.search_perplexity(
+        query="latest advances in multi-agent AI systems",
+        max_results=5,
+        country="US",
+        search_recency_filter="month",
+    )
+    print_results(filtered_result)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/toolkits/test_search_functions.py
+++ b/test/toolkits/test_search_functions.py
@@ -1212,3 +1212,152 @@ def test_search_querit_empty_results(mock_post, search_toolkit):
     assert "results" in result
     assert len(result["results"]) == 0
     assert result["search_id"] == 12348
+
+
+# ==================== Perplexity Search Tests ====================
+
+
+@patch('requests.post')
+def test_search_perplexity_success(mock_post, search_toolkit):
+    """Test successful Perplexity search."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "id": "abc123",
+        "server_time": "2026-04-30T00:00:00Z",
+        "results": [
+            {
+                "title": "CAMEL-AI",
+                "url": "https://www.camel-ai.org/",
+                "snippet": "CAMEL-AI is an open-source framework...",
+                "date": "2025-01-15",
+                "last_updated": "2025-03-01",
+            },
+            {
+                "title": "camel-ai/camel",
+                "url": "https://github.com/camel-ai/camel",
+                "snippet": "Multi-agent framework...",
+                "date": "2024-11-10",
+                "last_updated": "2025-04-01",
+            },
+        ],
+    }
+    mock_post.return_value = mock_response
+
+    with patch.dict(os.environ, {'PERPLEXITY_API_KEY': 'fake_api_key'}):
+        result = search_toolkit.search_perplexity(query="CAMEL-AI")
+
+    assert "results" in result
+    assert len(result["results"]) == 2
+    assert result["id"] == "abc123"
+    assert result["results"][0]["url"] == "https://www.camel-ai.org/"
+
+    mock_post.assert_called_once()
+    args, kwargs = mock_post.call_args
+    assert args[0] == "https://api.perplexity.ai/search"
+    assert kwargs['headers']['Authorization'] == 'Bearer fake_api_key'
+    assert kwargs['headers']['Content-Type'] == 'application/json'
+    # Attribution header must be present and use the camel-ai slug.
+    assert 'X-Pplx-Integration' in kwargs['headers']
+    assert kwargs['headers']['X-Pplx-Integration'].startswith('camel-ai/')
+    assert kwargs['json']['query'] == "CAMEL-AI"
+    assert kwargs['json']['max_results'] == 10
+    assert 'timeout' in kwargs
+
+
+@patch('requests.post')
+def test_search_perplexity_with_filters(mock_post, search_toolkit):
+    """Test Perplexity search with all filter parameters."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "id": "def456",
+        "server_time": "2026-04-30T00:00:00Z",
+        "results": [],
+    }
+    mock_post.return_value = mock_response
+
+    with patch.dict(os.environ, {'PERPLEXITY_API_KEY': 'fake_api_key'}):
+        search_toolkit.search_perplexity(
+            query="AI agents",
+            max_results=5,
+            max_tokens_per_page=2048,
+            country="US",
+            search_recency_filter="month",
+            search_domain_filter=["github.com"],
+            search_language_filter=["en"],
+            last_updated_after_filter="01/01/2025",
+            last_updated_before_filter="12/31/2025",
+            search_after_date_filter="01/01/2024",
+            search_before_date_filter="12/31/2025",
+        )
+
+    call_args = mock_post.call_args
+    payload = call_args[1]['json']
+
+    assert payload["query"] == "AI agents"
+    assert payload["max_results"] == 5
+    assert payload["max_tokens_per_page"] == 2048
+    assert payload["country"] == "US"
+    assert payload["search_recency_filter"] == "month"
+    assert payload["search_domain_filter"] == ["github.com"]
+    assert payload["search_language_filter"] == ["en"]
+    assert payload["last_updated_after_filter"] == "01/01/2025"
+    assert payload["last_updated_before_filter"] == "12/31/2025"
+    assert payload["search_after_date_filter"] == "01/01/2024"
+    assert payload["search_before_date_filter"] == "12/31/2025"
+
+
+@patch('requests.post')
+def test_search_perplexity_omits_unset_optional_params(
+    mock_post, search_toolkit
+):
+    """Test Perplexity search omits optional params when not set."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "id": "ghi789",
+        "server_time": "2026-04-30T00:00:00Z",
+        "results": [],
+    }
+    mock_post.return_value = mock_response
+
+    with patch.dict(os.environ, {'PERPLEXITY_API_KEY': 'fake_api_key'}):
+        search_toolkit.search_perplexity(query="test")
+
+    payload = mock_post.call_args[1]['json']
+    assert payload == {"query": "test", "max_results": 10}
+
+
+@patch('requests.post')
+def test_search_perplexity_http_error(mock_post, search_toolkit):
+    """Test HTTP error handling in Perplexity search."""
+    mock_response = MagicMock()
+    mock_response.status_code = 401
+    mock_response.text = '{"error": "Unauthorized"}'
+    mock_post.return_value = mock_response
+
+    with patch.dict(os.environ, {'PERPLEXITY_API_KEY': 'invalid_key'}):
+        result = search_toolkit.search_perplexity(query="test")
+
+    assert "error" in result
+    assert "401" in result["error"]
+
+
+@patch('requests.post')
+def test_search_perplexity_request_exception(mock_post, search_toolkit):
+    """Test request exception handling in Perplexity search."""
+    mock_post.side_effect = requests.exceptions.Timeout("Connection timed out")
+
+    with patch.dict(os.environ, {'PERPLEXITY_API_KEY': 'fake_key'}):
+        result = search_toolkit.search_perplexity(query="test")
+
+    assert "error" in result
+    assert "Perplexity search request failed" in result["error"]
+
+
+def test_search_perplexity_missing_api_key(search_toolkit):
+    """Test that missing PERPLEXITY_API_KEY raises a clear error."""
+    with patch.dict(os.environ, {}, clear=True):
+        with pytest.raises(ValueError):
+            search_toolkit.search_perplexity(query="test")


### PR DESCRIPTION
Closes #4050.

## Summary

This supersedes the closed #4035 and includes the requested example script for the Perplexity search toolkit method.

- Adds `SearchToolkit.search_perplexity`, authenticated with `PERPLEXITY_API_KEY`, for calling Perplexity's Search API.
- Sends the `X-Pplx-Integration: camel-ai/<version>` attribution header with Perplexity requests.
- Supports Perplexity search parameters including `max_results`, `max_tokens_per_page`, `country`, recency, domain, language, last-updated, and date filters.
- Registers `search_perplexity` in `SearchToolkit.get_tools()`.
- Adds unit coverage for success, optional filters, omitted unset parameters, HTTP errors, request exceptions, and missing API keys.
- Adds `examples/toolkits/search_perplexity_toolkit.py` showing a basic search and a filtered search using `search_recency_filter`, `country`, and `max_results`.

## Testing

- `python -c "import ast; ast.parse(open('examples/toolkits/search_perplexity_toolkit.py').read())"`
- `ruff check examples/toolkits/search_perplexity_toolkit.py`
- `ruff format --check examples/toolkits/search_perplexity_toolkit.py`
- `uv run --with 'pytest>=7,<8' --with 'mock>=5,<6' --with 'pytest-asyncio>=0.23.0,<0.24' --with 'wikipedia>=1.4.0,<2' pytest test/toolkits/test_search_functions.py -k perplexity`

cc @fengju0213

---
