### PR TITLE
docs: add firecrawl.dev link to Firecrawl reader docs

### DIFF
--- a/camel/loaders/firecrawl_reader.py
+++ b/camel/loaders/firecrawl_reader.py
@@ -19,7 +19,7 @@ from pydantic import BaseModel
 
 
 class Firecrawl:
-    r"""Firecrawl allows you to turn entire websites into LLM-ready markdown.
+    r"""[Firecrawl](https://www.firecrawl.dev) allows you to turn entire websites into LLM-ready markdown.
 
     Args:
         api_key (Optional[str]): API key for authenticating with the Firecrawl

--- a/camel/loaders/firecrawl_reader.py
+++ b/camel/loaders/firecrawl_reader.py
@@ -19,7 +19,8 @@ from pydantic import BaseModel
 
 
 class Firecrawl:
-    r"""[Firecrawl](https://www.firecrawl.dev) allows you to turn entire websites into LLM-ready markdown.
+    r"""[Firecrawl](https://www.firecrawl.dev) allows you to turn entire
+    websites into LLM-ready markdown.
 
     Args:
         api_key (Optional[str]): API key for authenticating with the Firecrawl

--- a/docs/mintlify/key_modules/loaders.mdx
+++ b/docs/mintlify/key_modules/loaders.mdx
@@ -45,7 +45,7 @@ doc_code_map:
 
 {" "}
 <Accordion title="Firecrawl Reader" icon="fire">
-  Converts entire websites into LLM-ready markdown using the Firecrawl API.<br></br>
+  Converts entire websites into LLM-ready markdown using the [Firecrawl](https://www.firecrawl.dev) API.<br></br>
   Useful for quickly ingesting web content as clean text.
 </Accordion>
 

--- a/docs/mintlify/reference/camel.loaders.firecrawl_reader.mdx
+++ b/docs/mintlify/reference/camel.loaders.firecrawl_reader.mdx
@@ -8,7 +8,7 @@
 class Firecrawl:
 ```
 
-Firecrawl allows you to turn entire websites into LLM-ready markdown.
+[Firecrawl](https://www.firecrawl.dev) allows you to turn entire websites into LLM-ready markdown.
 
 **Parameters:**
 


### PR DESCRIPTION
Adds a hyperlink to https://www.firecrawl.dev where the Firecrawl reader is described. Previously these pages mentioned "Firecrawl" only as plain text.

Changes:
- `docs/mintlify/key_modules/loaders.mdx` — link the "Firecrawl" mention in the Firecrawl Reader accordion.
- `docs/mintlify/reference/camel.loaders.firecrawl_reader.mdx` — link the "Firecrawl" mention in the class summary.
- `camel/loaders/firecrawl_reader.py` — same edit in the `Firecrawl` class docstring (the source the reference page is generated from), so the link survives the next docs regeneration.

No behavior changes — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)