### PR TITLE
feat: Add ToolkitManager for tool search across toolkits

### DIFF
--- a/camel/toolkits/__init__.py
+++ b/camel/toolkits/__init__.py
@@ -107,6 +107,7 @@ from .agent_toolkit import AgentToolkit
 from .planning_worktree_toolkit import PlanningWorktreeToolkit
 from .todo_toolkit import TodoItem, TodoToolkit
 from .web_fetch_toolkit import WebFetchToolkit
+from .toolkit_manager import ToolkitManager
 
 __all__ = [
     'BaseToolkit',
@@ -205,4 +206,5 @@ __all__ = [
     'TodoItem',
     'TodoToolkit',
     'WebFetchToolkit',
+    'ToolkitManager',
 ]

--- a/camel/toolkits/toolkit_manager.py
+++ b/camel/toolkits/toolkit_manager.py
@@ -1,0 +1,508 @@
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+from __future__ import annotations
+
+import re
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+    overload,
+)
+
+from camel.logger import get_logger
+from camel.toolkits.base import BaseToolkit
+from camel.toolkits.function_tool import FunctionTool
+from camel.utils import dependencies_required
+
+if TYPE_CHECKING:
+    from camel.embeddings import BaseEmbedding
+
+logger = get_logger(__name__)
+
+# A toolkit instance, a single tool, or a plain callable.
+ToolSource = Union[BaseToolkit, FunctionTool, Callable]
+
+_TOKEN_RE = re.compile(r"[A-Za-z0-9]+")
+
+
+class ToolkitManager:
+    r"""Aggregates tools from multiple toolkits and searches for the ones most
+    relevant to a query.
+
+    A capable agent may have access to many toolkits, which together expose
+    hundreds of tools. Passing all of them to a language model bloats the
+    context window and degrades tool-selection accuracy. ``ToolkitManager``
+    indexes the name, description, and parameters of every registered tool and
+    retrieves only the most relevant ones for a query -- the "tool RAG"
+    pattern.
+
+    Two usage patterns are supported:
+
+    1. **Static pre-filtering** -- call :meth:`search_tools` to obtain the
+       top-k relevant tools and pass them straight to a ``ChatAgent``::
+
+           manager = ToolkitManager([SearchToolkit(), MathToolkit()])
+           tools = manager.search_tools("add two numbers")
+           agent = ChatAgent(tools=tools)
+
+    2. **Agentic discovery** -- expose the meta-tools returned by
+       :meth:`get_search_tools` so the agent can search the registry and
+       invoke a discovered tool on demand, without ever seeing the full tool
+       list::
+
+           agent = ChatAgent(tools=manager.get_search_tools())
+
+    Args:
+        toolkits (Optional[Sequence[ToolSource]]): Initial toolkits, tools, or
+            plain callables to register. (default: :obj:`None`)
+        search_backend (Literal["bm25", "embedding"]): The ranking backend.
+            ``"bm25"`` is keyword based and requires no API key.
+            ``"embedding"`` ranks by semantic similarity and requires an
+            embedding model. (default: :obj:`"bm25"`)
+        embedding_model (Optional[BaseEmbedding]): The embedding model used
+            when ``search_backend="embedding"``. Falls back to
+            :obj:`OpenAIEmbedding` when not provided. (default: :obj:`None`)
+        default_top_k (int): The default number of tools returned by
+            :meth:`search_tools`. (default: :obj:`5`)
+    """
+
+    def __init__(
+        self,
+        toolkits: Optional[Sequence[ToolSource]] = None,
+        *,
+        search_backend: Literal["bm25", "embedding"] = "bm25",
+        embedding_model: Optional["BaseEmbedding"] = None,
+        default_top_k: int = 5,
+    ) -> None:
+        if search_backend not in ("bm25", "embedding"):
+            raise ValueError(
+                f"Unknown search_backend '{search_backend}'. "
+                f"Expected 'bm25' or 'embedding'."
+            )
+        if default_top_k <= 0:
+            raise ValueError("default_top_k must be a positive integer.")
+
+        self.search_backend = search_backend
+        self.default_top_k = default_top_k
+        self._embedding_model = embedding_model
+
+        # Registered tools keyed by name (insertion order preserved).
+        self._tools: Dict[str, FunctionTool] = {}
+
+        # Lazily built search index. ``_dirty`` is set whenever the set of
+        # registered tools changes so the index is rebuilt on next query.
+        self._dirty: bool = True
+        self._indexed_names: List[str] = []
+        self._bm25: Any = None
+        self._tool_embeddings: Any = None  # numpy.ndarray of unit vectors
+
+        if toolkits:
+            self.add(toolkits)
+
+    # ------------------------------------------------------------------ #
+    # Registration
+    # ------------------------------------------------------------------ #
+    def add(
+        self, source: Union[ToolSource, Sequence[ToolSource]]
+    ) -> "ToolkitManager":
+        r"""Registers one or more toolkits, tools, or callables.
+
+        Args:
+            source (Union[ToolSource, Sequence[ToolSource]]): A single
+                toolkit/tool/callable, or a sequence of them. Each
+                :obj:`BaseToolkit` is expanded into its individual tools.
+
+        Returns:
+            ToolkitManager: ``self``, to allow chaining.
+        """
+        # Normalize a single item into a one-element list. ``FunctionTool`` is
+        # callable, so it is checked before the generic ``callable`` case.
+        if isinstance(source, (BaseToolkit, FunctionTool)) or callable(source):
+            items: Sequence[ToolSource] = [source]  # type: ignore[list-item]
+        else:
+            items = source
+
+        for item in items:
+            if isinstance(item, BaseToolkit):
+                for tool in item.get_tools():
+                    self._register(tool)
+            elif isinstance(item, FunctionTool):
+                self._register(item)
+            elif callable(item):
+                self._register(FunctionTool(item))
+            else:
+                raise TypeError(
+                    f"Cannot register object of type {type(item)!r}. "
+                    f"Expected a BaseToolkit, FunctionTool, or callable."
+                )
+        return self
+
+    def _register(self, tool: FunctionTool) -> None:
+        r"""Registers a single tool, de-duplicating by function name."""
+        name = tool.get_function_name()
+        if name in self._tools:
+            logger.warning(
+                f"Tool '{name}' is already registered; overwriting the "
+                f"previous entry."
+            )
+        self._tools[name] = tool
+        self._dirty = True
+
+    # ------------------------------------------------------------------ #
+    # Accessors
+    # ------------------------------------------------------------------ #
+    def get_all_tools(self) -> List[FunctionTool]:
+        r"""Returns every registered tool.
+
+        Returns:
+            List[FunctionTool]: All registered tools, in registration order.
+        """
+        return list(self._tools.values())
+
+    @property
+    def tool_names(self) -> List[str]:
+        r"""The names of all registered tools."""
+        return list(self._tools.keys())
+
+    # ------------------------------------------------------------------ #
+    # Search
+    # ------------------------------------------------------------------ #
+    @overload
+    def search_tools(
+        self,
+        query: str,
+        top_k: Optional[int] = ...,
+        *,
+        with_scores: Literal[False] = ...,
+    ) -> List[FunctionTool]: ...
+
+    @overload
+    def search_tools(
+        self,
+        query: str,
+        top_k: Optional[int] = ...,
+        *,
+        with_scores: Literal[True],
+    ) -> List[Tuple[FunctionTool, float]]: ...
+
+    def search_tools(
+        self,
+        query: str,
+        top_k: Optional[int] = None,
+        *,
+        with_scores: bool = False,
+    ) -> Union[List[FunctionTool], List[Tuple[FunctionTool, float]]]:
+        r"""Returns the tools most relevant to ``query``, best match first.
+
+        Args:
+            query (str): A natural language description of the desired
+                capability (e.g. "download a paper from arxiv").
+            top_k (Optional[int]): The maximum number of tools to return.
+                Falls back to ``default_top_k`` when ``None``.
+                (default: :obj:`None`)
+            with_scores (bool): When ``True``, return ``(tool, score)`` tuples
+                instead of bare tools. (default: :obj:`False`)
+
+        Returns:
+            Union[List[FunctionTool], List[Tuple[FunctionTool, float]]]: The
+                ranked tools, optionally paired with their relevance scores.
+
+        Raises:
+            ValueError: If ``query`` is empty or ``top_k`` is not positive.
+        """
+        if not query or not query.strip():
+            raise ValueError("query must be a non-empty string.")
+        top_k = self.default_top_k if top_k is None else top_k
+        if top_k <= 0:
+            raise ValueError("top_k must be a positive integer.")
+        if not self._tools:
+            return []
+
+        ranked = self._rank(query)[:top_k]
+        if with_scores:
+            return [(self._tools[name], score) for name, score in ranked]
+        return [self._tools[name] for name, _ in ranked]
+
+    def _rank(self, query: str) -> List[Tuple[str, float]]:
+        r"""Ranks all tool names against ``query`` (descending score).
+
+        Ties are broken by tool name so results are deterministic.
+        """
+        self._ensure_index()
+        if self.search_backend == "bm25":
+            scores = self._bm25_scores(query)
+        else:
+            scores = self._embedding_scores(query)
+        paired = list(zip(self._indexed_names, scores))
+        paired.sort(key=lambda item: (-item[1], item[0]))
+        return paired
+
+    def _ensure_index(self) -> None:
+        r"""(Re)builds the search index if the tool set changed."""
+        if not self._dirty:
+            return
+        self._indexed_names = list(self._tools.keys())
+        if self.search_backend == "bm25":
+            self._build_bm25_index()
+        else:
+            self._build_embedding_index()
+        self._dirty = False
+
+    # ------------------------------------------------------------------ #
+    # BM25 backend
+    # ------------------------------------------------------------------ #
+    @dependencies_required('rank_bm25')
+    def _build_bm25_index(self) -> None:
+        from rank_bm25 import BM25Okapi
+
+        corpus = [
+            self._tokenize(self._tool_document(self._tools[name]))
+            for name in self._indexed_names
+        ]
+        # ``BM25Okapi`` cannot be built from an empty corpus.
+        self._bm25 = BM25Okapi(corpus) if corpus else None
+
+    def _bm25_scores(self, query: str) -> List[float]:
+        if self._bm25 is None:
+            return [0.0] * len(self._indexed_names)
+        return [float(s) for s in self._bm25.get_scores(self._tokenize(query))]
+
+    # ------------------------------------------------------------------ #
+    # Embedding backend
+    # ------------------------------------------------------------------ #
+    def _get_embedding_model(self) -> "BaseEmbedding":
+        if self._embedding_model is None:
+            from camel.embeddings import OpenAIEmbedding
+
+            self._embedding_model = OpenAIEmbedding()
+        return self._embedding_model
+
+    def _build_embedding_index(self) -> None:
+        import numpy as np
+
+        if not self._indexed_names:
+            self._tool_embeddings = None
+            return
+        documents = [
+            self._tool_document(self._tools[name])
+            for name in self._indexed_names
+        ]
+        vectors = np.asarray(
+            self._get_embedding_model().embed_list(documents), dtype=float
+        )
+        self._tool_embeddings = self._normalize_rows(vectors)
+
+    def _embedding_scores(self, query: str) -> List[float]:
+        import numpy as np
+
+        if self._tool_embeddings is None:
+            return [0.0] * len(self._indexed_names)
+        query_vector = np.asarray(
+            self._get_embedding_model().embed(query), dtype=float
+        )
+        query_vector = self._normalize_rows(query_vector[np.newaxis, :])[0]
+        # Cosine similarity reduces to a dot product of unit vectors.
+        return [float(s) for s in self._tool_embeddings @ query_vector]
+
+    @staticmethod
+    def _normalize_rows(matrix: Any) -> Any:
+        import numpy as np
+
+        norms = np.linalg.norm(matrix, axis=1, keepdims=True)
+        norms[norms == 0] = 1.0
+        return matrix / norms
+
+    # ------------------------------------------------------------------ #
+    # Agentic meta-tools
+    # ------------------------------------------------------------------ #
+    def get_search_tools(self) -> List[FunctionTool]:
+        r"""Returns meta-tools that let an agent search and call tools at
+        runtime.
+
+        Exposing these two tools -- ``search_tools`` and ``execute_tool`` --
+        instead of the full tool list keeps the agent's context small while
+        still granting access to every registered tool on demand.
+
+        Returns:
+            List[FunctionTool]: The ``search_tools`` and ``execute_tool``
+                meta-tools, bound to this manager.
+        """
+        manager = self
+
+        def search_tools(query: str, top_k: int = 5) -> str:
+            r"""Search the tool registry for tools relevant to a query.
+
+            Call this to discover which tools are available before invoking
+            ``execute_tool``.
+
+            Args:
+                query (str): A natural language description of what you want
+                    to do, e.g. "download a paper from arxiv".
+                top_k (int): The maximum number of tools to return.
+                    (default: :obj:`5`)
+
+            Returns:
+                str: The matching tool names with their descriptions and
+                    parameters, or a message stating that nothing matched.
+            """
+            try:
+                results = manager.search_tools(
+                    query, top_k=top_k, with_scores=True
+                )
+            except ValueError as error:
+                return f"Error: {error}"
+            if not results:
+                return "No matching tools were found."
+            return "\n\n".join(
+                manager._describe_tool(tool) for tool, _ in results
+            )
+
+        def execute_tool(
+            tool_name: str, arguments: Optional[Dict[str, Any]] = None
+        ) -> str:
+            r"""Execute a registered tool by name.
+
+            Use ``search_tools`` first to find the exact tool name and its
+            parameters.
+
+            Args:
+                tool_name (str): The exact name of the tool to execute, as
+                    returned by ``search_tools``.
+                arguments (Optional[Dict[str, Any]]): A mapping of parameter
+                    names to values passed to the tool. (default: :obj:`None`)
+
+            Returns:
+                str: The tool's result, or an error message if the tool is
+                    unknown or raised an exception.
+            """
+            return manager._execute_named_tool(tool_name, arguments)
+
+        return [FunctionTool(search_tools), FunctionTool(execute_tool)]
+
+    def _execute_named_tool(
+        self, tool_name: str, arguments: Optional[Dict[str, Any]] = None
+    ) -> str:
+        r"""Dispatches a call to a registered tool by name (error-safe)."""
+        tool = self._tools.get(tool_name)
+        if tool is None:
+            hint = ""
+            try:
+                suggestions = self.search_tools(tool_name, top_k=3)
+            except ValueError:
+                suggestions = []
+            names = ", ".join(tool.get_function_name() for tool in suggestions)
+            if names:
+                hint = f" Did you mean: {names}?"
+            return (
+                f"Error: no tool named '{tool_name}'.{hint} "
+                f"Use search_tools to discover available tools."
+            )
+        if arguments is None:
+            arguments = {}
+        if not isinstance(arguments, dict):
+            return (
+                "Error: 'arguments' must be a mapping of parameter names to "
+                "values."
+            )
+        try:
+            return str(tool(**arguments))
+        except Exception as error:
+            return f"Error executing '{tool_name}': {error}"
+
+    # ------------------------------------------------------------------ #
+    # Helpers
+    # ------------------------------------------------------------------ #
+    def _tool_document(self, tool: FunctionTool) -> str:
+        r"""Builds the searchable text for a tool from its name, description,
+        and parameter names/descriptions."""
+        name = tool.get_function_name()
+        description = tool.get_function_description() or ""
+        parts = [name, description]
+        try:
+            properties = (
+                tool.get_openai_tool_schema()["function"]
+                .get("parameters", {})
+                .get("properties", {})
+            )
+            for param_name, param_info in properties.items():
+                parts.append(param_name)
+                param_desc = param_info.get("description")
+                if param_desc:
+                    parts.append(param_desc)
+        except Exception:
+            # A malformed schema should not break indexing.
+            pass
+        return " ".join(part for part in parts if part)
+
+    def _describe_tool(self, tool: FunctionTool) -> str:
+        r"""Renders a human/LLM-readable description of a tool and its
+        parameters."""
+        name = tool.get_function_name()
+        description = tool.get_function_description() or ""
+        try:
+            parameters = tool.get_openai_tool_schema()["function"].get(
+                "parameters", {}
+            )
+        except Exception:
+            parameters = {}
+        properties = parameters.get("properties", {})
+        required = set(parameters.get("required", []))
+
+        if not properties:
+            params_text = " none"
+        else:
+            lines = []
+            for param_name, param_info in properties.items():
+                param_type = param_info.get("type", "any")
+                requirement = (
+                    "required" if param_name in required else "optional"
+                )
+                param_desc = param_info.get("description", "")
+                lines.append(
+                    f"    - {param_name} ({param_type}, {requirement}): "
+                    f"{param_desc}".rstrip()
+                )
+            params_text = "\n" + "\n".join(lines)
+        return f"{name}: {description}\n  parameters:{params_text}"
+
+    @staticmethod
+    def _tokenize(text: str) -> List[str]:
+        r"""Lowercases and splits text into alphanumeric tokens, also breaking
+        ``camelCase`` boundaries so e.g. ``downloadPapers`` matches
+        ``download``."""
+        spaced = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", " ", text)
+        return [match.lower() for match in _TOKEN_RE.findall(spaced)]
+
+    # ------------------------------------------------------------------ #
+    # Dunder helpers
+    # ------------------------------------------------------------------ #
+    def __len__(self) -> int:
+        return len(self._tools)
+
+    def __contains__(self, tool_name: object) -> bool:
+        return tool_name in self._tools
+
+    def __repr__(self) -> str:
+        return (
+            f"ToolkitManager(num_tools={len(self._tools)}, "
+            f"search_backend='{self.search_backend}')"
+        )

