### PR TITLE
feat: add Claude Fable 5 support

### DIFF
--- a/camel/types/enums.py
+++ b/camel/types/enums.py
@@ -235,6 +235,7 @@ class ModelType(UnifiedModelType, Enum):
     CLAUDE_SONNET_4 = "claude-sonnet-4-20250514"
     CLAUDE_SONNET_4_6 = "claude-sonnet-4-6"
     CLAUDE_HAIKU_4_5 = "claude-haiku-4-5"
+    CLAUDE_FABLE_5 = "claude-fable-5"
     CLAUDE_OPUS_4 = "claude-opus-4-20250514"
     CLAUDE_OPUS_4_1 = "claude-opus-4-1-20250805"
     CLAUDE_OPUS_4_5 = "claude-opus-4-5"
@@ -756,6 +757,7 @@ class ModelType(UnifiedModelType, Enum):
             ModelType.CLAUDE_SONNET_4_6,
             ModelType.CLAUDE_SONNET_4,
             ModelType.CLAUDE_HAIKU_4_5,
+            ModelType.CLAUDE_FABLE_5,
             ModelType.CLAUDE_OPUS_4,
             ModelType.CLAUDE_OPUS_4_1,
             ModelType.CLAUDE_OPUS_4_5,
@@ -1729,6 +1731,7 @@ class ModelType(UnifiedModelType, Enum):
             ModelType.CLAUDE_SONNET_4_6,
             ModelType.CLAUDE_OPUS_4_7,
             ModelType.CLAUDE_OPUS_4_8,
+            ModelType.CLAUDE_FABLE_5,
             ModelType.DEEPSEEK_V4_FLASH,
             ModelType.DEEPSEEK_V4_PRO,
             ModelType.GPT_5_4,

--- a/test/models/test_anthropic_model.py
+++ b/test/models/test_anthropic_model.py
@@ -44,6 +44,7 @@ class TravelResponse(BaseModel):
         ModelType.CLAUDE_OPUS_4_6,
         ModelType.CLAUDE_OPUS_4_8,
         ModelType.CLAUDE_HAIKU_4_5,
+        ModelType.CLAUDE_FABLE_5,
         ModelType.CLAUDE_SONNET_4,
         ModelType.CLAUDE_OPUS_4,
         ModelType.CLAUDE_OPUS_4_1,
@@ -61,6 +62,12 @@ def test_anthropic_model(model_type: ModelType):
 def test_claude_opus_4_8_metadata():
     assert ModelType.CLAUDE_OPUS_4_8.is_anthropic
     assert ModelType.CLAUDE_OPUS_4_8.token_limit == 1_000_000
+
+
+def test_claude_fable_5_metadata():
+    assert ModelType.CLAUDE_FABLE_5.value == "claude-fable-5"
+    assert ModelType.CLAUDE_FABLE_5.is_anthropic
+    assert ModelType.CLAUDE_FABLE_5.token_limit == 1_000_000
 
 
 def test_anthropic_model_uses_provided_token_counter():


### PR DESCRIPTION
## Summary

Closes #4106.

- Add `ModelType.CLAUDE_FABLE_5` for Anthropic's public `claude-fable-5` API model ID.
- Mark Claude Fable 5 as an Anthropic model.
- Set Claude Fable 5 token limit to 1,000,000 based on Anthropic's documented context window.
- Add Anthropic model tests for the new enum metadata.

## Notes

Anthropic documents `claude-mythos-5` as Project Glasswing / limited-access, so this PR intentionally adds only the generally available Claude Fable 5 model.

Official references:
- https://docs.anthropic.com/en/docs/about-claude/models/overview
- https://docs.anthropic.com/en/release-notes/api

## Tests

- `uv run python -m pytest test/models/test_anthropic_model.py::test_anthropic_model test/models/test_anthropic_model.py::test_claude_opus_4_8_metadata test/models/test_anthropic_model.py::test_claude_fable_5_metadata -q`
- Direct metadata check for value, `is_anthropic`, token limit, and tiktoken fallback