### PR TITLE
fix(toolkits): add require_approval gate to TerminalToolkit.shell_exec

### DIFF
--- a/camel/toolkits/terminal_toolkit/terminal_toolkit.py
+++ b/camel/toolkits/terminal_toolkit/terminal_toolkit.py
@@ -21,7 +21,7 @@ import threading
 import time
 import uuid
 from queue import Empty, Full, Queue
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from camel.logger import get_logger
 from camel.toolkits import manual_timeout
@@ -66,6 +66,28 @@ def _to_plain(text: str) -> str:
         return text
 
 
+def _default_console_approval(command: str) -> bool:
+    r"""Console-based approval prompt shown before each shell command.
+
+    Prints the pending command and asks the user to allow or deny
+    execution via stdin.  Returns ``False`` when stdin is not a tty
+    (e.g. in CI pipelines) so the safe default is to deny.
+
+    Args:
+        command (str): The shell command awaiting approval.
+
+    Returns:
+        bool: ``True`` if the user types ``y`` or ``yes``, ``False``
+            for anything else or when stdin is closed.
+    """
+    print(f"\n[TerminalToolkit] Pending shell command:\n  > {command}")
+    try:
+        answer = input("Allow execution? [y/N]: ").strip().lower()
+        return answer in ("y", "yes")
+    except EOFError:
+        return False
+
+
 @MCPServer()
 class TerminalToolkit(BaseToolkit):
     r"""A toolkit for LLM agents to execute and interact with terminal commands
@@ -100,6 +122,14 @@ class TerminalToolkit(BaseToolkit):
             ``Runtime.GO`` and ``Runtime.JAVA``. If empty (the default),
             only the Python runtime is configured. Example:
             ``enable_other_runtimes=[Runtime.GO, Runtime.JAVA]``.
+        require_approval (Optional[Callable[[str], bool]]): A callable
+            invoked with the command string before every ``shell_exec``
+            call.  Execution proceeds only when the callable returns
+            ``True``; otherwise ``shell_exec`` returns an error string
+            without running anything.  Defaults to
+            :func:`_default_console_approval`, which interactively
+            prompts the user via stdin.  Pass ``None`` to disable the
+            approval gate entirely (opt-in to unrestricted execution).
     """
 
     def __init__(
@@ -114,6 +144,9 @@ class TerminalToolkit(BaseToolkit):
         clone_current_env: bool = False,
         install_dependencies: Optional[List[str]] = None,
         enable_other_runtimes: list[Runtime] | None = None,
+        require_approval: Optional[Callable[[str], bool]] = (
+            _default_console_approval
+        ),
     ):
         # auto-detect if running inside a CAMEL runtime container
         # when inside a runtime, use local execution (already sandboxed)
@@ -166,6 +199,7 @@ class TerminalToolkit(BaseToolkit):
         if not os.path.exists(self.working_dir):
             os.makedirs(self.working_dir, exist_ok=True)
         self.safe_mode = safe_mode
+        self._require_approval = require_approval
 
         # Initialize whitelist of allowed commands if provided
         self.allowed_commands = (
@@ -717,6 +751,11 @@ class TerminalToolkit(BaseToolkit):
                     f"{message}"
                 )
             command = message
+
+        if self._require_approval is not None and not self._require_approval(
+            command
+        ):
+            return "Error: Command rejected by approval policy."
 
         if self.use_docker_backend:
             # For Docker, we always run commands in a shell

--- a/test/toolkits/test_terminal_toolkit.py
+++ b/test/toolkits/test_terminal_toolkit.py
@@ -24,7 +24,11 @@ from camel.toolkits.terminal_toolkit.utils import sanitize_command
 
 @pytest.fixture
 def terminal_toolkit(temp_dir, request):
-    toolkit = TerminalToolkit(working_directory=temp_dir, safe_mode=False)
+    toolkit = TerminalToolkit(
+        working_directory=temp_dir,
+        safe_mode=False,
+        require_approval=None,
+    )
     # Ensure cleanup happens after test completes
     request.addfinalizer(toolkit.cleanup)
     return toolkit
@@ -62,12 +66,12 @@ def test_shell_exec(terminal_toolkit, temp_dir):
     )
     assert "Hello World" in result
 
-    # Test command with error
+    # Test command with error (error wording differs by OS)
     result = terminal_toolkit.shell_exec(
         "test_session",
         "nonexistent_command",
     )
-    assert "not found" in result.lower()
+    assert "not found" in result.lower() or "not recognized" in result.lower()
 
     # Test session persistence - use non-blocking mode to create sessions
     session_id = "persistent_session"
@@ -365,3 +369,91 @@ def test_sanitize_command_respects_customized_dangerous_commands(
     )
     assert not is_safe
     assert "echo" in message.lower()
