### PR TITLE
fix: only run API tests on PR to reduce OpenAI API costs

### DIFF
--- a/.github/workflows/pytest_apps.yml
+++ b/.github/workflows/pytest_apps.yml
@@ -4,12 +4,6 @@
 name: Pytest Gradio Apps and Examples
 
 on:
-  push:
-    branches: [ "master", "qa" ]
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
-      - "LICENSE"
   pull_request:
     branches: [ "master", "qa" ]
     paths-ignore:

--- a/.github/workflows/pytest_package.yml
+++ b/.github/workflows/pytest_package.yml
@@ -4,12 +4,6 @@
 name: Pytest Camel package
 
 on:
-  push:
-    branches: [ "master", "qa" ]
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
-      - "LICENSE"
   pull_request:
     branches: [ "master", "qa" ]
     paths-ignore:


### PR DESCRIPTION
## Summary

Remove push trigger from pytest workflows to prevent unnecessary OpenAI API calls on every git push.

## Changes

- Modified `.github/workflows/pytest_package.yml` to only run on PRs
- Modified `.github/workflows/pytest_apps.yml` to only run on PRs

## Why

Currently, API tests run on every push to the repository, which causes unnecessary OpenAI API calls and increases costs. By only running these tests on PRs, we can significantly reduce API usage while still maintaining code quality.

Fixes #364