### PR TITLE
feat: Unify str/callable to BaseModel conversion in ChatAgent

### DIFF
--- a/camel/agents/chat_agent.py
+++ b/camel/agents/chat_agent.py
@@ -101,6 +101,7 @@ from camel.types.agents import ToolCallingRecord
 from camel.utils import (
     Constants,
     get_model_encoding,
+    get_pydantic_model,
     model_from_json_schema,
 )
 from camel.utils.commons import dependencies_required
@@ -2539,6 +2540,31 @@ class ChatAgent(BaseAgent):
         """
         self.update_memory(message, OpenAIBackendRole.ASSISTANT)
 
+    def _normalize_response_format(
+        self,
+        response_format: Optional[Union[Type[BaseModel], str, Callable]],
+    ) -> Optional[Type[BaseModel]]:
+        r"""Normalize a response format specification into a Pydantic model.
+
+        This unifies how a structured-output schema is converted into a
+        :obj:`BaseModel` across CAMEL (e.g. with
+        :obj:`OpenAISchemaConverter`) by routing through the shared
+        :obj:`get_pydantic_model` utility.
+
+        Args:
+            response_format (Optional[Union[Type[BaseModel], str, Callable]]):
+                The response format specification. May be a Pydantic model
+                class, a JSON-encoded string template, or a callable whose
+                signature defines the expected fields. (default: :obj:`None`)
+
+        Returns:
+            Optional[Type[BaseModel]]: The corresponding Pydantic model class,
+                or :obj:`None` if no response format was provided.
+        """
+        if response_format is None:
+            return None
+        return get_pydantic_model(response_format)
+
     def _try_format_message(
         self, message: BaseMessage, response_format: Type[BaseModel]
     ) -> bool:
@@ -2831,7 +2857,9 @@ class ChatAgent(BaseAgent):
     def step(
         self,
         input_message: Union[BaseMessage, str],
-        response_format: Optional[Type[BaseModel]] = None,
+        response_format: Optional[
+            Union[Type[BaseModel], str, Callable]
+        ] = None,
     ) -> Union[ChatAgentResponse, StreamingChatAgentResponse]:
         r"""Executes a single step in the chat session, generating a response
         to the input message.
@@ -2840,8 +2868,10 @@ class ChatAgent(BaseAgent):
             input_message (Union[BaseMessage, str]): The input message for the
                 agent. If provided as a BaseMessage, the `role` is adjusted to
                 `user` to indicate an external message.
-            response_format (Optional[Type[BaseModel]], optional): A Pydantic
-                model defining the expected structure of the response. Used to
+            response_format (Optional[Union[Type[BaseModel], str, Callable]],
+                optional): Defines the expected structure of the response.
+                Accepts a Pydantic model class, a JSON-encoded string template,
+                or a callable whose signature defines the fields. Used to
                 generate a structured response if provided. (default:
                 :obj:`None`)
 
@@ -2855,6 +2885,7 @@ class ChatAgent(BaseAgent):
         Raises:
             TimeoutError: If the step operation exceeds the configured timeout.
         """
+        response_format = self._normalize_response_format(response_format)
 
         stream = self.model_backend.model_config_dict.get("stream", False)
 
@@ -3128,7 +3159,9 @@ class ChatAgent(BaseAgent):
     async def astep(
         self,
         input_message: Union[BaseMessage, str],
-        response_format: Optional[Type[BaseModel]] = None,
+        response_format: Optional[
+            Union[Type[BaseModel], str, Callable]
+        ] = None,
     ) -> Union[ChatAgentResponse, AsyncStreamingChatAgentResponse]:
         r"""Performs a single step in the chat session by generating a response
         to the input message. This agent step can call async function calls.
@@ -3140,11 +3173,11 @@ class ChatAgent(BaseAgent):
                 will be set to `user` anyway since for the self agent any
                 incoming message is external. For str input, the `role_name`
                 would be `User`.
-            response_format (Optional[Type[BaseModel]], optional): A pydantic
-                model class that includes value types and field descriptions
-                used to generate a structured response by LLM. This schema
-                helps in defining the expected output format. (default:
-                :obj:`None`)
+            response_format (Optional[Union[Type[BaseModel], str, Callable]],
+                optional): Defines the expected structure of the response.
+                Accepts a Pydantic model class, a JSON-encoded string template,
+                or a callable whose signature defines the fields. Used to
+                generate a structured response by LLM. (default: :obj:`None`)
         Returns:
             Union[ChatAgentResponse, AsyncStreamingChatAgentResponse]:
                 If stream is False, returns a ChatAgentResponse. If stream is
