### PR TITLE
fix(agents): catch Anthropic RateLimitError in ChatAgent retry loop

### DIFF
--- a/camel/agents/chat_agent.py
+++ b/camel/agents/chat_agent.py
@@ -159,9 +159,7 @@ else:
 # Collect rate-limit error types from whichever provider SDKs are installed.
 # RateLimitError from openai is always present; anthropic's is optional.
 _RATE_LIMIT_ERRORS: tuple = tuple(
-    e
-    for e in [RateLimitError, AnthropicRateLimitError]
-    if e is not None
+    e for e in [RateLimitError, AnthropicRateLimitError] if e is not None
 )
 
 SIMPLE_FORMAT_PROMPT = TextPrompt(

--- a/camel/agents/chat_agent.py
+++ b/camel/agents/chat_agent.py
@@ -56,6 +56,11 @@ from openai import (
 )
 from pydantic import BaseModel, ValidationError
 
+try:
+    from anthropic import RateLimitError as AnthropicRateLimitError
+except ImportError:
+    AnthropicRateLimitError = None  # type: ignore[assignment,misc]
+
 from camel.agents._types import ModelResponse, ToolCallRequest
 from camel.agents._utils import (
     build_default_summary_prompt,
@@ -151,6 +156,13 @@ elif os.environ.get("TRACEROOT_ENABLED", "False").lower() == "true":
 else:
     from camel.utils import observe
 
+# Collect rate-limit error types from whichever provider SDKs are installed.
+# RateLimitError from openai is always present; anthropic's is optional.
+_RATE_LIMIT_ERRORS: tuple = tuple(
+    e
+    for e in [RateLimitError, AnthropicRateLimitError]
+    if e is not None
+)
 
 SIMPLE_FORMAT_PROMPT = TextPrompt(
     textwrap.dedent(
@@ -3595,7 +3607,7 @@ class ChatAgent(BaseAgent):
                 )
                 if response:
                     break
-            except RateLimitError as e:
+            except _RATE_LIMIT_ERRORS as e:  # type: ignore[misc]
                 last_error = e
                 if attempt < self.retry_attempts - 1:
                     delay = min(self.retry_delay * (2**attempt), 60.0)
@@ -3657,7 +3669,7 @@ class ChatAgent(BaseAgent):
                 )
                 if response:
                     break
-            except RateLimitError as e:
+            except _RATE_LIMIT_ERRORS as e:  # type: ignore[misc]
                 last_error = e
                 if attempt < self.retry_attempts - 1:
                     delay = min(self.retry_delay * (2**attempt), 60.0)

--- a/test/agents/test_chat_agent.py
+++ b/test/agents/test_chat_agent.py
@@ -2329,3 +2329,44 @@ async def test_chat_agent_async_stream_with_structured_output():
     assert len(responses) > 1, "Should receive multiple streaming chunks"
     assert responses[-1].msg.parsed.answer == 6
     assert responses[-1].msg.parsed.explanation
+
+
+def test_rate_limit_retry_on_openai_rate_limit_error():
+    r"""RateLimitError from openai triggers retries before raising."""
+    from openai import RateLimitError as OpenAIRateLimitError
+
+    from camel.agents.chat_agent import _RATE_LIMIT_ERRORS
+
+    assert OpenAIRateLimitError in _RATE_LIMIT_ERRORS
+
+    agent = ChatAgent(model=DummyModel(ModelType.GPT_4O_MINI))
+    agent.retry_attempts = 3
+    agent.retry_delay = 0.0
+
+    error = OpenAIRateLimitError(
+        message="rate limit",
+        response=MagicMock(status_code=429, headers={}),
+        body={},
+    )
+    agent.model_backend.run = MagicMock(side_effect=error)
+
+    with pytest.raises(Exception):
+        agent._get_model_response(openai_messages=[], current_iteration=0)
+
+    assert agent.model_backend.run.call_count == agent.retry_attempts
+
+
+def test_rate_limit_retry_respects_anthropic_error_when_installed():
+    r"""AnthropicRateLimitError, if the package is present, is in the tuple."""
+    from camel.agents.chat_agent import (
+        _RATE_LIMIT_ERRORS,
+        AnthropicRateLimitError,
+    )
+
+    if AnthropicRateLimitError is not None:
+        assert AnthropicRateLimitError in _RATE_LIMIT_ERRORS
+    else:
+        # anthropic not installed in this environment — tuple has only openai
+        from openai import RateLimitError as OpenAIRateLimitError
+
+        assert _RATE_LIMIT_ERRORS == (OpenAIRateLimitError,)

--- a/test/agents/test_chat_agent.py
+++ b/test/agents/test_chat_agent.py
@@ -160,20 +160,20 @@ def test_chat_agent(model, step_call_count=3):
         for i in range(step_call_count):
             for user_msg in [user_msg_bm, user_msg_str]:
                 response = assistant.step(user_msg)
-                assert isinstance(response.msgs, list), (
-                    f"Error in round {i + 1}"
-                )
+                assert isinstance(
+                    response.msgs, list
+                ), f"Error in round {i + 1}"
                 assert len(response.msgs) > 0, f"Error in round {i + 1}"
-                assert isinstance(response.terminated, bool), (
-                    f"Error in round {i + 1}"
-                )
+                assert isinstance(
+                    response.terminated, bool
+                ), f"Error in round {i + 1}"
                 assert response.terminated is False, f"Error in round {i + 1}"
-                assert isinstance(response.info, dict), (
-                    f"Error in round {i + 1}"
-                )
-                assert response.info['id'] is not None, (
-                    f"Error in round {i + 1}"
-                )
+                assert isinstance(
+                    response.info, dict
+                ), f"Error in round {i + 1}"
+                assert (
+                    response.info['id'] is not None
+                ), f"Error in round {i + 1}"
 
 
 def test_non_strict_tools_fall_back_to_prompt_formatting_by_default():
@@ -517,9 +517,9 @@ def test_chat_agent_step_with_external_tools(step_call_count=3):
         external_tool_call_requests = response.info[
             "external_tool_call_requests"
         ]
-        assert external_tool_call_requests[0].tool_name == "math_subtract", (
-            f"Error in calling round {i + 1}"
-        )
+        assert (
+            external_tool_call_requests[0].tool_name == "math_subtract"
+        ), f"Error in calling round {i + 1}"
 
 
 @pytest.mark.model_backend
@@ -661,9 +661,9 @@ async def test_chat_agent_astep_with_external_tools(step_call_count=3):
         external_tool_call_requests = response.info[
             "external_tool_call_requests"
         ]
-        assert external_tool_call_requests[0].tool_name == "math_subtract", (
-            f"Error in calling round {i + 1}"
-        )
+        assert (
+            external_tool_call_requests[0].tool_name == "math_subtract"
+        ), f"Error in calling round {i + 1}"
 
 
 def _mock_completion_with_usage(
@@ -1149,18 +1149,18 @@ def test_chat_agent_multiple_return_messages(n, step_call_count=3):
     )
 
     for i in range(step_call_count):
-        assert assistant_with_sys_msg_response.msgs is not None, (
-            f"Error in calling round {i + 1}"
-        )
-        assert len(assistant_with_sys_msg_response.msgs) == n, (
-            f"Error in calling round {i + 1}"
-        )
-        assert assistant_without_sys_msg_response.msgs is not None, (
-            f"Error in calling round {i + 1}"
-        )
-        assert len(assistant_without_sys_msg_response.msgs) == n, (
-            f"Error in calling round {i + 1}"
-        )
+        assert (
+            assistant_with_sys_msg_response.msgs is not None
+        ), f"Error in calling round {i + 1}"
+        assert (
+            len(assistant_with_sys_msg_response.msgs) == n
+        ), f"Error in calling round {i + 1}"
+        assert (
+            assistant_without_sys_msg_response.msgs is not None
+        ), f"Error in calling round {i + 1}"
+        assert (
+            len(assistant_without_sys_msg_response.msgs) == n
+        ), f"Error in calling round {i + 1}"
 
 
 @pytest.mark.model_backend
@@ -1245,12 +1245,12 @@ def test_chat_agent_stream_output(step_call_count=3):
             assert len(msg.content) > 0, f"Error in calling round {i + 1}"
 
         stream_usage = stream_assistant_response.info["usage"]
-        assert stream_usage["completion_tokens"] > 0, (
-            f"Error in calling round {i + 1}"
-        )
-        assert stream_usage["prompt_tokens"] > 0, (
-            f"Error in calling round {i + 1}"
-        )
+        assert (
+            stream_usage["completion_tokens"] > 0
+        ), f"Error in calling round {i + 1}"
+        assert (
+            stream_usage["prompt_tokens"] > 0
+        ), f"Error in calling round {i + 1}"
         assert (
             stream_usage["total_tokens"]
             == stream_usage["completion_tokens"]
@@ -1531,12 +1531,12 @@ def test_tool_calling_sync(step_call_count=3):
         ]
 
         assert len(tool_calls) > 0, f"Error in calling round {i + 1}"
-        assert str(tool_calls[0]).startswith("Tool Execution"), (
-            f"Error in calling round {i + 1}"
-        )
-        assert tool_calls[0].tool_name == "math_multiply", (
-            f"Error in calling round {i + 1}"
-        )
+        assert str(tool_calls[0]).startswith(
+            "Tool Execution"
+        ), f"Error in calling round {i + 1}"
+        assert (
+            tool_calls[0].tool_name == "math_multiply"
+        ), f"Error in calling round {i + 1}"
         assert tool_calls[0].args == {
             "a": 2,
             "b": 8,
@@ -1657,9 +1657,9 @@ async def test_tool_calling_math_async(step_call_count=3):
 
         tool_calls = agent_response.info['tool_calls']
 
-        assert tool_calls[0].tool_name == "math_multiply", (
-            f"Error in calling round {i + 1}"
-        )
+        assert (
+            tool_calls[0].tool_name == "math_multiply"
+        ), f"Error in calling round {i + 1}"
         assert tool_calls[0].args == {
             "a": 2,
             "b": 8,
@@ -1746,16 +1746,16 @@ async def test_tool_calling_async(step_call_count=3):
         tool_calls = agent_response.info['tool_calls']
 
         assert tool_calls, f"Error in calling round {i + 1}"
-        assert str(tool_calls[0]).startswith("Tool Execution"), (
-            f"Error in calling round {i + 1}"
-        )
+        assert str(tool_calls[0]).startswith(
+            "Tool Execution"
+        ), f"Error in calling round {i + 1}"
 
-        assert tool_calls[0].tool_name == "async_sleep", (
-            f"Error in calling round {i + 1}"
-        )
-        assert tool_calls[0].args == {'second': 1}, (
-            f"Error in calling round {i + 1}"
-        )
+        assert (
+            tool_calls[0].tool_name == "async_sleep"
+        ), f"Error in calling round {i + 1}"
+        assert tool_calls[0].args == {
+            'second': 1
+        }, f"Error in calling round {i + 1}"
         assert tool_calls[0].result == 1, f"Error in calling round {i + 1}"
 
 
@@ -1786,9 +1786,9 @@ def test_response_words_termination(step_call_count=3):
 
         assert agent.terminated, f"Error in calling round {i + 1}"
         assert agent_response.terminated, f"Error in calling round {i + 1}"
-        assert "goodbye" in agent_response.info['termination_reasons'][0], (
-            f"Error in calling round {i + 1}"
-        )
+        assert (
+            "goodbye" in agent_response.info['termination_reasons'][0]
+        ), f"Error in calling round {i + 1}"
 
 
 def test_chat_agent_vision(step_call_count=3):
@@ -1854,9 +1854,9 @@ def test_chat_agent_vision(step_call_count=3):
 
     for i in range(step_call_count):
         agent_response = agent.step(user_msg)
-        assert agent_response.msgs[0].content == "Yes.", (
-            f"Error in calling round {i + 1}"
-        )
+        assert (
+            agent_response.msgs[0].content == "Yes."
+        ), f"Error in calling round {i + 1}"
 
 
 @pytest.mark.model_backend
@@ -2026,9 +2026,9 @@ async def test_chat_agent_async_stream_with_async_generator():
     # Create an async generator that wraps the chunks
     # This simulates what GeminiModel does with _wrap_async_stream_with_
     # thought_preservation
-    async def mock_async_generator() -> AsyncGenerator[
-        ChatCompletionChunk, None
-    ]:
+    async def mock_async_generator() -> (
+        AsyncGenerator[ChatCompletionChunk, None]
+    ):
         for chunk in chunks:
             yield chunk
 
@@ -2055,12 +2055,12 @@ async def test_chat_agent_async_stream_with_async_generator():
 
     # Verify final response contains the accumulated content
     final_response = responses[-1]
-    assert final_response.msg is not None, (
-        "Final response should have a message"
-    )
-    assert "Hello" in final_response.msg.content, (
-        "Final content should contain 'Hello'"
-    )
+    assert (
+        final_response.msg is not None
+    ), "Final response should have a message"
+    assert (
+        "Hello" in final_response.msg.content
+    ), "Final content should contain 'Hello'"
 
 
 @pytest.mark.model_backend
@@ -2210,9 +2210,9 @@ async def test_chat_agent_async_stream_with_async_generator_tool_calls():
 
     call_count = 0
 
-    async def mock_async_generator() -> AsyncGenerator[
-        ChatCompletionChunk, None
-    ]:
+    async def mock_async_generator() -> (
+        AsyncGenerator[ChatCompletionChunk, None]
+    ):
         nonlocal call_count
         if call_count == 0:
             call_count += 1

--- a/test/agents/test_chat_agent.py
+++ b/test/agents/test_chat_agent.py
@@ -160,20 +160,20 @@ def test_chat_agent(model, step_call_count=3):
         for i in range(step_call_count):
             for user_msg in [user_msg_bm, user_msg_str]:
                 response = assistant.step(user_msg)
-                assert isinstance(
-                    response.msgs, list
-                ), f"Error in round {i + 1}"
+                assert isinstance(response.msgs, list), (
+                    f"Error in round {i + 1}"
+                )
                 assert len(response.msgs) > 0, f"Error in round {i + 1}"
-                assert isinstance(
-                    response.terminated, bool
-                ), f"Error in round {i + 1}"
+                assert isinstance(response.terminated, bool), (
+                    f"Error in round {i + 1}"
+                )
                 assert response.terminated is False, f"Error in round {i + 1}"
-                assert isinstance(
-                    response.info, dict
-                ), f"Error in round {i + 1}"
-                assert (
-                    response.info['id'] is not None
-                ), f"Error in round {i + 1}"
+                assert isinstance(response.info, dict), (
+                    f"Error in round {i + 1}"
+                )
+                assert response.info['id'] is not None, (
+                    f"Error in round {i + 1}"
+                )
 
 
 def test_non_strict_tools_fall_back_to_prompt_formatting_by_default():
@@ -517,9 +517,9 @@ def test_chat_agent_step_with_external_tools(step_call_count=3):
         external_tool_call_requests = response.info[
             "external_tool_call_requests"
         ]
-        assert (
-            external_tool_call_requests[0].tool_name == "math_subtract"
-        ), f"Error in calling round {i + 1}"
+        assert external_tool_call_requests[0].tool_name == "math_subtract", (
+            f"Error in calling round {i + 1}"
+        )
 
 
 @pytest.mark.model_backend
@@ -661,9 +661,9 @@ async def test_chat_agent_astep_with_external_tools(step_call_count=3):
         external_tool_call_requests = response.info[
             "external_tool_call_requests"
         ]
-        assert (
-            external_tool_call_requests[0].tool_name == "math_subtract"
-        ), f"Error in calling round {i + 1}"
+        assert external_tool_call_requests[0].tool_name == "math_subtract", (
+            f"Error in calling round {i + 1}"
+        )
 
 
 def _mock_completion_with_usage(
@@ -1149,18 +1149,18 @@ def test_chat_agent_multiple_return_messages(n, step_call_count=3):
     )
 
     for i in range(step_call_count):
-        assert (
-            assistant_with_sys_msg_response.msgs is not None
-        ), f"Error in calling round {i + 1}"
-        assert (
-            len(assistant_with_sys_msg_response.msgs) == n
-        ), f"Error in calling round {i + 1}"
-        assert (
-            assistant_without_sys_msg_response.msgs is not None
-        ), f"Error in calling round {i + 1}"
-        assert (
-            len(assistant_without_sys_msg_response.msgs) == n
-        ), f"Error in calling round {i + 1}"
+        assert assistant_with_sys_msg_response.msgs is not None, (
+            f"Error in calling round {i + 1}"
+        )
+        assert len(assistant_with_sys_msg_response.msgs) == n, (
+            f"Error in calling round {i + 1}"
+        )
+        assert assistant_without_sys_msg_response.msgs is not None, (
+            f"Error in calling round {i + 1}"
+        )
+        assert len(assistant_without_sys_msg_response.msgs) == n, (
+            f"Error in calling round {i + 1}"
+        )
 
 
 @pytest.mark.model_backend
@@ -1245,12 +1245,12 @@ def test_chat_agent_stream_output(step_call_count=3):
             assert len(msg.content) > 0, f"Error in calling round {i + 1}"
 
         stream_usage = stream_assistant_response.info["usage"]
-        assert (
-            stream_usage["completion_tokens"] > 0
-        ), f"Error in calling round {i + 1}"
-        assert (
-            stream_usage["prompt_tokens"] > 0
-        ), f"Error in calling round {i + 1}"
+        assert stream_usage["completion_tokens"] > 0, (
+            f"Error in calling round {i + 1}"
+        )
+        assert stream_usage["prompt_tokens"] > 0, (
+            f"Error in calling round {i + 1}"
+        )
         assert (
             stream_usage["total_tokens"]
             == stream_usage["completion_tokens"]
@@ -1531,12 +1531,12 @@ def test_tool_calling_sync(step_call_count=3):
         ]
 
         assert len(tool_calls) > 0, f"Error in calling round {i + 1}"
-        assert str(tool_calls[0]).startswith(
-            "Tool Execution"
-        ), f"Error in calling round {i + 1}"
-        assert (
-            tool_calls[0].tool_name == "math_multiply"
-        ), f"Error in calling round {i + 1}"
+        assert str(tool_calls[0]).startswith("Tool Execution"), (
+            f"Error in calling round {i + 1}"
+        )
+        assert tool_calls[0].tool_name == "math_multiply", (
+            f"Error in calling round {i + 1}"
+        )
         assert tool_calls[0].args == {
             "a": 2,
             "b": 8,
@@ -1657,9 +1657,9 @@ async def test_tool_calling_math_async(step_call_count=3):
 
         tool_calls = agent_response.info['tool_calls']
 
-        assert (
-            tool_calls[0].tool_name == "math_multiply"
-        ), f"Error in calling round {i + 1}"
+        assert tool_calls[0].tool_name == "math_multiply", (
+            f"Error in calling round {i + 1}"
+        )
         assert tool_calls[0].args == {
             "a": 2,
             "b": 8,
@@ -1746,16 +1746,16 @@ async def test_tool_calling_async(step_call_count=3):
         tool_calls = agent_response.info['tool_calls']
 
         assert tool_calls, f"Error in calling round {i + 1}"
-        assert str(tool_calls[0]).startswith(
-            "Tool Execution"
-        ), f"Error in calling round {i + 1}"
+        assert str(tool_calls[0]).startswith("Tool Execution"), (
+            f"Error in calling round {i + 1}"
+        )
 
-        assert (
-            tool_calls[0].tool_name == "async_sleep"
-        ), f"Error in calling round {i + 1}"
-        assert tool_calls[0].args == {
-            'second': 1
-        }, f"Error in calling round {i + 1}"
+        assert tool_calls[0].tool_name == "async_sleep", (
+            f"Error in calling round {i + 1}"
+        )
+        assert tool_calls[0].args == {'second': 1}, (
+            f"Error in calling round {i + 1}"
+        )
         assert tool_calls[0].result == 1, f"Error in calling round {i + 1}"
 
 
@@ -1786,9 +1786,9 @@ def test_response_words_termination(step_call_count=3):
 
         assert agent.terminated, f"Error in calling round {i + 1}"
         assert agent_response.terminated, f"Error in calling round {i + 1}"
-        assert (
-            "goodbye" in agent_response.info['termination_reasons'][0]
-        ), f"Error in calling round {i + 1}"
+        assert "goodbye" in agent_response.info['termination_reasons'][0], (
+            f"Error in calling round {i + 1}"
+        )
 
 
 def test_chat_agent_vision(step_call_count=3):
@@ -1854,9 +1854,9 @@ def test_chat_agent_vision(step_call_count=3):
 
     for i in range(step_call_count):
         agent_response = agent.step(user_msg)
-        assert (
-            agent_response.msgs[0].content == "Yes."
-        ), f"Error in calling round {i + 1}"
+        assert agent_response.msgs[0].content == "Yes.", (
+            f"Error in calling round {i + 1}"
+        )
 
 
 @pytest.mark.model_backend
@@ -2026,9 +2026,9 @@ async def test_chat_agent_async_stream_with_async_generator():
     # Create an async generator that wraps the chunks
     # This simulates what GeminiModel does with _wrap_async_stream_with_
     # thought_preservation
-    async def mock_async_generator() -> (
-        AsyncGenerator[ChatCompletionChunk, None]
-    ):
+    async def mock_async_generator() -> AsyncGenerator[
+        ChatCompletionChunk, None
+    ]:
         for chunk in chunks:
             yield chunk
 
@@ -2055,12 +2055,12 @@ async def test_chat_agent_async_stream_with_async_generator():
 
     # Verify final response contains the accumulated content
     final_response = responses[-1]
-    assert (
-        final_response.msg is not None
-    ), "Final response should have a message"
-    assert (
-        "Hello" in final_response.msg.content
-    ), "Final content should contain 'Hello'"
+    assert final_response.msg is not None, (
+        "Final response should have a message"
+    )
+    assert "Hello" in final_response.msg.content, (
+        "Final content should contain 'Hello'"
+    )
 
 
 @pytest.mark.model_backend
@@ -2210,9 +2210,9 @@ async def test_chat_agent_async_stream_with_async_generator_tool_calls():
 
     call_count = 0
 
-    async def mock_async_generator() -> (
-        AsyncGenerator[ChatCompletionChunk, None]
-    ):
+    async def mock_async_generator() -> AsyncGenerator[
+        ChatCompletionChunk, None
+    ]:
         nonlocal call_count
         if call_count == 0:
             call_count += 1
@@ -2336,6 +2336,7 @@ def test_rate_limit_retry_on_openai_rate_limit_error():
     from openai import RateLimitError as OpenAIRateLimitError
 
     from camel.agents.chat_agent import _RATE_LIMIT_ERRORS
+    from camel.models import ModelProcessingError
 
     assert OpenAIRateLimitError in _RATE_LIMIT_ERRORS
 
@@ -2350,7 +2351,7 @@ def test_rate_limit_retry_on_openai_rate_limit_error():
     )
     agent.model_backend.run = MagicMock(side_effect=error)
 
-    with pytest.raises(Exception):
+    with pytest.raises(ModelProcessingError):
         agent._get_model_response(openai_messages=[], current_iteration=0)
 
     assert agent.model_backend.run.call_count == agent.retry_attempts


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Related Issue

Closes #3882

### Description

#### Problem

`ChatAgent._get_model_response` and `_aget_model_response` retry on rate-limit errors using exponential backoff. The `except` clause imported `RateLimitError` exclusively from the `openai` package:

```python
from openai import RateLimitError
...
except RateLimitError as e:   # only catches openai's exception class
```

When a user runs `ChatAgent` with `AnthropicModel`, a 429 response from the Anthropic API raises `anthropic.RateLimitError` — a completely separate class with no shared base. The retry loop never fires, and the error propagates uncaught to the caller as an unhandled exception, crashing the agent instead of retrying.

#### Fix

Introduce `_RATE_LIMIT_ERRORS`, a tuple built at import time from every provider rate-limit exception that is installed in the current environment:

```python
try:
    from anthropic import RateLimitError as AnthropicRateLimitError
except ImportError:
    AnthropicRateLimitError = None

_RATE_LIMIT_ERRORS: tuple = tuple(
    e for e in [RateLimitError, AnthropicRateLimitError] if e is not None
)
```

Both `except` clauses now catch `_RATE_LIMIT_ERRORS` instead of the bare `RateLimitError`. The `anthropic` package is already an optional dependency in `pyproject.toml` — no new dependencies added.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Changes Made

| File | Change |
|---|---|
| `camel/agents/chat_agent.py` | Optional import of `anthropic.RateLimitError`; build `_RATE_LIMIT_ERRORS` tuple; swap both `except RateLimitError` clauses |
| `test/agents/test_chat_agent.py` | Two new unit tests: one verifies `openai.RateLimitError` triggers the retry loop; one verifies `anthropic.RateLimitError` is included in the tuple when the package is installed |

**Net diff: +14 lines production code, +41 test lines.**

### Testing Done

```
OPENAI_API_KEY=sk-test python -m pytest \
  test/agents/test_chat_agent.py::test_rate_limit_retry_on_openai_rate_limit_error \
  test/agents/test_chat_agent.py::test_rate_limit_retry_respects_anthropic_error_when_installed \
  -v
```

```
PASSED test_rate_limit_retry_on_openai_rate_limit_error
PASSED test_rate_limit_retry_respects_anthropic_error_when_installed
2 passed in 0.79s
```

- `test_rate_limit_retry_on_openai_rate_limit_error`: mocks `model_backend.run` to always raise `openai.RateLimitError`, asserts `run` is called exactly `retry_attempts` (3) times before the final exception is raised.
- `test_rate_limit_retry_respects_anthropic_error_when_installed`: asserts `anthropic.RateLimitError` is present in `_RATE_LIMIT_ERRORS` when the `anthropic` package is installed, and gracefully skips otherwise.

### Checklist

- [x] I have read and agree to the [AI-Generated Code Policy](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md#ai-generated-code-policy) (**required**)
- [x] I have linked this PR to an issue (**required**)
- [x] I have checked if any dependencies need to be added or updated in `pyproject.toml` and run `uv lock` — no new deps; `anthropic` is already optional
- [x] I have updated the tests accordingly
- [ ] I have updated the documentation if needed
- [ ] I have added examples if this is a new feature