### PR TITLE
feat(storage): add DakeraStorage vector database backend

### DIFF
--- a/camel/storages/__init__.py
+++ b/camel/storages/__init__.py
@@ -27,6 +27,7 @@ from .vectordb_storages.base import (
     VectorRecord,
 )
 from .vectordb_storages.chroma import ChromaStorage
+from .vectordb_storages.dakera import DakeraStorage
 from .vectordb_storages.faiss import FaissStorage
 from .vectordb_storages.milvus import MilvusStorage
 from .vectordb_storages.oceanbase import OceanBaseStorage
@@ -56,4 +57,5 @@ __all__ = [
     'WeaviateStorage',
     'PgVectorStorage',
     'ChromaStorage',
+    'DakeraStorage',
 ]

--- a/camel/storages/vectordb_storages/__init__.py
+++ b/camel/storages/vectordb_storages/__init__.py
@@ -20,6 +20,7 @@ from .base import (
     VectorRecord,
 )
 from .chroma import ChromaStorage
+from .dakera import DakeraStorage
 from .faiss import FaissStorage
 from .milvus import MilvusStorage
 from .oceanbase import OceanBaseStorage
@@ -34,6 +35,7 @@ __all__ = [
     'VectorDBQuery',
     'VectorDBQueryResult',
     'ChromaStorage',
+    'DakeraStorage',
     'QdrantStorage',
     'MilvusStorage',
     "TiDBStorage",

--- a/camel/storages/vectordb_storages/dakera.py
+++ b/camel/storages/vectordb_storages/dakera.py
@@ -1,0 +1,298 @@
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+import logging
+import os
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, List, Optional
+
+from camel.storages.vectordb_storages import (
+    BaseVectorStorage,
+    VectorDBQuery,
+    VectorDBQueryResult,
+    VectorDBStatus,
+    VectorRecord,
+)
+from camel.types import VectorDistance
+from camel.utils import dependencies_required
+
+if TYPE_CHECKING:
+    from dakera import DakeraClient
+
+logger = logging.getLogger(__name__)
+
+# Maps CAMEL's distance metric to Dakera's ``distance_metric`` query parameter.
+DISTANCE_TYPE_MAP = {
+    VectorDistance.DOT: "dot_product",
+    VectorDistance.COSINE: "cosine",
+    VectorDistance.EUCLIDEAN: "euclidean",
+}
+
+
+class DakeraStorage(BaseVectorStorage):
+    r"""An implementation of the `BaseVectorStorage` for interacting with
+    Dakera, a self-hosted memory server that exposes a REST vector API.
+
+    Dakera runs beside the application (single container plus object storage,
+    provisioned via the ``dakera-ai/dakera-deploy`` docker-compose) and stores
+    vectors in server-side namespaces. This backend lets a CAMEL
+    :obj:`VectorDBBlock` persist agent memory across sessions without standing
+    up a separate managed vector database. The detailed information about
+    Dakera is available at: `Dakera <https://dakera.ai>`_
+
+    Args:
+        vector_dim (int): The dimension of storing vectors.
+        collection_name (Optional[str], optional): Name of the Dakera
+            namespace used to store vectors. If not provided, it is set to the
+            current time in iso format. (default: :obj:`None`)
+        url (Optional[str], optional): The base URL of the Dakera server. If
+            not provided, falls back to the ``DAKERA_API_URL`` environment
+            variable and finally to ``"http://localhost:3000"``.
+            (default: :obj:`None`)
+        api_key (Optional[str], optional): The API key (``dk-...``) used to
+            authenticate against the Dakera server. If not provided, falls back
+            to the ``DAKERA_API_KEY`` environment variable.
+            (default: :obj:`None`)
+        distance (VectorDistance, optional): The distance metric used when
+            querying the namespace. (default: :obj:`VectorDistance.COSINE`)
+        index_type (str, optional): The index type to create the namespace
+            with (e.g. ``"hnsw"``, ``"flat"``, ``"ivf"``).
+            (default: :obj:`"hnsw"`)
+        delete_collection_on_del (bool, optional): Flag to determine if the
+            namespace should be deleted upon object destruction.
+            (default: :obj:`False`)
+        **kwargs (Any): Additional keyword arguments for initializing
+            :obj:`DakeraClient`.
+
+    Raises:
+        ImportError: If `dakera` package is not installed.
+    """
+
+    @dependencies_required('dakera')
+    def __init__(
+        self,
+        vector_dim: int,
+        collection_name: Optional[str] = None,
+        url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        distance: VectorDistance = VectorDistance.COSINE,
+        index_type: str = "hnsw",
+        delete_collection_on_del: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        from dakera import DakeraClient
+
+        self.vector_dim = vector_dim
+        self.distance = distance
+        self.index_type = index_type
+        self.collection_name = (
+            collection_name or self._generate_collection_name()
+        )
+        self.delete_collection_on_del = delete_collection_on_del
+
+        resolved_url = (
+            url or os.environ.get("DAKERA_API_URL") or "http://localhost:3000"
+        )
+        resolved_api_key = api_key or os.environ.get("DAKERA_API_KEY")
+
+        self._client: "DakeraClient" = DakeraClient(
+            resolved_url,
+            api_key=resolved_api_key,
+            **kwargs,
+        )
+
+        self._check_and_create_collection()
+
+    def __del__(self) -> None:
+        r"""Deletes the namespace if :obj:`delete_collection_on_del` is set to
+        :obj:`True`.
+        """
+        if getattr(self, "delete_collection_on_del", False):
+            try:
+                self._delete_collection(self.collection_name)
+            except Exception as e:
+                logger.error(
+                    "Failed to delete namespace "
+                    f"'{self.collection_name}' during destruction: {e}"
+                )
+
+    def _generate_collection_name(self) -> str:
+        r"""Generates a collection name if user doesn't provide one."""
+        return datetime.now().isoformat()
+
+    def _collection_exists(self, collection_name: str) -> bool:
+        r"""Returns whether the namespace exists on the server."""
+        from dakera import NotFoundError
+
+        try:
+            self._client.get_namespace(collection_name)
+            return True
+        except NotFoundError:
+            return False
+
+    def _check_and_create_collection(self) -> None:
+        r"""Ensures the namespace exists with a matching vector dimension,
+        creating it if necessary.
+        """
+        from dakera import NotFoundError
+
+        try:
+            info = self._client.get_namespace(self.collection_name)
+        except NotFoundError:
+            self._client.create_namespace(
+                self.collection_name,
+                dimensions=self.vector_dim,
+                index_type=self.index_type,
+            )
+            return
+
+        if info.dimensions is not None and info.dimensions != self.vector_dim:
+            raise ValueError(
+                f"Namespace '{self.collection_name}' has dimension "
+                f"{info.dimensions}, which is different from the given "
+                f"vector dimension {self.vector_dim}."
+            )
+
+    def _delete_collection(self, collection_name: str) -> None:
+        r"""Deletes the namespace from the server."""
+        self._client.delete_namespace(collection_name)
+
+    def add(
+        self,
+        records: List[VectorRecord],
+        **kwargs: Any,
+    ) -> None:
+        r"""Saves a list of vector records to the Dakera namespace.
+
+        Args:
+            records (List[VectorRecord]): List of vector records to be saved.
+            **kwargs (Any): Additional keyword arguments passed to the Dakera
+                client's ``upsert`` call.
+
+        Raises:
+            RuntimeError: If there is an error during the saving process.
+        """
+        from dakera import DakeraError, Vector
+
+        vectors = [
+            Vector(
+                id=record.id,
+                values=record.vector,
+                metadata=record.payload or {},
+            )
+            for record in records
+        ]
+        try:
+            self._client.upsert(
+                self.collection_name, vectors=vectors, **kwargs
+            )
+        except DakeraError as e:
+            raise RuntimeError(
+                f"Failed to add vectors to Dakera namespace "
+                f"'{self.collection_name}': {e}"
+            ) from e
+
+    def delete(
+        self,
+        ids: List[str],
+        **kwargs: Any,
+    ) -> None:
+        r"""Deletes a list of vectors identified by their IDs from the
+        namespace.
+
+        Args:
+            ids (List[str]): List of unique identifiers for the vectors to be
+                deleted.
+            **kwargs (Any): Additional keyword arguments passed to the Dakera
+                client's ``delete`` call.
+
+        Raises:
+            RuntimeError: If there is an error during the deletion process.
+        """
+        from dakera import DakeraError
+
+        try:
+            self._client.delete(self.collection_name, ids=ids, **kwargs)
+        except DakeraError as e:
+            raise RuntimeError(
+                f"Failed to delete vectors from Dakera namespace "
+                f"'{self.collection_name}': {e}"
+            ) from e
+
+    def status(self) -> VectorDBStatus:
+        r"""Returns the status (dimension and vector count) of the namespace.
+
+        Returns:
+            VectorDBStatus: The vector database status.
+        """
+        info = self._client.get_namespace(self.collection_name)
+        return VectorDBStatus(
+            vector_dim=info.dimensions or self.vector_dim,
+            vector_count=info.vector_count,
+        )
+
+    def query(
+        self,
+        query: VectorDBQuery,
+        **kwargs: Any,
+    ) -> List[VectorDBQueryResult]:
+        r"""Searches for similar vectors in the namespace based on the provided
+        query.
+
+        Args:
+            query (VectorDBQuery): The query object containing the search
+                vector and the number of top similar vectors to retrieve.
+            **kwargs (Any): Additional keyword arguments passed to the Dakera
+                client's ``query`` call (e.g. a metadata ``filter``).
+
+        Returns:
+            List[VectorDBQueryResult]: A list of vectors retrieved from the
+                namespace based on similarity to the query vector.
+        """
+        from dakera import DistanceMetric
+
+        search_result = self._client.query(
+            self.collection_name,
+            vector=query.query_vector,
+            top_k=query.top_k,
+            include_values=True,
+            include_metadata=True,
+            distance_metric=DistanceMetric(DISTANCE_TYPE_MAP[self.distance]),
+            **kwargs,
+        )
+        return [
+            VectorDBQueryResult.create(
+                similarity=result.score,
+                id=result.id,
+                payload=result.metadata,
+                vector=result.values or [],
+            )
+            for result in search_result.results
+        ]
+
+    def clear(self) -> None:
+        r"""Remove all vectors from the namespace."""
+        self._client.delete(self.collection_name, delete_all=True)
+
+    def load(self) -> None:
+        r"""Load the collection hosted on cloud service.
+
+        Dakera namespaces are served remotely and are always available, so no
+        action is required.
+        """
+        pass
+
+    @property
+    def client(self) -> "DakeraClient":
+        r"""Provides access to the underlying Dakera client."""
+        return self._client

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -577,6 +577,7 @@ exclude = [
 
 [[tool.mypy.overrides]]
 module = [
+    "dakera.*",
     "transformers.*",
     "packaging.*",
     "tiktoken",

--- a/test/storages/vector_storages/test_dakera.py
+++ b/test/storages/vector_storages/test_dakera.py
@@ -1,0 +1,197 @@
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from camel.storages import (
+    DakeraStorage,
+    VectorDBQuery,
+    VectorRecord,
+)
+from camel.types import VectorDistance
+
+# ``dakera`` is an optional runtime dependency loaded lazily by
+# ``DakeraStorage`` (it is not in the ``storage``/``all`` extras because
+# ``dakera``'s ``requests>=2.33`` pin conflicts with ``arxiv (<3)`` in the
+# universal lock). Skip this module when it is not installed.
+pytest.importorskip("dakera")
+
+
+def _namespace_info(vector_count=0, dimensions=4):
+    info = MagicMock()
+    info.vector_count = vector_count
+    info.dimensions = dimensions
+    return info
+
+
+@pytest.fixture
+def mock_dakera_client():
+    r"""Patches ``DakeraClient`` so no live server is required and yields a
+    :obj:`DakeraStorage` wired to the mock client.
+    """
+    with patch('dakera.DakeraClient') as mock_client_cls:
+        client = MagicMock()
+        # Namespace already exists with a matching dimension.
+        client.get_namespace.return_value = _namespace_info(
+            vector_count=0, dimensions=4
+        )
+        mock_client_cls.return_value = client
+
+        storage = DakeraStorage(
+            vector_dim=4,
+            collection_name="test_collection",
+            url="http://localhost:3000",
+            api_key="dk-test",
+        )
+        yield storage, client
+
+
+def test_client_initialization(mock_dakera_client):
+    with patch('dakera.DakeraClient') as mock_client_cls:
+        from dakera import NotFoundError
+
+        client = MagicMock()
+        # Namespace missing -> should be created with the given dimension.
+        client.get_namespace.side_effect = NotFoundError("missing")
+        mock_client_cls.return_value = client
+
+        DakeraStorage(
+            vector_dim=8,
+            collection_name="fresh",
+            url="http://localhost:3000",
+            api_key="dk-test",
+            index_type="hnsw",
+        )
+        mock_client_cls.assert_called_once_with(
+            "http://localhost:3000", api_key="dk-test"
+        )
+        client.create_namespace.assert_called_once_with(
+            "fresh", dimensions=8, index_type="hnsw"
+        )
+
+
+def test_dimension_mismatch_raises(mock_dakera_client):
+    with patch('dakera.DakeraClient') as mock_client_cls:
+        client = MagicMock()
+        client.get_namespace.return_value = _namespace_info(dimensions=16)
+        mock_client_cls.return_value = client
+
+        with pytest.raises(ValueError):
+            DakeraStorage(vector_dim=4, collection_name="mismatch")
+
+
+def test_add_vectors(mock_dakera_client):
+    from dakera import Vector
+
+    storage, client = mock_dakera_client
+    records = [
+        VectorRecord(vector=[0.2, 0.2, 0.2, 0.2], payload={"label": "A"}),
+        VectorRecord(vector=[-0.2, -0.2, -0.2, -0.2], payload={"label": "B"}),
+    ]
+    storage.add(records=records)
+
+    client.upsert.assert_called_once()
+    _, kwargs = client.upsert.call_args
+    args, _ = client.upsert.call_args
+    assert args[0] == "test_collection"
+    sent = kwargs["vectors"]
+    assert len(sent) == 2
+    assert all(isinstance(v, Vector) for v in sent)
+    assert sent[0].id == records[0].id
+    assert sent[0].values == [0.2, 0.2, 0.2, 0.2]
+    assert sent[0].metadata == {"label": "A"}
+
+
+def test_add_wraps_errors(mock_dakera_client):
+    from dakera import DakeraError
+
+    storage, client = mock_dakera_client
+    client.upsert.side_effect = DakeraError("boom")
+    with pytest.raises(RuntimeError):
+        storage.add(records=[VectorRecord(vector=[0.1, 0.1, 0.1, 0.1])])
+
+
+def test_query_maps_results(mock_dakera_client):
+    storage, client = mock_dakera_client
+
+    result = MagicMock()
+    result.id = "vec-1"
+    result.score = 0.97
+    result.metadata = {"label": "A"}
+    result.values = [0.2, 0.2, 0.2, 0.2]
+    search_result = MagicMock()
+    search_result.results = [result]
+    client.query.return_value = search_result
+
+    query = VectorDBQuery(query_vector=[0.2, 0.2, 0.2, 0.2], top_k=1)
+    results = storage.query(query)
+
+    assert len(results) == 1
+    assert results[0].record.id == "vec-1"
+    assert results[0].similarity == 0.97
+    assert results[0].record.payload == {"label": "A"}
+    assert results[0].record.vector == [0.2, 0.2, 0.2, 0.2]
+
+    _, kwargs = client.query.call_args
+    assert kwargs["vector"] == [0.2, 0.2, 0.2, 0.2]
+    assert kwargs["top_k"] == 1
+    assert kwargs["distance_metric"].value == "cosine"
+
+
+def test_query_distance_metric_mapping(mock_dakera_client):
+    storage, client = mock_dakera_client
+    storage.distance = VectorDistance.EUCLIDEAN
+    search_result = MagicMock()
+    search_result.results = []
+    client.query.return_value = search_result
+
+    storage.query(VectorDBQuery(query_vector=[0.0, 0.0, 0.0, 0.0], top_k=3))
+    _, kwargs = client.query.call_args
+    assert kwargs["distance_metric"].value == "euclidean"
+
+
+def test_delete_vectors(mock_dakera_client):
+    storage, client = mock_dakera_client
+    storage.delete(ids=["vec-1", "vec-2"])
+    client.delete.assert_called_once_with(
+        "test_collection", ids=["vec-1", "vec-2"]
+    )
+
+
+def test_status(mock_dakera_client):
+    storage, client = mock_dakera_client
+    client.get_namespace.return_value = _namespace_info(
+        vector_count=5, dimensions=4
+    )
+    status = storage.status()
+    assert status.vector_count == 5
+    assert status.vector_dim == 4
+
+
+def test_clear(mock_dakera_client):
+    storage, client = mock_dakera_client
+    storage.clear()
+    client.delete.assert_called_once_with("test_collection", delete_all=True)
+
+
+def test_load_is_noop(mock_dakera_client):
+    storage, _ = mock_dakera_client
+    # Remote namespaces are always available; load() must not raise.
+    assert storage.load() is None
+
+
+def test_client_property(mock_dakera_client):
+    storage, client = mock_dakera_client
+    assert storage.client is client


### PR DESCRIPTION
### Related Issue

Closes #4138

### Description

This PR adds **`DakeraStorage`**, a `BaseVectorStorage` implementation backed by [Dakera](https://dakera.ai) — a self-hosted memory server that exposes a REST vector API. It lets a CAMEL `VectorDBBlock` persist agent memory across sessions against a single self-hosted server, without standing up a separate managed vector database.

**Problem.** CAMEL agents using `VectorDBBlock` with in-memory Qdrant lose all memory between runs. Persistent Qdrant/Milvus deployments solve persistence but add operational surface. Dakera runs beside the app (a single server plus object storage, provisioned via the [`dakera-ai/dakera-deploy`](https://github.com/dakera-ai/dakera-deploy) docker-compose) and stores vectors in server-side namespaces.

**Design.** `DakeraStorage` mirrors the existing `QdrantStorage` backend and implements the full `BaseVectorStorage` contract against the Dakera Python SDK's vector namespace API:

| `BaseVectorStorage` | Dakera SDK call |
|---|---|
| `add(records)` | `client.upsert(namespace, vectors=[Vector(id, values, metadata)])` |
| `query(query)` | `client.query(namespace, vector, top_k, distance_metric)` → mapped to `VectorDBQueryResult` |
| `delete(ids)` | `client.delete(namespace, ids=...)` |
| `status()` | `client.get_namespace(namespace)` → `VectorDBStatus(vector_dim, vector_count)` |
| `clear()` | `client.delete(namespace, delete_all=True)` |
| `load()` | no-op (remote namespace, always available) |
| `client` | the underlying `DakeraClient` |

Because `BaseVectorStorage` is a pure vector-in/vector-out contract, `DakeraStorage` uses Dakera's raw vector namespace API — CAMEL supplies embeddings via its own `BaseEmbedding`, exactly as with the other backends. The `dakera` package is imported lazily via `@dependencies_required('dakera')`, matching the pattern used by `QdrantStorage`, `MilvusStorage`, etc. Connection defaults resolve from `url`/`api_key` args, then the `DAKERA_API_URL`/`DAKERA_API_KEY` env vars, then `http://localhost:3000`.

### Usage

```bash
# Start a self-hosted Dakera server (server + MinIO) via docker-compose:
git clone https://github.com/dakera-ai/dakera-deploy && cd dakera-deploy && docker compose up -d
# API is then available at http://localhost:3000
pip install dakera
```

```python
from camel.storages import DakeraStorage, VectorDBQuery, VectorRecord

storage = DakeraStorage(
    vector_dim=4,
    collection_name="camel-agent-memory",
    url="http://localhost:3000",
    api_key="dk-...",
)

storage.add([
    VectorRecord(vector=[0.2, 0.2, 0.2, 0.2], payload={"content": "Paris is the capital of France"}),
])
results = storage.query(VectorDBQuery(query_vector=[0.2, 0.2, 0.2, 0.2], top_k=1))
print(results[0].record.payload["content"])
```

It plugs straight into `VectorDBBlock`:

```python
from camel.memories.blocks import VectorDBBlock

memory_block = VectorDBBlock(storage=DakeraStorage(vector_dim=384))
```

### Testing

`test/storages/vector_storages/test_dakera.py` adds 11 unit tests that mock the `DakeraClient` (mirroring `test_weaviate.py`), covering namespace create/existence + dimension-mismatch guard, `add` mapping to `Vector`, error wrapping, `query` result mapping, distance-metric mapping (cosine/euclidean), `delete`, `status`, `clear`, `load`, and the `client` property. All pass locally with `dakera==0.12.8`; `ruff check` and `ruff format --check` are clean on all changed files.

### Note on `pyproject.toml`

I intentionally did **not** add `dakera` to the `storage`/`all` extras. `dakera 0.12.8` requires `requests>=2.33`, while CAMEL's `arxiv (<3)` (in `research_tools`/`all`) pins `requests<2.33`, so `uv lock` cannot produce a satisfiable universal lock with `dakera` included. Instead `dakera` is an optional runtime dependency installed with `pip install dakera` and loaded lazily by `@dependencies_required`; the test module `importorskip`s it so CI stays green. Happy to add it to the extras once the `requests` ranges reconcile (e.g. an `arxiv` bump), or to gate it behind a conflicting-extras declaration if you prefer.

### What is the purpose of this pull request?

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Checklist

- [x] I have read and agree to the [AI-Generated Code Policy](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md#ai-generated-code-policy) (**required**)
- [x] I have linked this PR to an issue (**required**)
- [x] I have checked if any dependencies need to be added or updated in `pyproject.toml` and run `uv lock` (see note above — `dakera` is an optional runtime dep, not added to the locked extras due to a transitive `requests`/`arxiv` conflict)
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed
- [x] I have added examples if this is a new feature (usage example above)
