### PR TITLE
fix: Summarize context up to the last user message

### DIFF
--- a/camel/agents/chat_agent.py
+++ b/camel/agents/chat_agent.py
@@ -1022,7 +1022,9 @@ class ChatAgent(BaseAgent):
                 f"Summary tokens ({summary_token_count}) "
                 f"exceed limit, full compression."
             )
-            summary = self.summarize(include_summaries=True)
+            summary = self.summarize(
+                include_summaries=True, exclude_last_user_message=True
+            )
             self._update_memory_with_summary(
                 summary.get("summary", ""), include_summaries=True
             )
@@ -1034,7 +1036,9 @@ class ChatAgent(BaseAgent):
                 f"Token count ({num_tokens}) exceed threshold "
                 f"({threshold}). Triggering summarization."
             )
-            summary = self.summarize(include_summaries=False)
+            summary = self.summarize(
+                include_summaries=False, exclude_last_user_message=True
+            )
             self._update_memory_with_summary(
                 summary.get("summary", ""), include_summaries=False
             )
@@ -1058,7 +1062,9 @@ class ChatAgent(BaseAgent):
                 f"Summary tokens ({summary_token_count}) "
                 f"exceed limit, full compression."
             )
-            summary = await self.asummarize(include_summaries=True)
+            summary = await self.asummarize(
+                include_summaries=True, exclude_last_user_message=True
+            )
             self._update_memory_with_summary(
                 summary.get("summary", ""), include_summaries=True
             )
@@ -1070,7 +1076,9 @@ class ChatAgent(BaseAgent):
                 f"Token count ({num_tokens}) exceed threshold "
                 f"({threshold}). Triggering summarization."
             )
-            summary = await self.asummarize(include_summaries=False)
+            summary = await self.asummarize(
+                include_summaries=False, exclude_last_user_message=True
+            )
             self._update_memory_with_summary(
                 summary.get("summary", ""), include_summaries=False
             )
@@ -1164,9 +1172,11 @@ class ChatAgent(BaseAgent):
         )
         self.update_memory(new_summary_msg, OpenAIBackendRole.ASSISTANT)
 
-        # Restore last user message to maintain conversation structure
-        # The summary already contains all user messages, but we keep the
-        # latest one so the model knows what to respond to
+        # Restore the last user message verbatim to maintain conversation
+        # structure. The automatic summarization flow summarizes the context
+        # up to (but excluding) this message, so re-appending it here keeps the
+        # model's most recent instruction intact instead of folded into the
+        # summary.
         if last_user_message:
             # Avoid duplicate prefix - check if already prefixed
             context_prefix = (
@@ -1723,6 +1733,7 @@ class ChatAgent(BaseAgent):
         working_directory: Optional[Union[str, Path]] = None,
         include_summaries: bool = False,
         add_user_messages: bool = True,
+        exclude_last_user_message: bool = False,
     ) -> Dict[str, Any]:
         r"""Summarize the agent's current conversation context and persist it
         to a markdown file.
@@ -1752,6 +1763,10 @@ class ChatAgent(BaseAgent):
                 directory used by ContextUtility.
             add_user_messages (bool): Whether add user messages to summary.
                 (default: :obj:`True`)
+            exclude_last_user_message (bool): Whether to exclude the most
+                recent user message from the summarized content. Used by the
+                automatic summarization flow, which re-appends that message
+                verbatim after the summary. (default: :obj:`False`)
         Returns:
             Dict[str, Any]: A dictionary containing the summary text, file
                 path, status message, and optionally structured_summary if
@@ -1798,7 +1813,7 @@ class ChatAgent(BaseAgent):
             # build conversation text using shared helper
             conversation_text, user_messages = (
                 self._build_conversation_text_from_messages(
-                    messages, include_summaries
+                    messages, include_summaries, exclude_last_user_message
                 )
             )
 
@@ -1955,6 +1970,7 @@ class ChatAgent(BaseAgent):
         self,
         messages: List[Any],
         include_summaries: bool = False,
+        exclude_last_user_message: bool = False,
     ) -> tuple[str, List[str]]:
         r"""Build conversation text from messages for summarization.
 
@@ -1966,16 +1982,37 @@ class ChatAgent(BaseAgent):
             messages (List[Any]): List of messages to convert.
             include_summaries (bool): Whether to include messages starting
                 with [CONTEXT_SUMMARY]. (default: :obj:`False`)
