### PR TITLE
docs: standardize docstring format for camel/extractors

### DIFF
--- a/camel/extractors/__init__.py
+++ b/camel/extractors/__init__.py
@@ -11,6 +11,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+
+r"""Extraction strategies and base classes for processing LLM responses.
+
+This module provides a flexible framework for extracting structured
+content from LLM responses using configurable strategy pipelines.
+"""
+
 from .base import BaseExtractor, BaseExtractorStrategy
 from .python_strategies import (
     BoxedStrategy,
@@ -24,8 +31,8 @@ __all__ = [
     "BaseExtractor",
     "BaseExtractorStrategy",
     "BoxedStrategy",
-    "PythonListStrategy",
     "PythonDictStrategy",
+    "PythonListStrategy",
     "PythonSetStrategy",
     "PythonTupleStrategy",
 ]

--- a/camel/extractors/base.py
+++ b/camel/extractors/base.py
@@ -12,6 +12,12 @@
 # limitations under the License.
 # ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
 
+r"""Base classes for the extraction framework.
+
+This module defines the abstract base strategy and the main extractor
+that orchestrates a multi-stage pipeline for processing LLM responses.
+"""
+
 import asyncio
 from abc import ABC, abstractmethod
 from types import TracebackType
@@ -84,7 +90,6 @@ class BaseExtractor:
                 scaling down. (default: :obj:`85.0`)
             **kwargs: Additional extractor parameters.
         """
-
         self._metadata = {
             'cache_templates': cache_templates,
             'max_cache_size': max_cache_size,
@@ -226,8 +231,10 @@ class BaseExtractor:
         await self.cleanup()
 
     async def extract(self, response: str) -> Optional[str]:
-        r"""Extracts a normalized, comparable part of the LLM response
-        using the fixed multi-stage strategy pipeline.
+        r"""Extract a normalized, comparable part of an LLM response.
+
+        This method uses the fixed multi-stage strategy pipeline to
+        extract and normalize content from the raw response text.
 
         Args:
             response (str): The raw response text.

--- a/camel/extractors/python_strategies.py
+++ b/camel/extractors/python_strategies.py
@@ -12,6 +12,13 @@
 # limitations under the License.
 # ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
 
+r"""Extraction strategies for Python literal structures.
+
+This module provides strategies for extracting and normalizing Python
+data structures such as lists, dicts, sets, tuples, and boxed content
+from LLM responses.
+"""
+
 import ast
 from typing import Optional
 
@@ -102,7 +109,6 @@ class PythonListStrategy(BaseExtractorStrategy):
         Returns:
             Optional[str]: Normalized list as a string if found, else None.
         """
-
         text = text.strip()
         if not (text.startswith('[') and text.endswith(']')):
             logger.debug("Content is not a list format (missing brackets)")
@@ -136,7 +142,6 @@ class PythonDictStrategy(BaseExtractorStrategy):
         Returns:
             Optional[str]: Normalized dictionary as a string, else None.
         """
-
         text = text.strip()
         if not (text.startswith('{') and text.endswith('}')):
             logger.debug("Content is not a dictionary format (missing braces)")
@@ -174,7 +179,6 @@ class PythonSetStrategy(BaseExtractorStrategy):
         Returns:
             Optional[str]: Normalized set as a string if found, else None.
         """
-
         text = text.strip()
         # Check for set syntax: {1, 2, 3} or set([1, 2, 3])
         if not (
@@ -212,7 +216,6 @@ class PythonTupleStrategy(BaseExtractorStrategy):
         Returns:
             Optional[str]: Normalized tuple as a string if found, else None.
         """
-
         text = text.strip()
         # Check for tuple syntax: (1, 2, 3) or (1,)
         if not (text.startswith('(') and text.endswith(')')):


### PR DESCRIPTION
## Summary
- Standardize docstrings in `camel/extractors/` to match Google-style convention
- Add module-level docstrings to all three files
- Fix D205 (blank line between summary and extended description) in the `BaseExtractor.extract` method
- Alphabetize `__all__` list in `__init__.py`
- Remove extraneous blank lines after docstrings
- Part of #911 docstring unification effort

Fixes #911

## Test Plan
- [x] `ruff check camel/extractors/ --select D` passes with no docstring warnings
- [x] No functional changes — documentation only