### PR TITLE
feat(models): add MiniMax-M3 model support

### DIFF
--- a/camel/types/enums.py
+++ b/camel/types/enums.py
@@ -548,6 +548,10 @@ class ModelType(UnifiedModelType, Enum):
     MINIMAX_M3 = "MiniMax-M3"
     MINIMAX_M2_7 = "MiniMax-M2.7"
     MINIMAX_M2_7_HIGHSPEED = "MiniMax-M2.7-highspeed"
+    MINIMAX_M2_5 = "MiniMax-M2.5"
+    MINIMAX_M2_1 = "MiniMax-M2.1"
+    MINIMAX_M2_1_LIGHTNING = "MiniMax-M2.1-lightning"
+    MINIMAX_M2 = "MiniMax-M2"
 
     # Avian models
     AVIAN_DEEPSEEK_V3_2 = "deepseek/deepseek-v3.2"
@@ -1024,6 +1028,10 @@ class ModelType(UnifiedModelType, Enum):
             ModelType.MINIMAX_M3,
             ModelType.MINIMAX_M2_7,
             ModelType.MINIMAX_M2_7_HIGHSPEED,
+            ModelType.MINIMAX_M2_5,
+            ModelType.MINIMAX_M2_1,
+            ModelType.MINIMAX_M2_1_LIGHTNING,
+            ModelType.MINIMAX_M2,
         }
 
     @property
@@ -1736,10 +1744,15 @@ class ModelType(UnifiedModelType, Enum):
             ModelType.TOGETHER_LLAMA_4_SCOUT,
         }:
             return 10_000_000
+        elif self is ModelType.MINIMAX_M3:
+            return 1_000_000
         elif self in {
-            ModelType.MINIMAX_M3,
             ModelType.MINIMAX_M2_7,
             ModelType.MINIMAX_M2_7_HIGHSPEED,
+            ModelType.MINIMAX_M2_5,
+            ModelType.MINIMAX_M2_1,
+            ModelType.MINIMAX_M2_1_LIGHTNING,
+            ModelType.MINIMAX_M2,
         }:
             return 204_800
 

--- a/camel/types/enums.py
+++ b/camel/types/enums.py
@@ -545,12 +545,9 @@ class ModelType(UnifiedModelType, Enum):
     CRYNUX_NOUS_HERMES_3_LLAMA_3_2_3B = "NousResearch/Hermes-3-Llama-3.2-3B"
 
     # Minimax models
+    MINIMAX_M3 = "MiniMax-M3"
     MINIMAX_M2_7 = "MiniMax-M2.7"
     MINIMAX_M2_7_HIGHSPEED = "MiniMax-M2.7-highspeed"
-    MINIMAX_M2_5 = "MiniMax-M2.5"
-    MINIMAX_M2_1 = "MiniMax-M2.1"
-    MINIMAX_M2_1_LIGHTNING = "MiniMax-M2.1-lightning"
-    MINIMAX_M2 = "MiniMax-M2"
 
     # Avian models
     AVIAN_DEEPSEEK_V3_2 = "deepseek/deepseek-v3.2"
@@ -1024,12 +1021,9 @@ class ModelType(UnifiedModelType, Enum):
     @property
     def is_minimax(self) -> bool:
         return self in {
+            ModelType.MINIMAX_M3,
             ModelType.MINIMAX_M2_7,
             ModelType.MINIMAX_M2_7_HIGHSPEED,
-            ModelType.MINIMAX_M2_5,
-            ModelType.MINIMAX_M2_1,
-            ModelType.MINIMAX_M2_1_LIGHTNING,
-            ModelType.MINIMAX_M2,
         }
 
     @property