+            exclude_last_user_message (bool): Whether to exclude the most
+                recent user message from the conversation text. This is used
+                by the automatic summarization flow, which re-appends the last
+                user message verbatim after the summary so the model always
+                sees the latest instruction intact instead of folded into the
+                summary. (default: :obj:`False`)
 
         Returns:
             tuple[str, List[str]]: A tuple containing:
                 - Formatted conversation text
                 - List of user messages extracted from the conversation
         """
+        # Locate the most recent user message so it can be excluded from the
+        # summarized content when requested.
+        last_user_index = -1
+        if exclude_last_user_message:
+            for index, message in enumerate(messages):
+                content = message.get('content', '')
+                if (
+                    message.get('role') == 'user'
+                    and isinstance(content, str)
+                    and content
+                ):
+                    last_user_index = index
+
         # Convert messages to conversation text
         conversation_lines = []
         user_messages: List[str] = []
-        for message in messages:
+        for index, message in enumerate(messages):
+            if exclude_last_user_message and index == last_user_index:
+                continue
             role = message.get('role', 'unknown')
             content = message.get('content', '')
 
@@ -2172,6 +2209,7 @@ class ChatAgent(BaseAgent):
         working_directory: Optional[Union[str, Path]] = None,
         include_summaries: bool = False,
         add_user_messages: bool = True,
+        exclude_last_user_message: bool = False,
     ) -> Dict[str, Any]:
         r"""Asynchronously summarize the agent's current conversation context
         and persist it to a markdown file.
@@ -2201,6 +2239,10 @@ class ChatAgent(BaseAgent):
                 (full compression). (default: :obj:`False`)
             add_user_messages (bool): Whether add user messages to summary.
                 (default: :obj:`True`)
+            exclude_last_user_message (bool): Whether to exclude the most
+                recent user message from the summarized content. Used by the
+                automatic summarization flow, which re-appends that message
+                verbatim after the summary. (default: :obj:`False`)
 
         Returns:
             Dict[str, Any]: A dictionary containing the summary text, file
@@ -2238,7 +2280,7 @@ class ChatAgent(BaseAgent):
             # build conversation text using shared helper
             conversation_text, user_messages = (
                 self._build_conversation_text_from_messages(
-                    messages, include_summaries
+                    messages, include_summaries, exclude_last_user_message
                 )
             )
 

--- a/test/agents/test_chat_agent_summarize_context.py
+++ b/test/agents/test_chat_agent_summarize_context.py
@@ -1,0 +1,121 @@
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+r"""Tests for excluding the last user message from context summarization
+(see issue #3371)."""
+
+import pytest
+
+from camel.agents import ChatAgent
+from camel.models import BaseModelBackend
+from camel.types import ModelType
+
+
+class _DummyModel(BaseModelBackend):
+    r"""Offline model stub so a ChatAgent can be built without API calls.
+
+    ``_build_conversation_text_from_messages`` never invokes the model, so the
+    run methods are intentionally not implemented.
+    """
+
+    @property
+    def token_counter(self):
+        return self._token_counter
+
+    def _run(self, messages, response_format=None, tools=None):
+        raise NotImplementedError
+
+    async def _arun(self, messages, response_format=None, tools=None):
+        raise NotImplementedError
+
+
+@pytest.fixture
+def agent() -> ChatAgent:
+    return ChatAgent(model=_DummyModel(ModelType.GPT_4O_MINI))
+
+
+def _conversation():
+    return [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "First question about apples."},
+        {"role": "assistant", "content": "Here is the answer about apples."},
+        {"role": "user", "content": "Second question about bananas."},
+    ]
+
+
+def test_includes_last_user_message_by_default(agent: ChatAgent):
+    text, user_messages = agent._build_conversation_text_from_messages(
+        _conversation()
+    )
+    assert "Second question about bananas." in text
+    assert user_messages == [
+        "First question about apples.",
+        "Second question about bananas.",
+    ]
+
+
+def test_excludes_only_the_last_user_message(agent: ChatAgent):
+    text, user_messages = agent._build_conversation_text_from_messages(
+        _conversation(), exclude_last_user_message=True
+    )
+    # The most recent user message is dropped...
+    assert "Second question about bananas." not in text
+    # ...while earlier context is preserved.
+    assert "First question about apples." in text
+    assert "Here is the answer about apples." in text
+    assert user_messages == ["First question about apples."]
+
+
+def test_exclusion_is_noop_without_user_messages(agent: ChatAgent):
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "assistant", "content": "Nothing to respond to yet."},
+    ]
+    with_flag, _ = agent._build_conversation_text_from_messages(
+        messages, exclude_last_user_message=True
+    )
+    without_flag, _ = agent._build_conversation_text_from_messages(messages)
+    assert with_flag == without_flag
+    assert "Nothing to respond to yet." in with_flag
+
+
+def test_excludes_last_user_message_even_when_not_final(agent: ChatAgent):
+    # The last *user* message is not necessarily the final message; messages
+    # produced after it (assistant/tool) must be retained.
+    messages = [
+        {"role": "system", "content": "System."},
+        {"role": "user", "content": "Earlier user turn."},
+        {"role": "user", "content": "Latest user turn."},
+        {"role": "assistant", "content": "Assistant reply after user."},
+    ]
+    text, user_messages = agent._build_conversation_text_from_messages(
+        messages, exclude_last_user_message=True
+    )
+    assert "Latest user turn." not in text
+    assert "Earlier user turn." in text
+    assert "Assistant reply after user." in text
+    assert user_messages == ["Earlier user turn."]
+
+
+def test_empty_string_user_content_is_not_treated_as_last(agent: ChatAgent):
+    # A trailing empty user message must not be chosen as the one to exclude;
+    # the real last user message should be dropped instead.
+    messages = [
+        {"role": "user", "content": "Real instruction."},
+        {"role": "user", "content": ""},
+    ]
+    text, user_messages = agent._build_conversation_text_from_messages(
+        messages, exclude_last_user_message=True
+    )
+    assert "Real instruction." not in text
+    assert user_messages == []