@@ -3156,6 +3189,8 @@ class ChatAgent(BaseAgent):
             asyncio.TimeoutError: If the step operation exceeds the configured
                 timeout.
         """
+        response_format = self._normalize_response_format(response_format)
+
         # Set agent_id in context-local storage for logging
         from camel.utils.agent_context import set_current_agent_id
 

--- a/camel/schemas/openai_converter.py
+++ b/camel/schemas/openai_converter.py
@@ -93,12 +93,10 @@ class OpenAISchemaConverter(BaseConverter):
         prompt = prompt or DEFAULT_CONVERTER_PROMPTS
         if output_schema is None:
             raise ValueError("Expected an output schema, got None.")
-        if not isinstance(output_schema, type):
-            output_schema = get_pydantic_model(output_schema)
-        elif not issubclass(output_schema, BaseModel):
-            raise ValueError(
-                f"Expected a BaseModel, got {type(output_schema)}"
-            )
+        # Normalize the schema (BaseModel / JSON string / callable) into a
+        # Pydantic model via the shared utility, unifying the conversion with
+        # the rest of CAMEL (e.g. ``ChatAgent``).
+        output_schema = get_pydantic_model(output_schema)
 
         self.model_config_dict["response_format"] = output_schema
         response = self._client.beta.chat.completions.parse(

--- a/camel/utils/response_format.py
+++ b/camel/utils/response_format.py
@@ -31,9 +31,9 @@ def get_pydantic_model(
     input_data (Union[str, type, Callable]):
         - If a string is provided, it should be a JSON-encoded string
             that will be converted into a BaseModel.
+        - If a BaseModel class is provided, it will be returned directly.
         - If a function is provided, it will be decorated such that
             its arguments are converted into a BaseModel.
-        - If a BaseModel class is provided, it will be returned directly.
 
     Returns:
         Type[BaseModel]: The BaseModel class that will be used to
@@ -47,7 +47,13 @@ def get_pydantic_model(
         )
         return TemporaryModel(**data_dict).__class__
 
-    elif callable(input_data):
+    # A BaseModel subclass must be checked before the ``callable`` branch
+    # below, because a class is itself callable and would otherwise be
+    # wrongly wrapped into a new model from its ``__init__`` signature.
+    if isinstance(input_data, type) and issubclass(input_data, BaseModel):
+        return input_data
+
+    if callable(input_data):
         WrapperClass = create_model(  # type: ignore[call-overload]
             f"{input_data.__name__.capitalize()}Model",
             **{
@@ -58,8 +64,6 @@ def get_pydantic_model(
             },
         )
         return WrapperClass
-    if issubclass(input_data, BaseModel):
-        return input_data
     raise ValueError("Invalid input data provided.")
 
 

--- a/examples/agents/chat_agent_response_format_schema_types.py
+++ b/examples/agents/chat_agent_response_format_schema_types.py
@@ -1,0 +1,67 @@
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+
+"""Demonstrates the unified ``response_format`` handling of ``ChatAgent``.
+
+In addition to a Pydantic ``BaseModel`` class, ``ChatAgent.step`` now accepts
+a JSON-encoded string template or a callable as ``response_format`` and
+converts it into a ``BaseModel`` via the shared ``get_pydantic_model``
+utility. This unifies structured output with ``OpenAISchemaConverter.convert``
+(see issue #1242).
+
+Required environment variable:
+    export OPENAI_API_KEY="<your-openai-api-key>"
+
+Run:
+    python examples/agents/chat_agent_response_format_schema_types.py
+"""
+
+from pydantic import BaseModel
+
+from camel.agents import ChatAgent
+
+
+# 1. A Pydantic model class.
+class Temperature(BaseModel):
+    location: str
+    date: str
+    temperature: float
+
+
+# 2. A callable whose signature defines the expected fields.
+def get_temperature(location: str, date: str, temperature: float):
+    pass
+
+
+# 3. A JSON-encoded string template.
+temperature_template = (
+    '{"location": "Beijing", "date": "2023-09-01", "temperature": 30.0}'
+)
+
+
+agent = ChatAgent("Extract structured data from the user's text.")
+
+content = "Today is 2023-09-01, the temperature in Beijing is 30 degrees."
+
+for response_format in (Temperature, get_temperature, temperature_template):
+    response = agent.step(content, response_format=response_format)
+    print(response.msgs[0].parsed)
+
+"""
+===============================================================================
+location='Beijing' date='2023-09-01' temperature=30.0
+location='Beijing' date='2023-09-01' temperature=30.0
+location='Beijing' date='2023-09-01' temperature=30.0
+===============================================================================
+"""

--- a/test/agents/test_chat_agent.py
+++ b/test/agents/test_chat_agent.py
@@ -243,6 +243,47 @@ def test_native_structured_output_backend_keeps_response_format_with_tools():
     assert used_prompt_formatting is False
 
 
+def test_normalize_response_format_handles_all_schema_types():
+    r"""``ChatAgent`` should accept a Pydantic model, a JSON-encoded string,
+    or a callable as ``response_format`` and unify them into a BaseModel via
+    the shared ``get_pydantic_model`` utility (issue #1242)."""
+    agent = ChatAgent(
+        system_message="You are a helpful assistant.",
+        model=DummyModel(ModelType.GPT_4O_MINI),
+    )
+
+    # None passes through unchanged.
+    assert agent._normalize_response_format(None) is None
+
+    # A BaseModel subclass is returned as-is.
+    assert agent._normalize_response_format(TripSchema) is TripSchema
+
+    # A JSON-encoded string template is converted into a BaseModel.
+    template = (
+        '{"location": "Beijing", "date": "2023-09-01", "temperature": 30.0}'
+    )
+    str_model = agent._normalize_response_format(template)
+    assert str_model is not None
+    assert issubclass(str_model, BaseModel)
+    assert set(str_model.model_fields.keys()) == {
+        "location",
+        "date",
+        "temperature",
+    }
+
+    # A callable's signature defines the fields of the converted BaseModel.
+    def get_temperature(location: str, date: str, temperature: float): ...
+
+    callable_model = agent._normalize_response_format(get_temperature)
+    assert callable_model is not None
+    assert issubclass(callable_model, BaseModel)
+    assert set(callable_model.model_fields.keys()) == {
+        "location",
+        "date",
+        "temperature",
+    }
+
+
 def test_chat_agent_reset_clears_tool_output_history():
     model = DummyModel(ModelType.GPT_4O_MINI)
     assistant = ChatAgent(
@@ -389,6 +430,51 @@ def test_chat_agent_step_with_structure_response(step_call_count=3):
                 f"Error in calling round {i + 1}: "
                 f"Key {key} not found in response content"
             )
+
+
+@pytest.mark.model_backend
+def test_chat_agent_step_with_str_and_callable_response_format():
+    r"""``step`` should accept a JSON-encoded string template or a callable as
+    ``response_format``, unifying it with ``OpenAISchemaConverter.convert``
+    (issue #1242)."""
+    system_msg = BaseMessage(
+        role_name="assistant",
+        role_type=RoleType.ASSISTANT,
+        meta_dict=None,
+        content="You are a help assistant.",
+    )
+
+    def get_temperature(location: str, date: str, temperature: float): ...
+
+    temperature_template = (
+        '{"location": "Beijing", "date": "2023-09-01", "temperature": 30.0}'
+    )
+
+    structured_content = (
+        '{"location": "Beijing", "date": "2023-09-01", "temperature": 30.0}'
+    )
+
+    for response_format in (temperature_template, get_temperature):
+        assistant = ChatAgent(system_message=system_msg)
+
+        model_backend_rsp = deepcopy(model_backend_rsp_base)
+        model_backend_rsp.choices[0].message.content = structured_content
+        model_backend_rsp.choices[0].message.tool_calls = []
+        assistant.model_backend.run = MagicMock(return_value=model_backend_rsp)
+
+        user_msg = BaseMessage.make_user_message(
+            role_name="User",
+            content="Today is 2023-09-01, Beijing is 30 degrees.",
+        )
+
+        response = assistant.step(user_msg, response_format=response_format)
+        response_content_json = json.loads(response.msg.content)
+
+        assert set(response_content_json.keys()) == {
+            "location",
+            "date",
+            "temperature",
+        }
 
 
 @pytest.mark.model_backend

--- a/test/utils/test_response_format.py
+++ b/test/utils/test_response_format.py
@@ -15,7 +15,46 @@ import unittest
 
 from pydantic import BaseModel, ValidationError
 
-from camel.utils.response_format import model_from_json_schema
+from camel.utils.response_format import (
+    get_pydantic_model,
+    model_from_json_schema,
+)
+
+
+class TestGetPydanticModel(unittest.TestCase):
+    def test_basemodel_returned_as_is(self):
+        class Trip(BaseModel):
+            city: str
+
+        # A BaseModel subclass (which is itself callable) must be returned
+        # directly rather than wrapped from its __init__ signature.
+        self.assertIs(get_pydantic_model(Trip), Trip)
+
+    def test_json_string_converted_to_model(self):
+        template = (
+            '{"location": "Beijing", "date": "2023-09-01", '
+            '"temperature": 30.0}'
+        )
+        Model = get_pydantic_model(template)
+        self.assertTrue(issubclass(Model, BaseModel))
+        self.assertEqual(
+            set(Model.model_fields.keys()),
+            {"location", "date", "temperature"},
+        )
+
+    def test_callable_converted_to_model(self):
+        def get_temperature(location: str, date: str, temperature: float): ...
+
+        Model = get_pydantic_model(get_temperature)
+        self.assertTrue(issubclass(Model, BaseModel))
+        self.assertEqual(
+            set(Model.model_fields.keys()),
+            {"location", "date", "temperature"},
+        )
+
+    def test_invalid_input_raises(self):
+        with self.assertRaises(ValueError):
+            get_pydantic_model(123)
 
 
 class TestModelFromJsonSchema(unittest.TestCase):


### PR DESCRIPTION
### Related Issue

Closes #1242

### Description

Per the discussion in #1242, `OpenAISchemaConverter.convert()` and `ChatAgent`
each handled structured-output schemas differently: the converter accepted a
Pydantic `BaseModel`, a JSON-encoded string template, **or** a callable (via the
shared `get_pydantic_model()` utility), while `ChatAgent.step()`/`astep()` only
accepted a `Type[BaseModel]`. The "str → pydantic `BaseModel`" conversion lived
in two places with diverging capabilities.

This PR unifies that conversion through the single `get_pydantic_model()`
utility, so both classes behave consistently and the duplicated logic is
removed.

**Changes**
- `camel/utils/response_format.py`: reorder `get_pydantic_model` so a `BaseModel`
  subclass is returned **before** the `callable` branch. A class is itself
  callable, so the previous order would have wrongly wrapped a `BaseModel` from
  its `__init__` signature (latent bug).
- `camel/agents/chat_agent.py`: add a `_normalize_response_format()` helper and
  widen `step()`/`astep()` `response_format` to
  `Optional[Union[Type[BaseModel], str, Callable]]`, normalizing through the
  shared utility. Docstrings updated.
- `camel/schemas/openai_converter.py`: route `convert()` through the same
  utility, removing the duplicated type-guard logic.
- Tests + example added.

`OpenAISchemaConverter` is intentionally kept for backward compatibility (it is
used by the alpaca/sharegpt data collectors, which pass `BaseModel` classes and
behave identically).

### What is the purpose of this pull request?

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Checklist

- [x] I have read and agree to the [AI-Generated Code Policy](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md#ai-generated-code-policy) (**required**)
- [x] I have linked this PR to an issue (**required**)
- [x] I have checked if any dependencies need to be added or updated in `pyproject.toml` and run `uv lock` (no dependency changes needed)
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [x] I have updated the documentation if needed (docstrings updated; the Mintlify reference under `docs/` is auto-generated from them)
- [x] I have added examples if this is a new feature

### Proof of testing

`ruff check` (changed files):

All checks passed!

`mypy` (changed source files):

Success: no issues found in 3 source files

`pytest`:

```
test/utils/test_response_format.py ..........
test/agents/test_chat_agent.py::test_normalize_response_format_handles_all_schema_types .
test/agents/test_chat_agent.py::test_chat_agent_step_with_str_and_callable_response_format .
test/agents/test_chat_agent.py::test_chat_agent_step_with_structure_response .
13 passed
```

> Note: the converter's own 3 tests in `test/schema_outputs/test_openai_converter.py` make live OpenAI calls and were not run locally; the changed normalization path is covered by the new `get_pydantic_model` unit tests instead.