### PR TITLE
feat(bots): use api_keys_required decorators

### DIFF
--- a/camel/bots/slack/slack_app.py
+++ b/camel/bots/slack/slack_app.py
@@ -26,7 +26,7 @@ from camel.bots.slack.models import (
     SlackEventBody,
     SlackEventProfile,
 )
-from camel.utils import dependencies_required
+from camel.utils import api_keys_required, dependencies_required
 
 if TYPE_CHECKING:
     from slack_bolt.context.async_context import AsyncBoltContext
@@ -58,6 +58,13 @@ class SlackApp:
     """
 
     @dependencies_required('slack_bolt')
+    @api_keys_required(
+        [
+            ("token", "SLACK_TOKEN"),
+            ("scopes", "SLACK_SCOPES"),
+            ("signing_secret", "SLACK_SIGNING_SECRET"),
+        ]
+    )
     def __init__(
         self,
         token: Optional[str] = None,
@@ -100,13 +107,6 @@ class SlackApp:
         self.client_secret: Optional[str] = client_secret or os.getenv(
             "SLACK_CLIENT_SECRET"
         )
-
-        if not all([self.token, self.scopes, self.signing_secret]):
-            raise ValueError(
-                "`SLACK_TOKEN`, `SLACK_SCOPES`, and `SLACK_SIGNING_SECRET` "
-                "environment variables must be set. Get it here: "
-                "`https://api.slack.com/apps`."
-            )
 
         # Setup OAuth settings if client ID and secret are provided
         if self.client_id and self.client_secret:

--- a/camel/bots/telegram_bot.py
+++ b/camel/bots/telegram_bot.py
@@ -46,6 +46,7 @@ class TelegramBot:
         self.chat_agent = chat_agent
 
         self.token = telegram_token or os.getenv('TELEGRAM_TOKEN')
+        assert self.token is not None
 
         import telebot  # type: ignore[import-untyped]
 

--- a/camel/bots/telegram_bot.py
+++ b/camel/bots/telegram_bot.py
@@ -15,7 +15,7 @@ import os
 from typing import TYPE_CHECKING, Optional
 
 from camel.agents import ChatAgent
-from camel.utils import dependencies_required
+from camel.utils import api_keys_required, dependencies_required
 
 # Conditionally import telebot types only for type checking
 if TYPE_CHECKING:
@@ -33,6 +33,11 @@ class TelegramBot:
     """
 
     @dependencies_required('telebot')
+    @api_keys_required(
+        [
+            ("telegram_token", "TELEGRAM_TOKEN"),
+        ]
+    )
     def __init__(
         self,
         chat_agent: ChatAgent,
@@ -40,15 +45,7 @@ class TelegramBot:
     ) -> None:
         self.chat_agent = chat_agent
 
-        if not telegram_token:
-            self.token = os.getenv('TELEGRAM_TOKEN')
-            if not self.token:
-                raise ValueError(
-                    "`TELEGRAM_TOKEN` not found in environment variables. "
-                    "Get it from t.me/BotFather."
-                )
-        else:
-            self.token = telegram_token
+        self.token = telegram_token or os.getenv('TELEGRAM_TOKEN')
 
         import telebot  # type: ignore[import-untyped]
 

--- a/camel/utils/commons.py
+++ b/camel/utils/commons.py
@@ -343,6 +343,10 @@ def api_keys_required(
                     'ORCAROUTER_API_KEY': "https://www.orcarouter.ai/",
                     'QUERIT_API_KEY': "https://www.querit.ai/en/dashboard/home",
                     'PERPLEXITY_API_KEY': "https://www.perplexity.ai/account/api",
+                    'TELEGRAM_TOKEN': 'https://t.me/BotFather',
+                    'SLACK_TOKEN': "https://api.slack.com/apps",
+                    'SLACK_SCOPES': "https://api.slack.com/apps",
+                    'SLACK_SIGNING_SECRET': "https://api.slack.com/apps",
                 }
                 key_way = env_key_urls.get(
                     missing_keys[0], "the official website"


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Related Issue

<!-- REQUIRED: Link to the issue this PR resolves. PRs without a linked issue will be closed. -->
<!-- Example: Closes #123 or Fixes #456 -->

Closes #1043

### Description

This PR refactors the Telegram and Slack bots to use the @api_keys_required decorator, bringing them in line with the pattern already adopted across other CAMEL modules.

Scope:
This PR focuses only on the remaining `camel.bots` work for #1043.

Changes included:

Added @api_keys_required to TelegramBot.
Added @api_keys_required to SlackApp.
Removed the now-redundant manual API key validation logic from both implementations.
Added TELEGRAM_TOKEN, SLACK_TOKEN, SLACK_SCOPES, and SLACK_SIGNING_SECRET to env_key_urls so the decorator provides provider-specific guidance instead of the generic fallback message.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [X] Other

### Checklist

- [X] I have read and agree to the [AI-Generated Code Policy](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md#ai-generated-code-policy) (**required**)
- [X] I have linked this PR to an issue (**required**)
- [ ] I have checked if any dependencies need to be added or updated in `pyproject.toml` and run `uv lock`
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed
- [ ] I have added examples if this is a new feature

If you are unsure about any of these, don't hesitate to ask. We are here to help!