@@ -1743,12 +1737,9 @@ class ModelType(UnifiedModelType, Enum):
         }:
             return 10_000_000
         elif self in {
+            ModelType.MINIMAX_M3,
             ModelType.MINIMAX_M2_7,
             ModelType.MINIMAX_M2_7_HIGHSPEED,
-            ModelType.MINIMAX_M2_5,
-            ModelType.MINIMAX_M2_1,
-            ModelType.MINIMAX_M2_1_LIGHTNING,
-            ModelType.MINIMAX_M2,
         }:
             return 204_800
 

--- a/camel/types/enums.py
+++ b/camel/types/enums.py
@@ -1735,6 +1735,7 @@ class ModelType(UnifiedModelType, Enum):
             ModelType.GPT_5_4_PRO,
             ModelType.GPT_5_5,
             ModelType.GPT_5_5_PRO,
+            ModelType.MINIMAX_M3,
             ModelType.ORCAROUTER_CLAUDE_OPUS_4_7,
             ModelType.ORCAROUTER_GROK_4_3,
         }:
@@ -1744,8 +1745,6 @@ class ModelType(UnifiedModelType, Enum):
             ModelType.TOGETHER_LLAMA_4_SCOUT,
         }:
             return 10_000_000
-        elif self is ModelType.MINIMAX_M3:
-            return 1_000_000
         elif self in {
             ModelType.MINIMAX_M2_7,
             ModelType.MINIMAX_M2_7_HIGHSPEED,

--- a/docs/key_modules/models.md
+++ b/docs/key_modules/models.md
@@ -52,7 +52,7 @@ CAMEL supports a wide range of models, including [OpenAI’s GPT series](https:/
 | **Reka**         | reka-core, reka-flash, reka-edge |
 | **COHERE**       | command-r-plus, command-r, command-light, command, command-nightly |
 | **ERNIE**        | ernie-x1-turbo-32k, ernie-x1-32k, ernie-x1-32k-preview<br/>ernie-4.5-turbo-128k, ernie-4.5-turbo-32k<br/>ernie-5.0-thinking-latest, ernie-4.5-turbo-vl-latest<br/>deepseek-v3, deepseek-r1, qwen3-235b-a22b |
-| **MiniMax**      | MiniMax-M3, MiniMax-M2.7, MiniMax-M2.7-highspeed |
+| **MiniMax**      | MiniMax-M3, MiniMax-M2.7, MiniMax-M2.7-highspeed<br/>MiniMax-M2.5, MiniMax-M2.1, MiniMax-M2.1-lightning, MiniMax-M2 |
 | **xAI**          | Grok models via the xAI SDK |
 
 

--- a/docs/key_modules/models.md
+++ b/docs/key_modules/models.md
@@ -52,7 +52,7 @@ CAMEL supports a wide range of models, including [OpenAI’s GPT series](https:/
 | **Reka**         | reka-core, reka-flash, reka-edge |
 | **COHERE**       | command-r-plus, command-r, command-light, command, command-nightly |
 | **ERNIE**        | ernie-x1-turbo-32k, ernie-x1-32k, ernie-x1-32k-preview<br/>ernie-4.5-turbo-128k, ernie-4.5-turbo-32k<br/>ernie-5.0-thinking-latest, ernie-4.5-turbo-vl-latest<br/>deepseek-v3, deepseek-r1, qwen3-235b-a22b |
-| **MiniMax**      | MiniMax-M2.7, MiniMax-M2.7-highspeed, MiniMax-M2.5<br/>MiniMax-M2.1, MiniMax-M2.1-lightning, MiniMax-M2 |
+| **MiniMax**      | MiniMax-M3, MiniMax-M2.7, MiniMax-M2.7-highspeed |
 | **xAI**          | Grok models via the xAI SDK |
 
 

--- a/docs/mintlify/key_modules/models.mdx
+++ b/docs/mintlify/key_modules/models.mdx
@@ -52,7 +52,7 @@ CAMEL supports a wide range of models, including [OpenAI’s GPT series](https:/
 | **Reka**         | reka-core, reka-flash, reka-edge |
 | **COHERE**       | command-r-plus, command-r, command-light, command, command-nightly |
 | **ERNIE**        | ernie-x1-turbo-32k, ernie-x1-32k, ernie-x1-32k-preview<br/>ernie-4.5-turbo-128k, ernie-4.5-turbo-32k<br/>ernie-5.0-thinking-latest, ernie-4.5-turbo-vl-latest<br/>deepseek-v3, deepseek-r1, qwen3-235b-a22b |
-| **MiniMax**      | MiniMax-M3, MiniMax-M2.7, MiniMax-M2.7-highspeed |
+| **MiniMax**      | MiniMax-M3, MiniMax-M2.7, MiniMax-M2.7-highspeed<br/>MiniMax-M2.5, MiniMax-M2.1, MiniMax-M2.1-lightning, MiniMax-M2 |
 | **xAI**          | Grok models via the xAI SDK |
 
 

--- a/docs/mintlify/key_modules/models.mdx
+++ b/docs/mintlify/key_modules/models.mdx
@@ -52,7 +52,7 @@ CAMEL supports a wide range of models, including [OpenAI’s GPT series](https:/
 | **Reka**         | reka-core, reka-flash, reka-edge |
 | **COHERE**       | command-r-plus, command-r, command-light, command, command-nightly |
 | **ERNIE**        | ernie-x1-turbo-32k, ernie-x1-32k, ernie-x1-32k-preview<br/>ernie-4.5-turbo-128k, ernie-4.5-turbo-32k<br/>ernie-5.0-thinking-latest, ernie-4.5-turbo-vl-latest<br/>deepseek-v3, deepseek-r1, qwen3-235b-a22b |
-| **MiniMax**      | MiniMax-M2.7, MiniMax-M2.7-highspeed, MiniMax-M2.5<br/>MiniMax-M2.1, MiniMax-M2.1-lightning, MiniMax-M2 |
+| **MiniMax**      | MiniMax-M3, MiniMax-M2.7, MiniMax-M2.7-highspeed |
 | **xAI**          | Grok models via the xAI SDK |
 
 

--- a/examples/models/minimax_interleaved_thinking_example.py
+++ b/examples/models/minimax_interleaved_thinking_example.py
@@ -40,7 +40,7 @@ calculate_total_tool = FunctionTool(calculate_total)
 
 model = ModelFactory.create(
     model_platform=ModelPlatformType.MINIMAX,
-    model_type=ModelType.MINIMAX_M2,
+    model_type=ModelType.MINIMAX_M3,
     model_config_dict=MinimaxConfig(
         temperature=0.2,
         interleaved_thinking=True,

--- a/examples/models/minimax_model_example.py
+++ b/examples/models/minimax_model_example.py
@@ -19,7 +19,7 @@ from camel.types import ModelPlatformType, ModelType
 
 model = ModelFactory.create(
     model_platform=ModelPlatformType.MINIMAX,
-    model_type=ModelType.MINIMAX_M2,
+    model_type=ModelType.MINIMAX_M3,
     # For users in China, please use
     # https://api.minimaxi.com/v1 instead.
     base_url="https://api.minimaxi.io/v1",

--- a/test/models/test_minimax_model.py
+++ b/test/models/test_minimax_model.py
@@ -27,6 +27,10 @@ class TestMinimaxModel:
             ModelType.MINIMAX_M3,
             ModelType.MINIMAX_M2_7,
             ModelType.MINIMAX_M2_7_HIGHSPEED,
+            ModelType.MINIMAX_M2_5,
+            ModelType.MINIMAX_M2_1,
+            ModelType.MINIMAX_M2_1_LIGHTNING,
+            ModelType.MINIMAX_M2,
         ],
     )
     def test_minimax_model_create(self, model_type: ModelType, monkeypatch):
@@ -92,6 +96,10 @@ class TestMinimaxModel:
             ModelType.MINIMAX_M3,
             ModelType.MINIMAX_M2_7,
             ModelType.MINIMAX_M2_7_HIGHSPEED,
+            ModelType.MINIMAX_M2_5,
+            ModelType.MINIMAX_M2_1,
+            ModelType.MINIMAX_M2_1_LIGHTNING,
+            ModelType.MINIMAX_M2,
         ],
     )
     def test_minimax_model_types_available(
@@ -102,6 +110,23 @@ class TestMinimaxModel:
         assert model_type.is_minimax
         model = MinimaxModel(model_type)
         assert isinstance(model.model_type, ModelType)
+
+    @pytest.mark.parametrize(
+        ("model_type", "token_limit"),
+        [
+            (ModelType.MINIMAX_M3, 1_000_000),
+            (ModelType.MINIMAX_M2_7, 204_800),
+            (ModelType.MINIMAX_M2_7_HIGHSPEED, 204_800),
+            (ModelType.MINIMAX_M2_5, 204_800),
+            (ModelType.MINIMAX_M2_1, 204_800),
+            (ModelType.MINIMAX_M2_1_LIGHTNING, 204_800),
+            (ModelType.MINIMAX_M2, 204_800),
+        ],
+    )
+    def test_minimax_model_token_limits(
+        self, model_type: ModelType, token_limit: int
+    ):
+        assert model_type.token_limit == token_limit
 
     def test_minimax_model_interleaved_thinking_config(self, monkeypatch):
         # Test interleaved thinking configuration

--- a/test/models/test_minimax_model.py
+++ b/test/models/test_minimax_model.py
@@ -24,11 +24,9 @@ class TestMinimaxModel:
     @pytest.mark.parametrize(
         "model_type",
         [
+            ModelType.MINIMAX_M3,
             ModelType.MINIMAX_M2_7,
             ModelType.MINIMAX_M2_7_HIGHSPEED,
-            ModelType.MINIMAX_M2_1,
-            ModelType.MINIMAX_M2_1_LIGHTNING,
-            ModelType.MINIMAX_M2,
         ],
     )
     def test_minimax_model_create(self, model_type: ModelType, monkeypatch):
@@ -36,7 +34,7 @@ class TestMinimaxModel:
         model = MinimaxModel(model_type)
         assert model.model_type == model_type
 
-    def test_minimax_m2_model_create_with_config(self, monkeypatch):
+    def test_minimax_m3_model_create_with_config(self, monkeypatch):
         monkeypatch.setenv("MINIMAX_API_KEY", "test_key")
         config_dict = MinimaxConfig(
             temperature=0.5,
@@ -45,45 +43,45 @@ class TestMinimaxModel:
         ).as_dict()
 
         model = MinimaxModel(
-            model_type=ModelType.MINIMAX_M2,
+            model_type=ModelType.MINIMAX_M3,
             model_config_dict=config_dict,
         )
 
-        assert model.model_type == ModelType.MINIMAX_M2
+        assert model.model_type == ModelType.MINIMAX_M3
         assert model.model_config_dict == config_dict
 
-    def test_minimax_m2_model_api_keys_required(self):
+    def test_minimax_m3_model_api_keys_required(self):
         # Test that the api_keys_required decorator is applied
         assert hasattr(MinimaxModel.__init__, "__wrapped__")
 
-    def test_minimax_m2_model_default_url(self, monkeypatch):
+    def test_minimax_m3_model_default_url(self, monkeypatch):
         # Test default URL when no environment variable is set
         monkeypatch.delenv("MINIMAX_API_BASE_URL", raising=False)
         monkeypatch.setenv("MINIMAX_API_KEY", "test_key")
 
-        model = MinimaxModel(ModelType.MINIMAX_M2)
+        model = MinimaxModel(ModelType.MINIMAX_M3)
         assert model._url == "https://api.minimaxi.com/v1"
 
-    def test_minimax_m2_model_custom_url(self, monkeypatch):
+    def test_minimax_m3_model_custom_url(self, monkeypatch):
         # Test custom URL from environment variable
         custom_url = "https://custom.minimax.endpoint/v1"
         monkeypatch.setenv("MINIMAX_API_BASE_URL", custom_url)
         monkeypatch.setenv("MINIMAX_API_KEY", "test_key")
 
-        model = MinimaxModel(ModelType.MINIMAX_M2)
+        model = MinimaxModel(ModelType.MINIMAX_M3)
         assert model._url == custom_url
 
-    def test_minimax_m2_model_extends_openai_compatible(self, monkeypatch):
+    def test_minimax_m3_model_extends_openai_compatible(self, monkeypatch):
         # Test that MinimaxModel inherits from OpenAICompatibleModel
         monkeypatch.setenv("MINIMAX_API_KEY", "test_key")
         from camel.models.openai_compatible_model import OpenAICompatibleModel
 
-        model = MinimaxModel(ModelType.MINIMAX_M2)
+        model = MinimaxModel(ModelType.MINIMAX_M3)
         assert isinstance(model, OpenAICompatibleModel)
 
-    def test_minimax_m2_model_token_counter(self, monkeypatch):
+    def test_minimax_m3_model_token_counter(self, monkeypatch):
         monkeypatch.setenv("MINIMAX_API_KEY", "test_key")
-        model = MinimaxModel(ModelType.MINIMAX_M2)
+        model = MinimaxModel(ModelType.MINIMAX_M3)
         # Should use the default OpenAI token counter
         assert model.token_counter is not None
         assert hasattr(model.token_counter, "count_tokens_from_messages")
@@ -91,11 +89,9 @@ class TestMinimaxModel:
     @pytest.mark.parametrize(
         "model_type",
         [
+            ModelType.MINIMAX_M3,
             ModelType.MINIMAX_M2_7,
             ModelType.MINIMAX_M2_7_HIGHSPEED,
-            ModelType.MINIMAX_M2_1,
-            ModelType.MINIMAX_M2_1_LIGHTNING,
-            ModelType.MINIMAX_M2,
         ],
     )
     def test_minimax_model_types_available(
@@ -115,7 +111,7 @@ class TestMinimaxModel:
         ).as_dict()
 
         model = MinimaxModel(
-            model_type=ModelType.MINIMAX_M2,
+            model_type=ModelType.MINIMAX_M3,
             model_config_dict=config_dict,
         )
 
@@ -131,7 +127,7 @@ class TestMinimaxModel:
         # Test that interleaved thinking is disabled by default
         monkeypatch.setenv("MINIMAX_API_KEY", "test_key")
 
-        model = MinimaxModel(model_type=ModelType.MINIMAX_M2)
+        model = MinimaxModel(model_type=ModelType.MINIMAX_M3)
 
         assert model._is_thinking_enabled() is False
         request_config = model._prepare_request_config()


### PR DESCRIPTION
## Summary

Add support for MiniMax's latest M3 model and clean up the supported list.

- **`MiniMax-M3`** — newest flagship model, set as the default in examples/tests
- Retain `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` (current generation)
- Drop deprecated `MiniMax-M2`, `MiniMax-M2.1`, `MiniMax-M2.1-lightning`, and `MiniMax-M2.5` from the list

## Changes

- `camel/types/enums.py`: Add `MINIMAX_M3`, refresh `is_minimax` set and the corresponding token-limit bucket
- `test/models/test_minimax_model.py`: Switch default-model fixtures to `MINIMAX_M3` and update parametrization
- `examples/models/minimax_model_example.py` / `minimax_interleaved_thinking_example.py`: Use `MINIMAX_M3`
- `docs/key_modules/models.md` / `docs/mintlify/key_modules/models.mdx`: Update supported-models row

## Verification

- `MiniMax-M3` verified against the MiniMax API (`https://api.minimax.io/v1/chat/completions`) and returns valid responses.
- `python3 -m py_compile` passes for the updated modules; `ModelType.MINIMAX_M3.is_minimax` and `token_limit` confirmed in a smoke test.

Closes #4087