--- a/examples/toolkits/toolkit_manager.py
+++ b/examples/toolkits/toolkit_manager.py
@@ -1,0 +1,87 @@
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+from camel.agents import ChatAgent
+from camel.toolkits import (
+    MathToolkit,
+    SearchToolkit,
+    SemanticScholarToolkit,
+    ToolkitManager,
+    WeatherToolkit,
+)
+
+# Aggregate several toolkits. Together these expose dozens of tools; exposing
+# all of them to a model at once would bloat the context and hurt tool
+# selection. The default "bm25" backend is keyword based and needs no API key;
+# pass search_backend="embedding" for semantic matching instead.
+manager = ToolkitManager(
+    [
+        MathToolkit(),
+        SearchToolkit(),
+        WeatherToolkit(),
+        SemanticScholarToolkit(),
+    ]
+)
+
+print(f"{manager}\nRegistered {len(manager)} tools:")
+print("  " + ", ".join(manager.tool_names))
+
+# ---------------------------------------------------------------------------
+# Pattern 1: static pre-filtering
+# ---------------------------------------------------------------------------
+# Retrieve only the tools relevant to the task and hand them to the agent.
+query = "find an academic paper by its title"
+relevant_tools = manager.search_tools(query, top_k=3, with_scores=True)
+
+print(f"\nTop tools for: {query!r}")
+for function_tool, score in relevant_tools:
+    print(f"  {function_tool.get_function_name():28s} score={score:.3f}")
+
+focused_agent = ChatAgent(
+    "You are a helpful research assistant.",
+    tools=[tool for tool, _ in relevant_tools],
+)
+# focused_agent only sees the 3 relevant tools instead of all of them.
+
+# ---------------------------------------------------------------------------
+# Pattern 2: agentic discovery
+# ---------------------------------------------------------------------------
+# Give the agent just two meta-tools (`search_tools` and `execute_tool`). It
+# searches the full registry at runtime and calls tools on demand, keeping its
+# context small no matter how many toolkits are registered.
+discovery_agent = ChatAgent(
+    "You can discover tools with `search_tools` and run them with "
+    "`execute_tool`. Always search before executing.",
+    tools=manager.get_search_tools(),
+)
+
+response = discovery_agent.step(
+    "What is 2024 divided by 8? Find and use the right tool."
+)
+print(f"\nAgentic discovery answer:\n{response.msgs[0].content}")
+
+"""
+===============================================================================
+ToolkitManager(num_tools=27, search_backend='bm25')
+Registered 27 tools:
+  math_add, math_subtract, ..., get_weather_data, fetch_paper_data_title, ...
+
+Top tools for: 'find an academic paper by its title'
+  fetch_paper_data_title       score=6.016
+  fetch_paper_data_id          score=4.678
+  fetch_bulk_paper_data        score=4.417
+
+Agentic discovery answer:
+2024 divided by 8 is 253.
+===============================================================================
+"""

