### PR TITLE
feat(retrievers): add optional reranker stage to HybridRetriever

### DIFF
--- a/camel/retrievers/__init__.py
+++ b/camel/retrievers/__init__.py
@@ -14,6 +14,7 @@
 # ruff: noqa: I001
 from .auto_retriever import AutoRetriever
 from .base import BaseRetriever
+from .base_rerank import BaseRerankRetriever
 from .bm25_retriever import BM25Retriever
 from .jina_rerank_retriever import JinaRerankRetriever
 from .cohere_rerank_retriever import CohereRerankRetriever
@@ -21,11 +22,12 @@ from .vector_retriever import VectorRetriever
 from .hybrid_retrival import HybridRetriever
 
 __all__ = [
-    'BaseRetriever',
-    'VectorRetriever',
     'AutoRetriever',
     'BM25Retriever',
-    'JinaRerankRetriever',
+    'BaseRerankRetriever',
+    'BaseRetriever',
     'CohereRerankRetriever',
     'HybridRetriever',
+    'JinaRerankRetriever',
+    'VectorRetriever',
 ]

--- a/camel/retrievers/base_rerank.py
+++ b/camel/retrievers/base_rerank.py
@@ -1,0 +1,57 @@
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+from abc import abstractmethod
+from typing import Any, Dict, List
+
+from camel.retrievers.base import BaseRetriever
+
+DEFAULT_TOP_K_RESULTS = 1
+
+
+class BaseRerankRetriever(BaseRetriever):
+    r"""Abstract base class for re-ranking retrievers.
+
+    A re-ranking retriever takes a query together with a list of already
+    retrieved results (for example, the output of a :class:`VectorRetriever`,
+    a :class:`BM25Retriever`, or a :class:`HybridRetriever`) and re-orders
+    those results by their semantic relevance to the query, typically using a
+    cross-encoder or a dedicated re-ranking API.
+
+    Unlike first-stage retrievers, re-rankers do not ingest content, so the
+    :meth:`process` method is not required and is left unimplemented.
+    """
+
+    @abstractmethod
+    def query(
+        self,
+        query: str,
+        retrieved_result: List[Dict[str, Any]],
+        top_k: int = DEFAULT_TOP_K_RESULTS,
+    ) -> List[Dict[str, Any]]:
+        r"""Re-ranks the given retrieved results against the query.
+
+        Args:
+            query (str): The query string used for re-ranking.
+            retrieved_result (List[Dict[str, Any]]): The content to be
+                re-ranked, typically the output of a first-stage retriever.
+                Each item should contain a ``'text'`` entry.
+            top_k (int, optional): The number of top results to return after
+                re-ranking. Must be a positive integer. (default:
+                :obj:`DEFAULT_TOP_K_RESULTS`)
+
+        Returns:
+            List[Dict[str, Any]]: The re-ranked results, each containing the
+                original data plus an updated ``'similarity score'``.
+        """
+        raise NotImplementedError

--- a/camel/retrievers/cohere_rerank_retriever.py
+++ b/camel/retrievers/cohere_rerank_retriever.py
@@ -14,13 +14,13 @@
 import os
 from typing import Any, Dict, List, Optional
 
-from camel.retrievers import BaseRetriever
+from camel.retrievers.base_rerank import BaseRerankRetriever
 from camel.utils import api_keys_required, dependencies_required
 
 DEFAULT_TOP_K_RESULTS = 1
 
 
-class CohereRerankRetriever(BaseRetriever):
+class CohereRerankRetriever(BaseRerankRetriever):
     r"""An implementation of the `BaseRetriever` using the `Cohere Re-ranking`
     model.
 

--- a/camel/retrievers/hybrid_retrival.py
+++ b/camel/retrievers/hybrid_retrival.py
@@ -230,7 +230,11 @@ class HybridRetriever(BaseRetriever):
 
         # When a reranker is used, fuse a larger candidate pool first and let
         # the reranker decide the final top_k ordering.
-        fusion_top_k = max(top_k, rerank_input_top_k) if reranker else top_k
+        fusion_top_k = (
+            max(top_k, rerank_input_top_k)
+            if reranker is not None
+            else top_k
+        )
 
         all_retrieved_info = self._sort_rrf_scores(
             vector_retriever_results,

--- a/camel/retrievers/hybrid_retrival.py
+++ b/camel/retrievers/hybrid_retrival.py
@@ -15,6 +15,7 @@ from typing import Any, Dict, List, Optional, Union
 
 from camel.embeddings import BaseEmbedding
 from camel.retrievers import BaseRetriever, BM25Retriever, VectorRetriever
+from camel.retrievers.base_rerank import BaseRerankRetriever
 from camel.storages import BaseVectorStorage
 from camel.utils import dependencies_required
 
@@ -163,6 +164,8 @@ class HybridRetriever(BaseRetriever):
         vector_retriever_similarity_threshold: float = 0.5,
         bm25_retriever_top_k: int = 50,
         return_detailed_info: bool = False,
+        reranker: Optional[BaseRerankRetriever] = None,
+        rerank_input_top_k: int = 50,
     ) -> Dict[str, Any]:
         r"""Executes a hybrid retrieval query using both vector and BM25
         retrievers.
@@ -178,6 +181,15 @@ class HybridRetriever(BaseRetriever):
                 threshold for vector retriever.
             bm25_retriever_top_k (int): Top results from BM25 retriever.
             return_detailed_info (bool): Return detailed info if True.