+
+
+# ---------------------------------------------------------------------------
+# require_approval tests
+# ---------------------------------------------------------------------------
+
+
+def test_require_approval_blocks_when_callback_returns_false(
+    temp_dir, request
+):
+    r"""A callback that always returns False must prevent command execution."""
+    toolkit = TerminalToolkit(
+        working_directory=str(temp_dir),
+        safe_mode=False,
+        require_approval=lambda cmd: False,
+    )
+    request.addfinalizer(toolkit.cleanup)
+
+    result = toolkit.shell_exec("s_reject", "echo hello")
+    assert "error" in result.lower()
+    assert "rejected by approval policy" in result.lower()
+
+
+def test_require_approval_allows_when_callback_returns_true(temp_dir, request):
+    r"""A callback that always returns True must let the command run."""
+    toolkit = TerminalToolkit(
+        working_directory=str(temp_dir),
+        safe_mode=False,
+        require_approval=lambda cmd: True,
+    )
+    request.addfinalizer(toolkit.cleanup)
+
+    result = toolkit.shell_exec("s_allow", "echo hello")
+    assert "hello" in result.lower()
+
+
+def test_require_approval_none_disables_gate(temp_dir, request):
+    r"""Passing require_approval=None must skip the approval check entirely."""
+    toolkit = TerminalToolkit(
+        working_directory=str(temp_dir),
+        safe_mode=False,
+        require_approval=None,
+    )
+    request.addfinalizer(toolkit.cleanup)
+
+    result = toolkit.shell_exec("s_none", "echo hello")
+    assert "hello" in result.lower()
+
+
+def test_require_approval_callback_receives_command(temp_dir, request):
+    r"""The approval callback must be called with the exact command string."""
+    received: list = []
+
+    def capture(cmd: str) -> bool:
+        received.append(cmd)
+        return True
+
+    toolkit = TerminalToolkit(
+        working_directory=str(temp_dir),
+        safe_mode=False,
+        require_approval=capture,
+    )
+    request.addfinalizer(toolkit.cleanup)
+
+    toolkit.shell_exec("s_capture", "echo test_cmd")
+    assert len(received) == 1
+    assert "echo test_cmd" in received[0]
+
+
+def test_require_approval_not_called_after_safe_mode_rejection(
+    temp_dir, request
+):
+    r"""Approval callback must not fire for commands already blocked by
+    safe mode."""
+    called: list = []
+
+    toolkit = TerminalToolkit(
+        working_directory=str(temp_dir),
+        safe_mode=True,
+        require_approval=lambda cmd: called.append(cmd) or True,
+    )
+    request.addfinalizer(toolkit.cleanup)
+
+    result = toolkit.shell_exec("s_safe", "rm -rf /")
+    assert "safe mode" in result.lower()
+    assert (
+        called == []
+    ), "Approval callback should not be invoked for safe-mode-blocked commands"


### PR DESCRIPTION
## Related Issue
Closes #4038

## What changed and why
`TerminalToolkit.shell_exec` previously executed any shell command the
LLM decided to call — no user confirmation was required. This meant a
single prompt like "create a file" was enough to trigger arbitrary
`subprocess.Popen(..., shell=True)` execution.

This PR adds an optional `require_approval` parameter to
`TerminalToolkit.__init__`:

- **Default** (`_default_console_approval`): prompts the user via stdin
  before every command; denies automatically in non-interactive / CI
  environments (`EOFError` → `False`).
- **Custom callback**: any `Callable[[str], bool]` — enables allowlists,
  logging, or policy-based approval.
- **`require_approval=None`**: explicit opt-out for unrestricted
  execution (previous behaviour).

The gate fires **after** `safe_mode` sanitisation and **before**
Docker/venv wrapping, so users see the clean command and are never
prompted for commands that `safe_mode` would already reject.

## Testing
All 37 tests pass locally:

collected 37 items
test/toolkits/test_terminal_toolkit.py .....................................
37 passed in 284.50s


New tests added:
- `test_require_approval_blocks_when_callback_returns_false`
- `test_require_approval_allows_when_callback_returns_true`
- `test_require_approval_none_disables_gate`
- `test_require_approval_callback_receives_command`
- `test_require_approval_not_called_after_safe_mode_rejection`

Pre-existing fixes bundled in this PR:
- `terminal_toolkit` test fixture now passes `require_approval=None`
  (automated tests have no stdin).
- `test_shell_exec` now accepts both `"not found"` (Unix) and
  `"not recognized"` (Windows) so the suite passes cross-platform.

Labels to set: `fix`
Milestone: Sprint 54 (matches the issue)
Development: Link to issue [#4038](https://github.com/camel-ai/camel/issues/4038)