--- a/test/toolkits/test_toolkit_manager.py
+++ b/test/toolkits/test_toolkit_manager.py
@@ -1,0 +1,273 @@
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+from typing import Any, ClassVar, List
+
+import pytest
+
+from camel.embeddings import BaseEmbedding
+from camel.toolkits import FunctionTool, MathToolkit, ToolkitManager
+
+# ``rank_bm25`` backs the default search backend.
+pytest.importorskip("rank_bm25")
+
+
+def fetch_weather(city: str) -> str:
+    r"""Get the current weather forecast for a city.
+
+    Args:
+        city (str): The name of the city.
+
+    Returns:
+        str: A weather description.
+    """
+    return f"Sunny in {city}."
+
+
+def send_email(recipient: str, body: str) -> str:
+    r"""Send an email message to a recipient.
+
+    Args:
+        recipient (str): The email address of the recipient.
+        body (str): The body of the email message.
+
+    Returns:
+        str: A confirmation string.
+    """
+    return f"Sent to {recipient}: {body}"
+
+
+class _BagOfWordsEmbedding(BaseEmbedding):
+    r"""Deterministic, offline embedding for tests.
+
+    Each text is embedded as token-count vector over a fixed vocabulary, so
+    semantic similarity reduces to keyword overlap without any network call.
+    """
+
+    VOCAB: ClassVar[List[str]] = [
+        "weather",
+        "forecast",
+        "city",
+        "email",
+        "message",
+        "send",
+        "recipient",
+        "add",
+        "sum",
+        "number",
+    ]
+
+    def embed_list(self, objs: List[str], **kwargs: Any) -> List[List[float]]:
+        vectors = []
+        for obj in objs:
+            tokens = obj.lower().replace(".", " ").replace(",", " ").split()
+            vectors.append([float(tokens.count(word)) for word in self.VOCAB])
+        return vectors
+
+    def get_output_dim(self) -> int:
+        return len(self.VOCAB)
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+def test_register_expands_toolkit_and_dedups():
+    manager = ToolkitManager([MathToolkit()])
+    assert len(manager) == 5
+    assert "math_divide" in manager
+    assert set(manager.tool_names) == {
+        "math_add",
+        "math_subtract",
+        "math_multiply",
+        "math_divide",
+        "math_round",
+    }
+
+    # Registering the same toolkit again must not create duplicates.
+    manager.add(MathToolkit())
+    assert len(manager) == 5
+
+
+def test_register_function_tool_and_callable():
+    manager = ToolkitManager()
+    assert len(manager) == 0
+
+    returned = manager.add(fetch_weather)  # plain callable
+    assert returned is manager  # chainable
+    manager.add(FunctionTool(send_email))  # FunctionTool instance
+
+    assert len(manager) == 2
+    assert "fetch_weather" in manager
+    assert "send_email" in manager
+    assert all(isinstance(t, FunctionTool) for t in manager.get_all_tools())
+
+
+def test_register_rejects_unsupported_type():
+    manager = ToolkitManager()
+    with pytest.raises(TypeError):
+        manager.add(42)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Initialization validation
+# ---------------------------------------------------------------------------
+def test_init_validation():
+    with pytest.raises(ValueError):
+        ToolkitManager(search_backend="invalid")  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        ToolkitManager(default_top_k=0)
+
+
+# ---------------------------------------------------------------------------
+# BM25 search
+# ---------------------------------------------------------------------------
+def test_search_ranks_relevant_tool_first():
+    manager = ToolkitManager([MathToolkit()])
+    results = manager.search_tools("divide one number by another", top_k=3)
+    assert len(results) == 3
+    assert results[0].get_function_name() == "math_divide"
+
+
+def test_search_respects_top_k_and_with_scores():
+    manager = ToolkitManager([MathToolkit()])
+
+    top1 = manager.search_tools("multiply", top_k=1)
+    assert len(top1) == 1
+    assert top1[0].get_function_name() == "math_multiply"
+
+    scored = manager.search_tools("subtract", top_k=2, with_scores=True)
+    assert len(scored) == 2
+    assert all(
+        isinstance(tool, FunctionTool) and isinstance(score, float)
+        for tool, score in scored
+    )
+    # Scores must be sorted descending.
+    assert scored[0][1] >= scored[1][1]
+
+
+def test_search_top_k_larger_than_registry_returns_all():
+    manager = ToolkitManager([MathToolkit()])
+    results = manager.search_tools("add", top_k=100)
+    assert len(results) == len(manager) == 5
+
+
+def test_search_uses_default_top_k():
+    manager = ToolkitManager([MathToolkit()], default_top_k=2)
+    assert len(manager.search_tools("add")) == 2
+
+
+def test_search_index_refreshes_after_add():
+    manager = ToolkitManager([MathToolkit()])
+    manager.search_tools("add")  # builds the index
+    manager.add(fetch_weather)  # marks the index dirty
+    names = [t.get_function_name() for t in manager.search_tools("weather")]
+    assert "fetch_weather" in names
+
+
+def test_search_validation():
+    manager = ToolkitManager([MathToolkit()])
+    with pytest.raises(ValueError):
+        manager.search_tools("")
+    with pytest.raises(ValueError):
+        manager.search_tools("   ")
+    with pytest.raises(ValueError):
+        manager.search_tools("add", top_k=0)
+
+
+def test_search_on_empty_manager_returns_empty():
+    manager = ToolkitManager()
+    assert manager.search_tools("anything") == []
+
+
+# ---------------------------------------------------------------------------
+# Embedding backend
+# ---------------------------------------------------------------------------
+def test_embedding_backend_ranks_by_similarity():
+    manager = ToolkitManager(
+        [fetch_weather, send_email],
+        search_backend="embedding",
+        embedding_model=_BagOfWordsEmbedding(),
+    )
+    results = manager.search_tools("send an email message", top_k=2)
+    assert results[0].get_function_name() == "send_email"
+
+    results = manager.search_tools("weather forecast for a city", top_k=2)
+    assert results[0].get_function_name() == "fetch_weather"
+
+
+def test_embedding_backend_handles_unmatched_query():
+    # A query with no overlapping vocabulary yields all-zero similarity but
+    # must not raise (zero vectors are normalized safely).
+    manager = ToolkitManager(
+        [fetch_weather, send_email],
+        search_backend="embedding",
+        embedding_model=_BagOfWordsEmbedding(),
+    )
+    results = manager.search_tools("zzz", top_k=2)
+    assert len(results) == 2
+
+
+# ---------------------------------------------------------------------------
+# Agentic meta-tools
+# ---------------------------------------------------------------------------
+def test_get_search_tools_names():
+    manager = ToolkitManager([MathToolkit()])
+    meta = manager.get_search_tools()
+    assert [t.get_function_name() for t in meta] == [
+        "search_tools",
+        "execute_tool",
+    ]
+
+
+def test_meta_search_tools_returns_descriptions():
+    manager = ToolkitManager([MathToolkit()])
+    search_tools, _ = manager.get_search_tools()
+    output = search_tools("add two numbers", 2)
+    assert "math_add" in output
+    assert "parameters:" in output
+
+
+def test_meta_search_tools_handles_bad_query():
+    manager = ToolkitManager([MathToolkit()])
+    search_tools, _ = manager.get_search_tools()
+    # The meta-tool must not raise for the model; it returns an error string.
+    assert search_tools("", 2).startswith("Error:")
+
+
+def test_meta_execute_tool_runs_tool():
+    manager = ToolkitManager([MathToolkit()])
+    _, execute_tool = manager.get_search_tools()
+    assert execute_tool("math_add", {"a": 2, "b": 40}) == "42"
+
+
+def test_meta_execute_tool_unknown_name_suggests_alternatives():
+    manager = ToolkitManager([MathToolkit()])
+    _, execute_tool = manager.get_search_tools()
+    result = execute_tool("add", {"a": 1, "b": 2})
+    assert "no tool named 'add'" in result
+    assert "Did you mean" in result
+    assert "math_add" in result
+
+
+def test_meta_execute_tool_rejects_non_mapping_arguments():
+    manager = ToolkitManager([MathToolkit()])
+    _, execute_tool = manager.get_search_tools()
+    result = execute_tool("math_add", ["a", "b"])  # type: ignore[arg-type]
+    assert "must be a mapping" in result
+
+
+def test_meta_execute_tool_reports_execution_error():
+    manager = ToolkitManager([MathToolkit()])
+    _, execute_tool = manager.get_search_tools()
+    result = execute_tool("math_divide", {"a": 1, "b": 0})
+    assert result.startswith("Error executing 'math_divide'")


