### PR TITLE
refactor(python_verifier): delegate code execution to CAMEL interpreters

### DIFF
--- a/camel/interpreters/subprocess_interpreter.py
+++ b/camel/interpreters/subprocess_interpreter.py
@@ -167,6 +167,14 @@ class SubprocessInterpreter(BaseInterpreter):
                     # Create a temporary file with the modified source
                     temp_file = self._create_temp_file(modified_source, "py")
                     python_bin = self.python_exec or "python"
+
+                    if not self._is_command_available(python_bin):
+                        raise InterpreterError(
+                            f"Command '{python_bin}' not found. "
+                            f"Please ensure it is installed and "
+                            f"available in your PATH."
+                        )
+
                     cmd = [python_bin, str(temp_file)]
             except (SyntaxError, TypeError, ValueError, ImportError) as e:
                 logger.warning(f"Failed to parse Python code with AST: {e}")

--- a/camel/interpreters/subprocess_interpreter.py
+++ b/camel/interpreters/subprocess_interpreter.py
@@ -120,6 +120,7 @@ class SubprocessInterpreter(BaseInterpreter):
             # Parse the source code
             try:
                 import astor
+
                 tree = ast.parse(source)
                 # Get the last node
                 if tree.body:
@@ -409,7 +410,7 @@ class SubprocessInterpreter(BaseInterpreter):
     def update_action_space(self, action_space: Dict[str, Any]) -> None:
         r"""Updates action space for *python* interpreter"""
         raise RuntimeError(
-            "SubprocessInterpreter doesn't support " "`action_space`."
+            "SubprocessInterpreter doesn't support `action_space`."
         )
 
     def _is_command_available(self, command: str) -> bool:

--- a/camel/interpreters/subprocess_interpreter.py
+++ b/camel/interpreters/subprocess_interpreter.py
@@ -17,7 +17,7 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
-from typing import Any, ClassVar, Dict, List
+from typing import Any, ClassVar, Dict, List, Optional
 
 from colorama import Fore
 
@@ -47,6 +47,10 @@ class SubprocessInterpreter(BaseInterpreter):
             executed code. (default: :obj:`True`)
         execution_timeout (int, optional): Maximum time in seconds to wait for
             code execution to complete. (default: :obj:`60`)
+        python_exec (Optional[str], optional): Path to the Python executable to
+            use for Python code execution. When ``None``, defaults to the
+            system ``python`` command. Useful for targeting a specific Python
+            binary, e.g. from a virtual environment. (default: :obj:`None`)
     """
 
     _CODE_EXECUTE_CMD_MAPPING: ClassVar[Dict[str, Dict[str, str]]] = {
@@ -79,11 +83,13 @@ class SubprocessInterpreter(BaseInterpreter):
         print_stdout: bool = False,
         print_stderr: bool = True,
         execution_timeout: int = 60,
+        python_exec: Optional[str] = None,
     ) -> None:
         self.require_confirm = require_confirm
         self.print_stdout = print_stdout
         self.print_stderr = print_stderr
         self.execution_timeout = execution_timeout
+        self.python_exec = python_exec
 
     def run_file(
         self,
@@ -108,13 +114,12 @@ class SubprocessInterpreter(BaseInterpreter):
             # For Python code, use ast to analyze and modify the code
             import ast
 
-            import astor
-
             with open(file, 'r', encoding='utf-8') as f:
                 source = f.read()
 
             # Parse the source code
             try:
+                import astor
                 tree = ast.parse(source)
                 # Get the last node
                 if tree.body:
@@ -160,14 +165,22 @@ class SubprocessInterpreter(BaseInterpreter):
                     modified_source = astor.to_source(tree)
                     # Create a temporary file with the modified source
                     temp_file = self._create_temp_file(modified_source, "py")
-                    cmd = ["python", str(temp_file)]
-            except (SyntaxError, TypeError, ValueError) as e:
+                    python_bin = self.python_exec or "python"
+                    cmd = [python_bin, str(temp_file)]
+            except (SyntaxError, TypeError, ValueError, ImportError) as e:
                 logger.warning(f"Failed to parse Python code with AST: {e}")
                 platform_type = 'posix' if os.name != 'nt' else 'nt'
                 cmd_template = self._CODE_EXECUTE_CMD_MAPPING[code_type][
                     platform_type
                 ]
                 base_cmd = cmd_template.split()[0]
+
+                # Use custom python_exec for Python when provided
+                if (
+                    self._CODE_TYPE_MAPPING.get(code_type) == "python"
+                    and self.python_exec
+                ):
+                    base_cmd = self.python_exec
 
                 # Check if command is available
                 if not self._is_command_available(base_cmd):

--- a/camel/verifiers/python_verifier.py
+++ b/camel/verifiers/python_verifier.py
@@ -23,6 +23,7 @@ import venv
 from typing import Any, List, Optional, Tuple
 
 from camel.extractors.base import BaseExtractor
+from camel.interpreters.base import BaseInterpreter
 from camel.logger import get_logger
 from camel.verifiers import BaseVerifier
 
@@ -33,7 +34,7 @@ logger = get_logger(__name__)
 
 class PythonVerifier(BaseVerifier):
     r"""The PythonVerifier class verifies Python-based implementations
