### PR TITLE
fix: reorder chown in dev Dockerfile so pre-commit install succeeds

### DIFF
--- a/.container/Dockerfile
+++ b/.container/Dockerfile
@@ -5,13 +5,18 @@ RUN groupadd -r appuser && useradd -r -g appuser appuser
 
 WORKDIR /app/camel
 COPY . .
-RUN chown -R appuser:appuser /app/camel
 
 RUN uv venv .venv --python=3.10 && \
     . .venv/bin/activate && \
     uv pip install -e ".[all, dev, docs]" && \
     pip install pre-commit mypy && \
     pre-commit install
+
+# Hand ownership to the unprivileged user only after the privileged setup
+# above. Running `pre-commit install` before this chown keeps the repo
+# root-owned during the build, so git does not reject it with
+# "detected dubious ownership" (git >= 2.35.2).
+RUN chown -R appuser:appuser /app/camel
 
 ENV VIRTUAL_ENV=/app/camel/.venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"


### PR DESCRIPTION
### Related Issue

Closes #4144

### Description

`docker compose build` (via `.container/docker-compose.yaml`) fails at the final `pre-commit install` step. The heavy `uv pip install -e ".[all, dev, docs]"` completes fine, but the build then dies with:

```
An error has occurred: FatalError: git failed. Is it installed, and are you in a Git repository directory?
```

**Root cause:** the Dockerfile runs `chown -R appuser:appuser /app/camel` *before* the setup block, so `pre-commit install` executes as **root** against a working tree (and `.git`) owned by `appuser`. Git >= 2.35.2 rejects this with *"detected dubious ownership in repository"*, which pre-commit surfaces as the generic "git failed" error.

**Fix:** move the `chown` to *after* the privileged setup block. The repository stays root-owned while `pre-commit install` writes its hook, then ownership is handed to the unprivileged `appuser`. This is also the conventional Docker ordering (do privileged setup first, assign ownership last).

**Verification:** ran a full `docker compose build` on the fixed Dockerfile — exit code 0, image built, with `pre-commit installed at .git/hooks/pre-commit` in the build log. Reproduced the original failure and confirmed root cause independently (`fatal: detected dubious ownership` when running git as root in the appuser-owned repo).

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Checklist

- [x] I have read and agree to the [AI-Generated Code Policy](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md#ai-generated-code-policy)
- [x] I have linked this PR to an issue
- [ ] I have checked if any dependencies need to be added or updated in `pyproject.toml` and run `uv lock` (no dependency changes)
- [ ] I have updated the tests accordingly (build-verified; no unit test applies to a Dockerfile)
- [ ] I have updated the documentation if needed (not needed)
- [ ] I have added examples if this is a new feature (not a new feature)