### PR DESCRIPTION
### Related Issue

Closes #3371

### Description

Automatic context summarization (triggered as the context approaches the token limit) summarized the **entire** conversation and then re-appended the last user message verbatim, so the user's most recent instruction ended up **both** folded into the summary **and** appended after it. It also left the agent relying on the model to infer where to resume from within the summary.

This implements the enhancement requested in #3371: the summary now covers the context **up to (but excluding) the last user message**, which is kept verbatim after the summary. The resulting context is:

```
System Message
Context Summary
Last User Message
```

**Changes (`camel/agents/chat_agent.py`):**
- `_build_conversation_text_from_messages`: new opt-in `exclude_last_user_message` parameter that skips the most recent user message (from both the summarized text and the returned user-messages list).
- `summarize` / `asummarize`: thread the parameter through — **default `False`**, so the public API and existing callers are unchanged.
- `_get_context_with_summarization` (sync + async): the automatic summarization flow passes `exclude_last_user_message=True` on both the progressive and full-compression paths. `_update_memory_with_summary` already re-appends the last user message, so this simply removes today's duplication.

**Tests (`test/agents/test_chat_agent_summarize_context.py`):** 5 offline unit tests (no API key; dummy model backend) covering: default includes the last user message; exclusion drops only it; no-op when there are no user messages; exclusion works when the last user message isn't the final message; and a trailing empty-string user message isn't mistaken for it.

#### Testing

```text
$ python -m pytest test/agents/test_chat_agent_summarize_context.py -v
test_includes_last_user_message_by_default PASSED
test_excludes_only_the_last_user_message PASSED
test_exclusion_is_noop_without_user_messages PASSED
test_excludes_last_user_message_even_when_not_final PASSED
test_empty_string_user_content_is_not_treated_as_last PASSED
============================== 5 passed in 2.26s ==============================

$ python -m ruff check camel/agents/chat_agent.py test/agents/test_chat_agent_summarize_context.py
All checks passed!

$ python -m mypy --namespace-packages camel/agents/chat_agent.py test/agents/test_chat_agent_summarize_context.py
Success: no issues in changed files
```

Existing summarizer tests (`test_context_summarizer_toolkit.py`, `test_message_summarizer.py`) still pass; no regressions.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Checklist

- [x] I have read and agree to the [AI-Generated Code Policy](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md#ai-generated-code-policy) (**required**)
- [x] I have linked this PR to an issue (**required**)
- [x] I have checked if any dependencies need to be added or updated in `pyproject.toml` and run `uv lock` , no dependency changes
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [x] I have updated the documentation if needed, docstrings updated for the new parameter
- [ ] I have added examples if this is a new feature, N/A (behavior fix, not a new user-facing feature)