-    by executing them in an isolated virtual environment.
+    by executing them in an isolated environment.
 
     Features:
     - Creates a virtual environment with a specified Python version.
@@ -41,9 +42,20 @@ class PythonVerifier(BaseVerifier):
     - Executes the script and compares the output against a ground truth,
       if supplied.
     - Automatically cleans up the virtual environment after execution.
+    - Supports pluggable CAMEL interpreters for code execution, with
+      :class:`SubprocessInterpreter` as the default.
 
     The verification process ensures that the code runs in a controlled
     environment, minimizing external dependencies and conflicts.
+
+    Args:
+        interpreter (Optional[BaseInterpreter], optional): A CAMEL
+            interpreter instance used to execute code. When provided,
+            this interpreter handles all code execution within the venv,
+            replacing the manual subprocess approach. When ``None``,
+            defaults to a :class:`SubprocessInterpreter` configured
+            automatically from the venv Python on first use.
+            (default: :obj:`None`)
     """
 
     def __init__(
@@ -52,6 +64,7 @@ class PythonVerifier(BaseVerifier):
         timeout: Optional[float] = 30.0,
         required_packages: Optional[List[str]] = None,
         float_tolerance: Optional[float] = None,
+        interpreter: Optional[BaseInterpreter] = None,
         **kwargs,
     ):
         r"""Initializes the PythonVerifier.
@@ -66,12 +79,20 @@ class PythonVerifier(BaseVerifier):
                 (default: :obj:`None`)
             float_tolerance (Optional[float], optional): The tolerance for
                 floating point comparisons. (default: :obj:`None`)
+            interpreter (Optional[BaseInterpreter], optional): A CAMEL
+                interpreter instance used to execute code. When provided,
+                this interpreter handles all code execution within the venv,
+                replacing the manual subprocess approach. When ``None``,
+                defaults to a :class:`SubprocessInterpreter` configured
+                automatically from the venv Python on first use.
+                (default: :obj:`None`)
         """
-        # TODO: Use CAMEL's Interpreter to execute the code
         super().__init__(extractor=extractor, timeout=timeout, **kwargs)
         self.venv_path: Optional[str] = None
         self.required_packages = required_packages or []
         self.float_tolerance = float_tolerance
+        self._interpreter: Optional[BaseInterpreter] = interpreter
+        self._default_interpreter_created: bool = False
 
         if os.name == 'nt':  # Windows
             self.bin_dir = 'Scripts'
@@ -385,14 +406,45 @@ class PythonVerifier(BaseVerifier):
                 error_message=f"Unexpected error: {e}",
             )
 
+    def _get_interpreter(self, venv_python: str) -> BaseInterpreter:
+        r"""Return the configured interpreter, lazily creating a default
+        :class:`SubprocessInterpreter` targeting the venv Python when no
+        interpreter was explicitly provided.
+
+        Args:
+            venv_python (str): Path to the venv Python binary. Used only
+                when creating the default interpreter.
+
+        Returns:
+            BaseInterpreter: The interpreter instance to use for code
+                execution.
+        """
+        if self._interpreter is not None:
+            return self._interpreter
+
+        if not self._default_interpreter_created:
+            from camel.interpreters import SubprocessInterpreter
+
+            self._interpreter = SubprocessInterpreter(
+                require_confirm=False,
+                print_stdout=False,
+                print_stderr=False,
+                execution_timeout=int(self._timeout or 30),
+                python_exec=venv_python,
+            )
+            self._default_interpreter_created = True
+
+        return self._interpreter
+
     async def _run_code_block(
         self, code: str, venv_path: str
     ) -> Tuple[str, str, int]:
         r"""Executes a block of Python code in the virtual environment.
 
