### PR TITLE
feat(models): clean up legacy MiniMax models, keep only M3 / M2.7 / M2.7-highspeed

### DIFF
--- a/camel/types/enums.py
+++ b/camel/types/enums.py
@@ -548,10 +548,6 @@ class ModelType(UnifiedModelType, Enum):
     MINIMAX_M3 = "MiniMax-M3"
     MINIMAX_M2_7 = "MiniMax-M2.7"
     MINIMAX_M2_7_HIGHSPEED = "MiniMax-M2.7-highspeed"
-    MINIMAX_M2_5 = "MiniMax-M2.5"
-    MINIMAX_M2_1 = "MiniMax-M2.1"
-    MINIMAX_M2_1_LIGHTNING = "MiniMax-M2.1-lightning"
-    MINIMAX_M2 = "MiniMax-M2"
 
     # Avian models
     AVIAN_DEEPSEEK_V3_2 = "deepseek/deepseek-v3.2"
@@ -1028,10 +1024,6 @@ class ModelType(UnifiedModelType, Enum):
             ModelType.MINIMAX_M3,
             ModelType.MINIMAX_M2_7,
             ModelType.MINIMAX_M2_7_HIGHSPEED,
-            ModelType.MINIMAX_M2_5,
-            ModelType.MINIMAX_M2_1,
-            ModelType.MINIMAX_M2_1_LIGHTNING,
-            ModelType.MINIMAX_M2,
         }
 
     @property
@@ -1748,10 +1740,6 @@ class ModelType(UnifiedModelType, Enum):
         elif self in {
             ModelType.MINIMAX_M2_7,
             ModelType.MINIMAX_M2_7_HIGHSPEED,
-            ModelType.MINIMAX_M2_5,
-            ModelType.MINIMAX_M2_1,
-            ModelType.MINIMAX_M2_1_LIGHTNING,
-            ModelType.MINIMAX_M2,
         }:
             return 204_800
 

--- a/docs/key_modules/models.md
+++ b/docs/key_modules/models.md
@@ -52,7 +52,7 @@ CAMEL supports a wide range of models, including [OpenAI’s GPT series](https:/
 | **Reka**         | reka-core, reka-flash, reka-edge |
 | **COHERE**       | command-r-plus, command-r, command-light, command, command-nightly |
 | **ERNIE**        | ernie-x1-turbo-32k, ernie-x1-32k, ernie-x1-32k-preview<br/>ernie-4.5-turbo-128k, ernie-4.5-turbo-32k<br/>ernie-5.0-thinking-latest, ernie-4.5-turbo-vl-latest<br/>deepseek-v3, deepseek-r1, qwen3-235b-a22b |
-| **MiniMax**      | MiniMax-M3, MiniMax-M2.7, MiniMax-M2.7-highspeed<br/>MiniMax-M2.5, MiniMax-M2.1, MiniMax-M2.1-lightning, MiniMax-M2 |
+| **MiniMax**      | MiniMax-M3, MiniMax-M2.7, MiniMax-M2.7-highspeed |
 | **xAI**          | Grok models via the xAI SDK |
 
 

--- a/docs/mintlify/key_modules/models.mdx
+++ b/docs/mintlify/key_modules/models.mdx
@@ -52,7 +52,7 @@ CAMEL supports a wide range of models, including [OpenAI’s GPT series](https:/
 | **Reka**         | reka-core, reka-flash, reka-edge |
 | **COHERE**       | command-r-plus, command-r, command-light, command, command-nightly |
 | **ERNIE**        | ernie-x1-turbo-32k, ernie-x1-32k, ernie-x1-32k-preview<br/>ernie-4.5-turbo-128k, ernie-4.5-turbo-32k<br/>ernie-5.0-thinking-latest, ernie-4.5-turbo-vl-latest<br/>deepseek-v3, deepseek-r1, qwen3-235b-a22b |
-| **MiniMax**      | MiniMax-M3, MiniMax-M2.7, MiniMax-M2.7-highspeed<br/>MiniMax-M2.5, MiniMax-M2.1, MiniMax-M2.1-lightning, MiniMax-M2 |
+| **MiniMax**      | MiniMax-M3, MiniMax-M2.7, MiniMax-M2.7-highspeed |
 | **xAI**          | Grok models via the xAI SDK |
 
 

--- a/test/models/test_minimax_model.py
+++ b/test/models/test_minimax_model.py
@@ -27,10 +27,6 @@ class TestMinimaxModel:
             ModelType.MINIMAX_M3,
             ModelType.MINIMAX_M2_7,
             ModelType.MINIMAX_M2_7_HIGHSPEED,
-            ModelType.MINIMAX_M2_5,
-            ModelType.MINIMAX_M2_1,
-            ModelType.MINIMAX_M2_1_LIGHTNING,
-            ModelType.MINIMAX_M2,
         ],
     )
     def test_minimax_model_create(self, model_type: ModelType, monkeypatch):
