### PR TITLE
docs: clarify MCP arxiv example prerequisites

### DIFF
--- a/examples/toolkits/mcp/mcp_arxiv_toolkit/client.py
+++ b/examples/toolkits/mcp/mcp_arxiv_toolkit/client.py
@@ -20,6 +20,16 @@ from camel.toolkits.mcp_toolkit import MCPClient, MCPToolkit
 
 
 async def run_example_http():
+    r"""Run the example against a streamable-http MCP server.
+
+    This requires the arxiv toolkit server to be already running in
+    streamable-http mode in a separate process, e.g.:
+
+        cd examples/toolkits/mcp/mcp_arxiv_toolkit
+        python arxiv_toolkit_server.py --mode streamable-http
+
+    Otherwise, connecting to the server will hang.
+    """
     config = {
         "mcpServers": {
             "arxiv_toolkit": {
@@ -109,5 +119,9 @@ async def run_example_stdio():
 
 
 if __name__ == "__main__":
-    asyncio.run(run_example_http())
+    # run_example_stdio() is self-contained and spawns its own server, so
+    # it is run by default. run_example_http() requires a separately
+    # running streamable-http server (see its docstring) and is therefore
+    # not run by default.
     asyncio.run(run_example_stdio())
+    # asyncio.run(run_example_http())

--- a/examples/toolkits/mcp/mcp_arxiv_toolkit/client_sync.py
+++ b/examples/toolkits/mcp/mcp_arxiv_toolkit/client_sync.py
@@ -18,6 +18,16 @@ from camel.toolkits.mcp_toolkit import MCPClient, MCPToolkit
 
 
 def run_example():
+    r"""Run the example against a streamable-http MCP server.
+
+    This requires the arxiv toolkit server to be already running in
+    streamable-http mode in a separate process, e.g.:
+
+        cd examples/toolkits/mcp/mcp_arxiv_toolkit
+        python arxiv_toolkit_server.py --mode streamable-http
+
+    Otherwise, connecting to the server will hang.
+    """
     mcp_toolkit = MCPToolkit(
         config_dict={
             "mcpServers": {


### PR DESCRIPTION
## Description

The MCP arxiv toolkit examples (`client.py` and `client_sync.py`) connect to
a streamable-http MCP server at `http://localhost:8000/mcp/`. This server
must be started separately by running `arxiv_toolkit_server.py --mode
streamable-http` in another process. Without this prerequisite, running the
examples hangs indefinitely at the connection step, with no indication of
what's wrong.

This PR:
- Adds a docstring to `run_example_http()` in `client.py` and `run_example()`
  in `client_sync.py` explaining the prerequisite and how to start the
  server.
- In `client.py`, changes the `__main__` block to run the self-contained
  `run_example_stdio()` by default (it spawns its own server and requires no
  setup), and comments out `run_example_http()` since it requires the extra
  setup step described above.

## Motivation and Context

Closes #2125

Users running the example as-is hit an indefinite hang at
`await mcp_toolkit.connect()` with no explanation, since the http example
requires an external server that isn't started by the script itself.

## Types of changes

- [x] Docs fix

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.