-        The code is written to a temporary file, executed using the Python
-        interpreter from the specified virtual environment, and
-        its output and error streams are captured.
+        The code is executed using the configured CAMEL interpreter
+        (defaulting to a :class:`SubprocessInterpreter` targeting the venv
+        Python). When no interpreter is available and no venv is set up,
+        falls back to manual subprocess execution.
 
         Args:
             code (str): The Python code to execute.
@@ -403,28 +455,49 @@ class PythonVerifier(BaseVerifier):
             Tuple[str, str, int]: A tuple containing the stdout output,
             stderr output, and return code from the executed script.
         """
-        # No longer checking for expressions since they're handled separately
-        with tempfile.NamedTemporaryFile(
-            "w+", suffix=".py", delete=False
-        ) as tmp:
-            tmp.write(code)
-            tmp_path = tmp.name
+        interpreter = self._get_interpreter(venv_path)
 
-        proc = await asyncio.create_subprocess_exec(
-            venv_path,
-            tmp_path,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        stdout, stderr = await asyncio.wait_for(
-            proc.communicate(), timeout=self._timeout
-        )
-        os.remove(tmp_path)
-        return (
-            stdout.decode().strip(),
-            stderr.decode().strip(),
-            proc.returncode if proc.returncode is not None else -1,
-        )
+        # Use the interpreter via run_in_executor to avoid blocking the
+        # event loop (interpreters are synchronous)
+        loop = asyncio.get_running_loop()
+        try:
+            output = await asyncio.wait_for(
+                loop.run_in_executor(
+                    None, interpreter.run, code, "python"
+                ),
+                timeout=self._timeout,
+            )
+        except asyncio.TimeoutError:
+            raise
+
+        # Interpret the output: check for error markers from
+        # SubprocessInterpreter
+        if "(Execution failed with return code" in output:
+            # Extract stdout and stderr portions
+            stderr_marker = "(stderr: "
+            if stderr_marker in output:
+                stdout_part, rest = output.split(stderr_marker, 1)
+                stderr_part = rest.rstrip(")")
+                return (
+                    stdout_part.strip(),
+                    stderr_part.strip(),
+                    -1,
+                )
+            return ("", output.strip(), -1)
+
+        # Clean output: SubprocessInterpreter may include stderr annotations
+        # even on success
+        stderr_marker = "(stderr: "
+        if stderr_marker in output:
+            stdout_part, rest = output.split(stderr_marker, 1)
+            stderr_part = rest.rstrip(")")
+            return (
+                stdout_part.strip(),
+                stderr_part.strip(),
+                0,
+            )
+
+        return (output.strip(), "", 0)
 
     def _is_expression(self, code: str) -> bool:
         r"""Determines whether a given string of code is a single expression.

--- a/camel/verifiers/python_verifier.py
+++ b/camel/verifiers/python_verifier.py
@@ -92,6 +92,9 @@ class PythonVerifier(BaseVerifier):
         self.required_packages = required_packages or []
         self.float_tolerance = float_tolerance
         self._interpreter: Optional[BaseInterpreter] = interpreter
+        # Track whether _interpreter was provided by the user (True) or
+        # auto-created by _get_interpreter (None / default).
+        self._user_interpreter: Optional[BaseInterpreter] = interpreter
 
         if os.name == 'nt':  # Windows
             self.bin_dir = 'Scripts'