+            reranker (Optional[BaseRerankRetriever]): An optional re-ranking
+                retriever (e.g. :class:`CohereRerankRetriever` or
+                :class:`JinaRerankRetriever`). When provided, the fused
+                results are re-ordered by the reranker before being truncated
+                to ``top_k``, forming a retrieve -> fuse -> rerank pipeline.
+                (default: :obj:`None`)
+            rerank_input_top_k (int): The number of top fused candidates fed
+                into the reranker. Only used when ``reranker`` is provided.
+                (default: :obj:`50`)
 
         Returns:
             Union[
@@ -216,14 +228,25 @@ class HybridRetriever(BaseRetriever):
             top_k=bm25_retriever_top_k,
         )
 
+        # When a reranker is used, fuse a larger candidate pool first and let
+        # the reranker decide the final top_k ordering.
+        fusion_top_k = max(top_k, rerank_input_top_k) if reranker else top_k
+
         all_retrieved_info = self._sort_rrf_scores(
             vector_retriever_results,
             bm25_retriever_results,
-            top_k,
+            fusion_top_k,
             vector_weight,
             bm25_weight,
             rank_smoothing_factor,
         )
+
+        if reranker is not None and all_retrieved_info:
+            all_retrieved_info = reranker.query(
+                query=query,
+                retrieved_result=all_retrieved_info,  # type: ignore[arg-type]
+                top_k=top_k,
+            )
 
         retrieved_info = {
             "Original Query": query,

--- a/camel/retrievers/hybrid_retrival.py
+++ b/camel/retrievers/hybrid_retrival.py
@@ -231,9 +231,7 @@ class HybridRetriever(BaseRetriever):
         # When a reranker is used, fuse a larger candidate pool first and let
         # the reranker decide the final top_k ordering.
         fusion_top_k = (
-            max(top_k, rerank_input_top_k)
-            if reranker is not None
-            else top_k
+            max(top_k, rerank_input_top_k) if reranker is not None else top_k
         )
 
         all_retrieved_info = self._sort_rrf_scores(

--- a/camel/retrievers/jina_rerank_retriever.py
+++ b/camel/retrievers/jina_rerank_retriever.py
@@ -14,7 +14,7 @@
 import os
 from typing import Any, Dict, List, Union
 
-from camel.retrievers import BaseRetriever
+from camel.retrievers.base_rerank import BaseRerankRetriever
 from camel.types.enums import JinaRerankerModelType
 from camel.utils import api_keys_required, dependencies_required
 
@@ -22,7 +22,7 @@ DEFAULT_TOP_K_RESULTS = 1
 JINA_RERANK_API_URL = "https://api.jina.ai/v1/rerank"
 
 
-class JinaRerankRetriever(BaseRetriever):
+class JinaRerankRetriever(BaseRerankRetriever):
     r"""An implementation of the `BaseRetriever` using the `Jina AI Reranker`
     model.
 

--- a/test/retrievers/test_hybrid_retriever.py
+++ b/test/retrievers/test_hybrid_retriever.py
@@ -60,3 +60,38 @@ def test_sort_rrf_scores_integration(mock_hybrid_retriever):
     assert len(results['Retrieved Context']) == 2
     assert results['Retrieved Context'][0]['text'] == 'Document 2'
     assert results['Retrieved Context'][1]['text'] == 'Document 1'
+
+
+def test_query_with_reranker(mock_hybrid_retriever):
+    # A mock reranker that reverses the fused order and returns top_k items.
+    def _rerank(query, retrieved_result, top_k):
+        reranked = list(reversed(retrieved_result))[:top_k]
+        for i, item in enumerate(reranked):
+            item['similarity score'] = 1.0 - i * 0.1
+        return reranked
+
+    reranker = MagicMock()
+    reranker.query = MagicMock(side_effect=_rerank)
+
+    results = mock_hybrid_retriever.query(
+        query="some query about document 1",
+        top_k=2,
+        return_detailed_info=True,
+        reranker=reranker,
+    )
+
+    # Reranker must have been invoked once with the fused candidates.
+    reranker.query.assert_called_once()
+    _, kwargs = reranker.query.call_args
+    assert kwargs['top_k'] == 2
+
+    # The reranker receives the full fused candidate pool (Document 2,
+    # Document 1, Document 3 by RRF), reverses it, and returns the top 2.
+    _, kwargs = reranker.query.call_args
+    assert len(kwargs['retrieved_result']) == 3
+
+    # Final order should reflect the reranker's reordering, not the raw RRF.
+    context = results['Retrieved Context']
+    assert len(context) == 2
+    assert context[0]['text'] == 'Document 3'
+    assert context[1]['text'] == 'Document 1'


### PR DESCRIPTION
### Related Issue

Closes #4132

### Description

`HybridRetriever` previously stopped at RRF fusion of vector + BM25 results, with no way to apply a re-ranking model as a final precision stage. This PR adds an optional reranker, completing the standard **retrieve -> fuse -> rerank** RAG pipeline.

Changes:
- Add `BaseRerankRetriever`, a shared base class for re-ranking retrievers, and make `CohereRerankRetriever` and `JinaRerankRetriever` inherit from it (no behavior change to the existing rerankers).
- `HybridRetriever.query` now accepts an optional `reranker` (and `rerank_input_top_k`). When provided, a larger fused candidate pool is built first, then re-ordered by the reranker down to `top_k`. When omitted, behavior is unchanged.
- Add a unit test covering the reranker path.

The change is backward compatible (`reranker` defaults to `None`) and reuses the existing reranker implementations.

### What is the purpose of this pull request?

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Checklist

- [x] I have read and agree to the [AI-Generated Code Policy](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md#ai-generated-code-policy) (**required**)
- [x] I have linked this PR to an issue (**required**)
- [ ] I have checked if any dependencies need to be added or updated in `pyproject.toml` and run `uv lock`
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed
- [ ] I have added examples if this is a new feature

### Note

This contribution was developed with the assistance of Claude (Anthropic). All code has been reviewed and tested by me; the new and existing hybrid-retriever unit tests pass locally.