### PR DESCRIPTION
### Related Issue

Closes #948

### Description

A capable agent often has access to many toolkits — CAMEL currently ships ~86 — which together expose hundreds of tools. Passing all of them to a model at once bloats the context window and hurts tool-selection accuracy. This PR adds **`ToolkitManager`**, a small "tool RAG" layer that indexes the registered tools and returns only the most relevant ones for a query.

**`camel/toolkits/toolkit_manager.py` (new)**
- Aggregates `BaseToolkit` instances, `FunctionTool`s, and plain callables; de-duplicates by tool name.
- `search_tools(query, top_k=5, with_scores=False)` → ranked `List[FunctionTool]` (typed with `@overload`).
- Two pluggable backends:
  - `"bm25"` (default): keyword ranking via `rank_bm25`, **no API key required**.
  - `"embedding"`: semantic cosine similarity over any `BaseEmbedding` (defaults to `OpenAIEmbedding`).
- Indexes each tool's name, description, and parameter names/descriptions; the index rebuilds lazily when the tool set changes.
- `get_search_tools()` returns two agentic meta-tools — `search_tools` and `execute_tool` — so an agent can discover and call tools at runtime without ever seeing the full list. `execute_tool` is error-safe and suggests near-matches for an unknown name.

**Usage**

```python
manager = ToolkitManager([SearchToolkit(), MathToolkit(), SemanticScholarToolkit()])

# 1) Static pre-filter: hand the agent only the relevant tools
agent = ChatAgent(tools=manager.search_tools("download a paper", top_k=5))

# 2) Agentic discovery: agent searches the registry + calls tools on demand
agent = ChatAgent(tools=manager.get_search_tools())
```