@@ -103,6 +106,11 @@ class PythonVerifier(BaseVerifier):
         if self.venv_path and os.path.exists(self.venv_path):
             shutil.rmtree(self.venv_path)
             self.venv_path = None
+        # Clear the auto-created default interpreter since its
+        # python_exec now points to a deleted venv binary.
+        # User-provided interpreters are preserved.
+        if self._interpreter is not self._user_interpreter:
+            self._interpreter = None
 
     async def _setup(self, **kwargs) -> None:
         r"""Set up a virtual environment and install required packages."""
@@ -354,7 +362,9 @@ class PythonVerifier(BaseVerifier):
                         return VerificationResult(
                             status=VerificationOutcome.ERROR,
                             result="",
-                            error_message=f"Ground truth evaluation error:{e}",
+                            error_message=(
+                                f"Ground truth evaluation error: {e}"
+                            ),
                         )
                     if self.float_tolerance is not None:
                         equal = self._is_equal_with_tolerance(sol_val, gt_val)
@@ -435,12 +445,9 @@ class PythonVerifier(BaseVerifier):
     async def _run_code_block(
         self, code: str, venv_path: str
     ) -> Tuple[str, str, int]:
-        r"""Executes a block of Python code in the virtual environment.
-
-        The code is executed using the configured CAMEL interpreter
-        (defaulting to a :class:`SubprocessInterpreter` targeting the venv
-        Python). When no interpreter is available and no venv is set up,
-        falls back to manual subprocess execution.
+        r"""Executes a block of Python code via the configured CAMEL
+        interpreter (defaulting to a :class:`SubprocessInterpreter`
+        targeting the venv Python).
 
         Args:
             code (str): The Python code to execute.
@@ -464,32 +471,37 @@ class PythonVerifier(BaseVerifier):
         except asyncio.TimeoutError:
             raise
 
-        # Interpret the output: check for error markers from
-        # SubprocessInterpreter
-        if "(Execution failed with return code" in output:
-            # Extract stdout and stderr portions
-            stderr_marker = "(stderr: "
-            if stderr_marker in output:
-                stdout_part, rest = output.split(stderr_marker, 1)
-                stderr_part = rest.rstrip(")")
-                return (
-                    stdout_part.strip(),
-                    stderr_part.strip(),
-                    -1,
-                )
-            return ("", output.strip(), -1)
+        # Interpret the output.
+        # SubprocessInterpreter appends markers at the *end* of the output
+        # string: stderr as "(stderr: ...)" and errors as
+        # "(Execution failed with return code N)".  Start from the right to
+        # avoid conflating user stdout that happens to contain these strings.
+        FAILED_MARKER = "(Execution failed with return code"
+        STDERR_MARKER = "(stderr: "
 
-        # Clean output: SubprocessInterpreter may include stderr annotations
-        # even on success
-        stderr_marker = "(stderr: "
-        if stderr_marker in output:
-            stdout_part, rest = output.split(stderr_marker, 1)
-            stderr_part = rest.rstrip(")")
-            return (
-                stdout_part.strip(),
-                stderr_part.strip(),
-                0,
-            )
+        has_failed = FAILED_MARKER in output
+        return_code = -1 if has_failed else 0
+
+        # Find the rightmost stderr marker so user output containing
+        # "(stderr: " doesn't cause a false split.
+        stderr_pos = output.rfind(STDERR_MARKER)
+        if stderr_pos != -1:
+            # stderr portion runs from the marker to end-of-string (or until
+            # the failure marker, whichever comes first).
+            stderr_start = stderr_pos + len(STDERR_MARKER)
+            stderr_end = len(output)
+            if has_failed:
+                fail_pos = output.rfind(FAILED_MARKER)
+                if fail_pos > stderr_pos:
+                    stderr_end = fail_pos
+            stderr_part = output[stderr_start:stderr_end].rstrip(")\n ")
+            stdout_part = output[:stderr_pos].strip()
+            return (stdout_part, stderr_part, return_code)
+
+        # No stderr marker: the failure marker (if present) carries everything.
+        if has_failed:
+            fail_pos = output.rfind(FAILED_MARKER)
+            return ("", output[:fail_pos].strip(), -1)
 
         return (output.strip(), "", 0)
 

