### PR TITLE
[codex] Use API key decorator for Cohere reranker

### DIFF
--- a/camel/retrievers/cohere_rerank_retriever.py
+++ b/camel/retrievers/cohere_rerank_retriever.py
@@ -15,7 +15,7 @@ import os
 from typing import Any, Dict, List, Optional
 
 from camel.retrievers import BaseRetriever
-from camel.utils import dependencies_required
+from camel.utils import api_keys_required, dependencies_required
 
 DEFAULT_TOP_K_RESULTS = 1
 
@@ -34,6 +34,7 @@ class CohereRerankRetriever(BaseRetriever):
     """
 
     @dependencies_required('cohere')
+    @api_keys_required([("api_key", "COHERE_API_KEY")])
     def __init__(
         self,
         model_name: str = "rerank-multilingual-v2.0",
@@ -60,13 +61,7 @@ class CohereRerankRetriever(BaseRetriever):
         """
         import cohere
 
-        try:
-            self.api_key = api_key or os.environ["COHERE_API_KEY"]
-        except ValueError as e:
-            raise ValueError(
-                "Must pass in cohere api key or specify via COHERE_API_KEY"
-                " environment variable."
-            ) from e
+        self.api_key = api_key or os.environ["COHERE_API_KEY"]
 
         self.co = cohere.Client(self.api_key)
         self.model_name = model_name

--- a/test/retrievers/test_cohere_rerank_retriever.py
+++ b/test/retrievers/test_cohere_rerank_retriever.py
@@ -11,6 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+import os
 from unittest.mock import patch
 
 import pytest
@@ -18,14 +19,34 @@ import pytest
 from camel.retrievers import CohereRerankRetriever
 
 
-def test_initialization():
+@patch.dict(os.environ, {"COHERE_API_KEY": "test_key"})
+@patch('cohere.Client')
+def test_initialization(mock_client):
     retriever = CohereRerankRetriever()
     assert retriever.model_name == "rerank-multilingual-v2.0"
+    assert retriever.api_key == "test_key"
+    mock_client.assert_called_once_with("test_key")
+
+
+@patch('cohere.Client')
+def test_initialization_with_explicit_api_key(mock_client):
+    retriever = CohereRerankRetriever(api_key="explicit_key")
+    assert retriever.api_key == "explicit_key"
+    mock_client.assert_called_once_with("explicit_key")
+
+
+def test_initialization_without_api_key():
+    with patch.dict(os.environ, {}, clear=True):
+        with pytest.raises(
+            ValueError,
+            match="Missing or empty required API keys.*COHERE_API_KEY",
+        ):
+            CohereRerankRetriever()
 
 
 @pytest.fixture
 def cohere_rerank():
-    return CohereRerankRetriever()
+    return CohereRerankRetriever(api_key="test_key")
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

- Apply the shared `api_keys_required` decorator to `CohereRerankRetriever`.
- Remove the manual missing-key branch that attempted to catch `ValueError` even though `os.environ["COHERE_API_KEY"]` raises `KeyError`.
- Add focused tests for environment, explicit-key, and missing-key initialization paths.

## Related Issue

Addresses part of #1043.

## Testing

- `uv run --with 'pytest>=7,<8' --with 'cohere>=5.11.0,<6' pytest test/retrievers/test_cohere_rerank_retriever.py`
- `uv run --with 'ruff>=0.7,<0.8' ruff check camel/retrievers/cohere_rerank_retriever.py test/retrievers/test_cohere_rerank_retriever.py`

## Checklist

- [x] I have read and agree to the AI-Generated Code Policy in `CONTRIBUTING.md`.
- [x] I have linked this PR to an issue.
- [x] I have updated the tests accordingly.