**Other changes**
- `camel/toolkits/__init__.py`: export `ToolkitManager`.
- `test/toolkits/test_toolkit_manager.py` (new): 20 offline unit tests (uses a fake `BaseEmbedding`; `importorskip("rank_bm25")`).
- `examples/toolkits/toolkit_manager.py` (new): both usage patterns.

No `pyproject.toml` changes — `rank-bm25` and `numpy` are already declared, so `uv lock` was not needed.

#### Testing

`ruff check`, `mypy`, and the new unit tests pass locally (Windows, Python 3.10+):

```text
$ python -m pytest test/toolkits/test_toolkit_manager.py -v
collected 20 items

test_toolkit_manager.py::test_register_expands_toolkit_and_dedups PASSED
test_toolkit_manager.py::test_register_function_tool_and_callable PASSED
test_toolkit_manager.py::test_register_rejects_unsupported_type PASSED
test_toolkit_manager.py::test_init_validation PASSED
test_toolkit_manager.py::test_search_ranks_relevant_tool_first PASSED
test_toolkit_manager.py::test_search_respects_top_k_and_with_scores PASSED
test_toolkit_manager.py::test_search_top_k_larger_than_registry_returns_all PASSED
test_toolkit_manager.py::test_search_uses_default_top_k PASSED
test_toolkit_manager.py::test_search_index_refreshes_after_add PASSED
test_toolkit_manager.py::test_search_validation PASSED
test_toolkit_manager.py::test_search_on_empty_manager_returns_empty PASSED
test_toolkit_manager.py::test_embedding_backend_ranks_by_similarity PASSED
test_toolkit_manager.py::test_embedding_backend_handles_unmatched_query PASSED
test_toolkit_manager.py::test_get_search_tools_names PASSED
test_toolkit_manager.py::test_meta_search_tools_returns_descriptions PASSED
test_toolkit_manager.py::test_meta_search_tools_handles_bad_query PASSED
test_toolkit_manager.py::test_meta_execute_tool_runs_tool PASSED
test_toolkit_manager.py::test_meta_execute_tool_unknown_name_suggests_alternatives PASSED
test_toolkit_manager.py::test_meta_execute_tool_rejects_non_mapping_arguments PASSED
test_toolkit_manager.py::test_meta_execute_tool_reports_execution_error PASSED

============================= 20 passed in 2.99s ==============================

$ python -m ruff check camel/toolkits/toolkit_manager.py test/toolkits/test_toolkit_manager.py examples/toolkits/toolkit_manager.py
All checks passed!

$ python -m mypy --namespace-packages camel/toolkits/toolkit_manager.py test/toolkits/test_toolkit_manager.py
Success: no issues found
```

### What is the purpose of this pull request?

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Checklist

- [x] I have read and agree to the [AI-Generated Code Policy](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md#ai-generated-code-policy) (**required**)
- [x] I have linked this PR to an issue (**required**)
- [x] I have checked if any dependencies need to be added or updated in `pyproject.toml` and run `uv lock` — none needed (`rank-bm25`/`numpy` already declared)
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [x] I have updated the documentation if needed — class/method docstrings are complete; the API reference is auto-generated from them
- [x] I have added examples if this is a new feature