### PR TITLE
Require confirmation for local subprocess execution

### DIFF
--- a/camel/interpreters/subprocess_interpreter.py
+++ b/camel/interpreters/subprocess_interpreter.py
@@ -295,7 +295,7 @@ class SubprocessInterpreter(BaseInterpreter):
                     f"The following {code_type} code will run on your "
                     f"computer: {code}"
                 ),
-                prompt="Running code? [Y/n]:",
+                prompt="Running code? [y/N]:",
                 declined_message=(
                     "Execution halted: User opted not to run the code. "
                     "This choice stops the current operation and any "
@@ -383,9 +383,9 @@ class SubprocessInterpreter(BaseInterpreter):
         logger.info(message)
         while True:
             choice = input(prompt).lower().strip()
-            if choice in ["y", "yes", "ye", ""]:
+            if choice in ["y", "yes", "ye"]:
                 return
-            if choice in ["no", "n"]:
+            if choice in ["no", "n", ""]:
                 raise InterpreterError(declined_message)
             print("Please enter 'y' or 'n'.")
 
@@ -448,21 +448,21 @@ class SubprocessInterpreter(BaseInterpreter):
         Raises:
             InterpreterError: If the command execution fails.
         """
-        try:
-            if self.require_confirm:
-                self._confirm_execution(
-                    message=(
-                        "The following shell command will run on your "
-                        f"computer: {command}"
-                    ),
-                    prompt="Running command? [Y/n]:",
-                    declined_message=(
-                        "Execution halted: User opted not to run the "
-                        "command. This choice stops the current operation "
-                        "and any further command execution."
-                    ),
-                )
+        if self.require_confirm:
+            self._confirm_execution(
+                message=(
+                    "The following shell command will run on your "
+                    f"computer: {command}"
+                ),
+                prompt="Running command? [y/N]:",
+                declined_message=(
+                    "Execution halted: User opted not to run the "
+                    "command. This choice stops the current operation "
+                    "and any further command execution."
+                ),
+            )
 
+        try:
             # Get current Python executable's environment
             env = os.environ.copy()
 

--- a/camel/interpreters/subprocess_interpreter.py
+++ b/camel/interpreters/subprocess_interpreter.py
@@ -35,11 +35,12 @@ class SubprocessInterpreter(BaseInterpreter):
     This class handles the execution of code in different scripting languages
     (currently Python and Bash) within a subprocess, capturing their
     stdout and stderr streams, and allowing user checking before executing code
-    strings.
+    strings or shell commands.
 
     Args:
         require_confirm (bool, optional): If True, prompt user before running
-            code strings for security. (default: :obj:`True`)
+            code strings or shell commands for security.
+            (default: :obj:`True`)
         print_stdout (bool, optional): If True, print the standard output of
             the executed code. (default: :obj:`False`)
         print_stderr (bool, optional): If True, print the standard error of the
@@ -288,24 +289,19 @@ class SubprocessInterpreter(BaseInterpreter):
         """
         code_type = self._check_code_type(code_type)
 
-        # Print code for security checking
         if self.require_confirm:
-            logger.info(
-                f"The following {code_type} code will run on your "
-                f"computer: {code}"
+            self._confirm_execution(
+                message=(
+                    f"The following {code_type} code will run on your "
+                    f"computer: {code}"
+                ),
+                prompt="Running code? [Y/n]:",
+                declined_message=(
+                    "Execution halted: User opted not to run the code. "
+                    "This choice stops the current operation and any "
+                    "further code execution."
+                ),
             )
-            while True:
-                choice = input("Running code? [Y/n]:").lower().strip()
-                if choice in ["y", "yes", "ye", ""]:
-                    break
-                elif choice in ["no", "n"]:
-                    raise InterpreterError(
-                        "Execution halted: User opted not to run the code. "
-                        "This choice stops the current operation and any "
-                        "further code execution."
-                    )
-                else:
-                    print("Please enter 'y' or 'n'.")
 
         temp_file_path = None
         temp_dir = None
@@ -380,6 +376,19 @@ class SubprocessInterpreter(BaseInterpreter):
             )
         return self._CODE_TYPE_MAPPING[code_type]
 
+    def _confirm_execution(
+        self, message: str, prompt: str, declined_message: str
+    ) -> None:
+        r"""Prompt the user before executing local subprocess work."""
+        logger.info(message)
+        while True:
+            choice = input(prompt).lower().strip()
+            if choice in ["y", "yes", "ye", ""]:
+                return
+            if choice in ["no", "n"]:
+                raise InterpreterError(declined_message)
+            print("Please enter 'y' or 'n'.")
+
     def supported_code_types(self) -> List[str]:
         r"""Provides supported code types by the interpreter."""
         return list(self._CODE_EXTENSION_MAPPING.keys())
@@ -440,6 +449,20 @@ class SubprocessInterpreter(BaseInterpreter):
             InterpreterError: If the command execution fails.
         """
         try:
+            if self.require_confirm:
+                self._confirm_execution(
+                    message=(
+                        "The following shell command will run on your "
+                        f"computer: {command}"
+                    ),
+                    prompt="Running command? [Y/n]:",
+                    declined_message=(
+                        "Execution halted: User opted not to run the "
+                        "command. This choice stops the current operation "
+                        "and any further command execution."
+                    ),
+                )
+
             # Get current Python executable's environment
             env = os.environ.copy()
 

--- a/camel/toolkits/code_execution.py
+++ b/camel/toolkits/code_execution.py
@@ -42,8 +42,9 @@ class CodeExecutionToolkit(BaseToolkit):
             by `eval()` without any security check. (default: :obj:`False`)
         import_white_list (Optional[List[str]]): A list of allowed imports.
             (default: :obj:`None`)
-        require_confirm (bool): Whether to require confirmation before
-            executing code. (default: :obj:`False`)
+        require_confirm (Optional[bool]): Whether to require confirmation
+            before executing code. If `None`, subprocess execution requires
+            confirmation by default. (default: :obj:`None`)
         timeout (Optional[float]): General timeout for toolkit operations.
             (default: :obj:`None`)
         microsandbox_config (Optional[dict]): Configuration for microsandbox
@@ -65,7 +66,7 @@ class CodeExecutionToolkit(BaseToolkit):
         verbose: bool = False,
         unsafe_mode: bool = False,
         import_white_list: Optional[List[str]] = None,
-        require_confirm: bool = False,
+        require_confirm: Optional[bool] = None,
         timeout: Optional[float] = None,
         # Microsandbox configuration dictionary
         microsandbox_config: Optional[dict] = None,
@@ -74,6 +75,11 @@ class CodeExecutionToolkit(BaseToolkit):
         self.verbose = verbose
         self.unsafe_mode = unsafe_mode
         self.import_white_list = import_white_list or list()
+        resolved_require_confirm = (
+            sandbox == "subprocess"
+            if require_confirm is None
+            else require_confirm
+        )
 
         # Type annotation for interpreter to allow all possible types
         self.interpreter: Union[
@@ -92,30 +98,32 @@ class CodeExecutionToolkit(BaseToolkit):
             )
         elif sandbox == "jupyter":
             self.interpreter = JupyterKernelInterpreter(
-                require_confirm=require_confirm,
+                require_confirm=resolved_require_confirm,
                 print_stdout=self.verbose,
                 print_stderr=self.verbose,
             )
         elif sandbox == "docker":
             self.interpreter = DockerInterpreter(
-                require_confirm=require_confirm,
+                require_confirm=resolved_require_confirm,
                 print_stdout=self.verbose,
                 print_stderr=self.verbose,
             )
         elif sandbox == "subprocess":
             self.interpreter = SubprocessInterpreter(
-                require_confirm=require_confirm,
+                require_confirm=resolved_require_confirm,
                 print_stdout=self.verbose,
                 print_stderr=self.verbose,
             )
         elif sandbox == "e2b":
-            self.interpreter = E2BInterpreter(require_confirm=require_confirm)
+            self.interpreter = E2BInterpreter(
+                require_confirm=resolved_require_confirm
+            )
         elif sandbox == "microsandbox":
             # Extract parameters with proper types for microsandbox
             config = microsandbox_config or {}
 
             self.interpreter = MicrosandboxInterpreter(
-                require_confirm=require_confirm,
+                require_confirm=resolved_require_confirm,
                 server_url=config.get("server_url"),
                 api_key=config.get("api_key"),
                 namespace=config.get("namespace", "default"),

--- a/docs/mintlify/reference/camel.interpreters.subprocess_interpreter.mdx
+++ b/docs/mintlify/reference/camel.interpreters.subprocess_interpreter.mdx
@@ -14,11 +14,11 @@ strings in a subprocess.
 This class handles the execution of code in different scripting languages
 (currently Python and Bash) within a subprocess, capturing their
 stdout and stderr streams, and allowing user checking before executing code
-strings.
+strings or shell commands.
 
 **Parameters:**
 
-- **require_confirm** (bool, optional): If True, prompt user before running code strings for security. (default: :obj:`True`)
+- **require_confirm** (bool, optional): If True, prompt user before running code strings or shell commands for security. (default: :obj:`True`)
 - **print_stdout** (bool, optional): If True, print the standard output of the executed code. (default: :obj:`False`)
 - **print_stderr** (bool, optional): If True, print the standard error of the executed code. (default: :obj:`True`)
 - **execution_timeout** (int, optional): Maximum time in seconds to wait for code execution to complete. (default: :obj:`60`)

--- a/docs/mintlify/reference/camel.toolkits.code_execution.mdx
+++ b/docs/mintlify/reference/camel.toolkits.code_execution.mdx
@@ -16,7 +16,7 @@ A toolkit for code execution.
 - **verbose** (bool): Whether to print the output of the code execution. (default: :obj:`False`)
 - **unsafe_mode** (bool): If `True`, the interpreter runs the code by `eval()` without any security check. (default: :obj:`False`)
 - **import_white_list** (Optional[List[str]]): A list of allowed imports. (default: :obj:`None`)
-- **require_confirm** (bool): Whether to require confirmation before executing code. (default: :obj:`False`)
+- **require_confirm** (Optional[bool]): Whether to require confirmation before executing code. If None, subprocess execution requires confirmation by default. (default: :obj:`None`)
 - **timeout** (Optional[float]): General timeout for toolkit operations. (default: :obj:`None`)
 - **microsandbox_config** (Optional[dict]): Configuration for microsandbox interpreter. Available keys: 'server_url', 'api_key', 'namespace', 'sandbox_name', 'timeout'. If None, uses default configuration. (default: :obj:`None`)
 
@@ -31,7 +31,7 @@ def __init__(
     verbose: bool = False,
     unsafe_mode: bool = False,
     import_white_list: Optional[List[str]] = None,
-    require_confirm: bool = False,
+    require_confirm: Optional[bool] = None,
     timeout: Optional[float] = None,
     microsandbox_config: Optional[dict] = None
 ):

--- a/test/interpreters/test_subprocess_interpreter.py
+++ b/test/interpreters/test_subprocess_interpreter.py
@@ -145,3 +145,19 @@ def test_require_confirm(subprocess_interpreter, monkeypatch):
     # No error should be raised when user inputs 'y'
     result = subprocess_interpreter.run(python_code, "python")
     assert "Hello\n" in result
+
+
+def test_execute_command_require_confirm(subprocess_interpreter, monkeypatch):
+    subprocess_interpreter.require_confirm = True
+
+    monkeypatch.setattr('builtins.input', lambda _: 'n')
+
+    with pytest.raises(InterpreterError) as exc_info:
+        subprocess_interpreter.execute_command("echo Hello")
+    assert "Execution halted" in str(exc_info.value)
+
+    monkeypatch.setattr('builtins.input', lambda _: 'y')
+
+    stdout, stderr = subprocess_interpreter.execute_command("echo Hello")
+    assert "Hello" in stdout
+    assert stderr == ""

--- a/test/interpreters/test_subprocess_interpreter.py
+++ b/test/interpreters/test_subprocess_interpreter.py
@@ -155,6 +155,7 @@ def test_execute_command_require_confirm(subprocess_interpreter, monkeypatch):
     with pytest.raises(InterpreterError) as exc_info:
         subprocess_interpreter.execute_command("echo Hello")
     assert "Execution halted" in str(exc_info.value)
+    assert "Error executing command" not in str(exc_info.value)
 
     monkeypatch.setattr('builtins.input', lambda _: 'y')
 

--- a/test/toolkits/test_code_execution.py
+++ b/test/toolkits/test_code_execution.py
@@ -210,6 +210,26 @@ def test_subprocess_default_confirmation_blocks_command(monkeypatch):
     assert "Execution halted" in str(exc_info.value)
 
 
+def test_subprocess_default_confirmation_blocks_empty_code(monkeypatch):
+    toolkit = CodeExecutionToolkit()
+    monkeypatch.setattr('builtins.input', lambda _: '')
+
+    with pytest.raises(InterpreterError) as exc_info:
+        toolkit.execute_code("print('blocked')")
+
+    assert "Execution halted" in str(exc_info.value)
+
+
+def test_subprocess_default_confirmation_blocks_empty_command(monkeypatch):
+    toolkit = CodeExecutionToolkit()
+    monkeypatch.setattr('builtins.input', lambda _: '')
+
+    with pytest.raises(InterpreterError) as exc_info:
+        toolkit.execute_command("echo blocked")
+
+    assert "Execution halted" in str(exc_info.value)
+
+
 def test_subprocess_confirmation_can_be_disabled():
     toolkit = CodeExecutionToolkit(sandbox="subprocess", require_confirm=False)
 

--- a/test/toolkits/test_code_execution.py
+++ b/test/toolkits/test_code_execution.py
@@ -16,6 +16,7 @@ import socket
 
 import pytest
 
+from camel.interpreters import InterpreterError, SubprocessInterpreter
 from camel.toolkits.code_execution import CodeExecutionToolkit
 from camel.utils import is_docker_running
 
@@ -39,7 +40,7 @@ def is_microsandbox_available(
 
 @pytest.fixture
 def code_execution_toolkit():
-    return CodeExecutionToolkit()
+    return CodeExecutionToolkit(require_confirm=False)
 
 
 @pytest.fixture
@@ -180,6 +181,40 @@ print(x[10])
 """
     result = subprocess_code_execution_toolkit.execute_code(code)
     assert "IndexError: list index out of range" in result
+
+
+def test_subprocess_requires_confirmation_by_default():
+    toolkit = CodeExecutionToolkit()
+
+    assert isinstance(toolkit.interpreter, SubprocessInterpreter)
+    assert toolkit.interpreter.require_confirm is True
+
+
+def test_subprocess_default_confirmation_blocks_code(monkeypatch):
+    toolkit = CodeExecutionToolkit()
+    monkeypatch.setattr('builtins.input', lambda _: 'n')
+
+    with pytest.raises(InterpreterError) as exc_info:
+        toolkit.execute_code("print('blocked')")
+
+    assert "Execution halted" in str(exc_info.value)
+
+
+def test_subprocess_default_confirmation_blocks_command(monkeypatch):
+    toolkit = CodeExecutionToolkit()
+    monkeypatch.setattr('builtins.input', lambda _: 'n')
+
+    with pytest.raises(InterpreterError) as exc_info:
+        toolkit.execute_command("echo blocked")
+
+    assert "Execution halted" in str(exc_info.value)
+
+
+def test_subprocess_confirmation_can_be_disabled():
+    toolkit = CodeExecutionToolkit(sandbox="subprocess", require_confirm=False)
+
+    assert isinstance(toolkit.interpreter, SubprocessInterpreter)
+    assert toolkit.interpreter.require_confirm is False
 
 
 def test_invalid_sandbox_type():


### PR DESCRIPTION
## Summary
- default CodeExecutionToolkit subprocess execution to require confirmation unless callers explicitly opt out
- reuse confirmation handling for SubprocessInterpreter code snippets and shell commands
- add regression coverage for default confirmation, opt-out behavior, and command confirmation

## Tests
- python3 -m py_compile camel/toolkits/code_execution.py camel/interpreters/subprocess_interpreter.py test/toolkits/test_code_execution.py test/interpreters/test_subprocess_interpreter.py
- uv run --extra dev python -m pytest test/toolkits/test_code_execution.py test/interpreters/test_subprocess_interpreter.py -q
- uv run --extra dev ruff check camel/toolkits/code_execution.py camel/interpreters/subprocess_interpreter.py test/toolkits/test_code_execution.py test/interpreters/test_subprocess_interpreter.py
- uv run --extra dev ruff format --check camel/toolkits/code_execution.py camel/interpreters/subprocess_interpreter.py test/toolkits/test_code_execution.py test/interpreters/test_subprocess_interpreter.py

Fixes #4037