@@ -96,10 +92,6 @@ class TestMinimaxModel:
             ModelType.MINIMAX_M3,
             ModelType.MINIMAX_M2_7,
             ModelType.MINIMAX_M2_7_HIGHSPEED,
-            ModelType.MINIMAX_M2_5,
-            ModelType.MINIMAX_M2_1,
-            ModelType.MINIMAX_M2_1_LIGHTNING,
-            ModelType.MINIMAX_M2,
         ],
     )
     def test_minimax_model_types_available(
@@ -117,10 +109,6 @@ class TestMinimaxModel:
             (ModelType.MINIMAX_M3, 1_000_000),
             (ModelType.MINIMAX_M2_7, 204_800),
             (ModelType.MINIMAX_M2_7_HIGHSPEED, 204_800),
-            (ModelType.MINIMAX_M2_5, 204_800),
-            (ModelType.MINIMAX_M2_1, 204_800),
-            (ModelType.MINIMAX_M2_1_LIGHTNING, 204_800),
-            (ModelType.MINIMAX_M2, 204_800),
         ],
     )
     def test_minimax_model_token_limits(


### PR DESCRIPTION
## Summary

Complete the MiniMax M3 upgrade by removing the legacy model entries that the prior M3 PR (#4088) was meant to drop but did not.

- `MiniMax-M3` is the default and only newly added model (already shipped in #4088)
- `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` are retained
- `MiniMax-M2.5`, `MiniMax-M2.1`, `MiniMax-M2.1-lightning`, and `MiniMax-M2` are now removed from the model list

## Changes

- `camel/types/enums.py`: Drop `MINIMAX_M2_5`, `MINIMAX_M2_1`, `MINIMAX_M2_1_LIGHTNING`, `MINIMAX_M2` from the `ModelType` enum, the `is_minimax` set, and the 204_800 token-limit bucket
- `test/models/test_minimax_model.py`: Update parametrized cases and token-limit table to cover only `MINIMAX_M3`, `MINIMAX_M2_7`, `MINIMAX_M2_7_HIGHSPEED`
- `docs/key_modules/models.md` and `docs/mintlify/key_modules/models.mdx`: Refresh the supported-models row to match the pruned list

## Why

PR #4088 added `MiniMax-M3` as default but left the deprecated `M2`/`M2.1`/`M2.1-lightning`/`M2.5` entries in the enum, the `is_minimax` set, and the tests. This PR finishes the cleanup so the supported list contains only the three current-generation models.

## Testing

- Smoke-tested: `ModelType.MINIMAX_M3.is_minimax == True`, `ModelType.MINIMAX_M2_7.is_minimax == True`, `ModelType.MINIMAX_M2_7_HIGHSPEED.is_minimax == True`
- Verified `MINIMAX_M2_5`, `MINIMAX_M2_1`, `MINIMAX_M2_1_LIGHTNING`, `MINIMAX_M2` are no longer accessible on `ModelType`
- Token limits: `MINIMAX_M3` = 1_000_000; `MINIMAX_M2_7` / `MINIMAX_M2_7_HIGHSPEED` = 204_800
- `python3 -m py_compile` passes for the updated modules
- Avian's `AVIAN_MINIMAX_M2_5` is intentionally untouched (different provider)