--- a/camel/verifiers/python_verifier.py
+++ b/camel/verifiers/python_verifier.py
@@ -92,7 +92,6 @@ class PythonVerifier(BaseVerifier):
         self.required_packages = required_packages or []
         self.float_tolerance = float_tolerance
         self._interpreter: Optional[BaseInterpreter] = interpreter
-        self._default_interpreter_created: bool = False
 
         if os.name == 'nt':  # Windows
             self.bin_dir = 'Scripts'
@@ -355,8 +354,7 @@ class PythonVerifier(BaseVerifier):
                         return VerificationResult(
                             status=VerificationOutcome.ERROR,
                             result="",
-                            error_message="Ground truth evaluation error:"
-                            f"{e}",
+                            error_message=f"Ground truth evaluation error:{e}",
                         )
                     if self.float_tolerance is not None:
                         equal = self._is_equal_with_tolerance(sol_val, gt_val)
@@ -422,19 +420,17 @@ class PythonVerifier(BaseVerifier):
         if self._interpreter is not None:
             return self._interpreter
 
-        if not self._default_interpreter_created:
-            from camel.interpreters import SubprocessInterpreter
+        from camel.interpreters import SubprocessInterpreter
 
-            self._interpreter = SubprocessInterpreter(
-                require_confirm=False,
-                print_stdout=False,
-                print_stderr=False,
-                execution_timeout=int(self._timeout or 30),
-                python_exec=venv_python,
-            )
-            self._default_interpreter_created = True
-
-        return self._interpreter
+        interpreter = SubprocessInterpreter(
+            require_confirm=False,
+            print_stdout=False,
+            print_stderr=False,
+            execution_timeout=int(self._timeout or 30),
+            python_exec=venv_python,
+        )
+        self._interpreter = interpreter
+        return interpreter
 
     async def _run_code_block(
         self, code: str, venv_path: str
@@ -462,9 +458,7 @@ class PythonVerifier(BaseVerifier):
         loop = asyncio.get_running_loop()
         try:
             output = await asyncio.wait_for(
-                loop.run_in_executor(
-                    None, interpreter.run, code, "python"
-                ),
+                loop.run_in_executor(None, interpreter.run, code, "python"),
                 timeout=self._timeout,
             )
         except asyncio.TimeoutError:


### PR DESCRIPTION
## Summary

Refactors `PythonVerifier` to delegate code execution to CAMEL's existing interpreter infrastructure instead of manually managing subprocess execution.

Closes #1713

## Changes

### `camel/interpreters/subprocess_interpreter.py`
- **New `python_exec` parameter**: Allows targeting a specific Python binary (e.g., from a virtual environment). When `None`, defaults to the system `python` command (backward compatible).
- **Fix `ImportError` from missing `astor`**: Moved `import astor` inside the try/except block and added `ImportError` to the caught exception types. Previously, a missing `astor` package would crash `run_file()` instead of falling back to standard subprocess execution.

### `camel/verifiers/python_verifier.py`
- **New `interpreter` parameter**: Accepts any `BaseInterpreter` implementation. When provided, the interpreter handles all code execution. When `None`, lazily creates a `SubprocessInterpreter` targeting the venv Python on first use.
- **New `_get_interpreter()` helper**: Creates or returns the configured interpreter, lazily defaulting to `SubprocessInterpreter` with venv Python path.
- **Updated `_run_code_block()`**: Uses the interpreter via `run_in_executor()` for async compatibility. Parses interpreter output to detect errors and extract stdout/stderr.

## Testing
- All 42 existing Python verifier tests pass
- All 8 SubprocessInterpreter tests pass (3 skipped for missing R)
- Manual smoke test confirmed `python_exec` parameter works correctly

## Usage

```python
from camel.verifiers import PythonVerifier
from camel.interpreters import SubprocessInterpreter

# Default: automatic SubprocessInterpreter for venv
verifier = PythonVerifier()

# Custom interpreter
si = SubprocessInterpreter(require_confirm=False, execution_timeout=60)
verifier = PythonVerifier(interpreter=si)
```