### PR TITLE
fix(messages): correct AlpacaItem round-trip for empty input

### DIFF
--- a/camel/messages/conversion/alpaca.py
+++ b/camel/messages/conversion/alpaca.py
@@ -79,15 +79,19 @@ class AlpacaItem(BaseModel):
         # Strip and standardize newlines
         text = text.strip().replace('\r\n', '\n')
 
-        # Try to extract sections using regex
+        # Try to extract sections using regex.
+        # Only consume trailing spaces/tabs on the header line (not the
+        # following newlines) so an empty section body does not greedily
+        # swallow the delimiter and the next section. Use ``.*?`` so an empty
+        # body (e.g. the documented "no input" case) is captured as "".
         instruction_match = re.search(
-            r'###\s*Instruction:\s*\n(.+?)(?=\n###|\Z)', text, re.DOTALL
+            r'###\s*Instruction:[ \t]*\n(.*?)(?=\n###|\Z)', text, re.DOTALL
         )
         input_match = re.search(
-            r'###\s*Input:\s*\n(.+?)(?=\n###|\Z)', text, re.DOTALL
+            r'###\s*Input:[ \t]*\n(.*?)(?=\n###|\Z)', text, re.DOTALL
         )
         response_match = re.search(
-            r'###\s*Response:\s*\n(.+?)(?=\n###|\Z)', text, re.DOTALL
+            r'###\s*Response:[ \t]*\n(.*?)(?=\n###|\Z)', text, re.DOTALL
         )
 
         if not instruction_match or not response_match:

--- a/test/messages/test_alpaca_conversion.py
+++ b/test/messages/test_alpaca_conversion.py
@@ -1,0 +1,70 @@
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+
+import pytest
+
+from camel.messages.conversion import AlpacaItem
+
+
+def test_roundtrip_with_empty_input():
+    r"""An item with an empty ``input`` must survive a
+    ``to_string`` -> ``from_string`` round-trip unchanged.
+
+    Regression test: previously the ``### Input:`` regex greedily consumed the
+    section delimiter and captured the following ``### Response:`` block as the
+    input value.
+    """
+    item = AlpacaItem(instruction="Say hi", input="", output="hi")
+    parsed = AlpacaItem.from_string(item.to_string())
+    assert parsed.instruction == "Say hi"
+    assert parsed.input == ""
+    assert parsed.output == "hi"
+
+
+def test_roundtrip_with_populated_input():
+    item = AlpacaItem(
+        instruction="Summarize the following article",
+        input="A long article about camels.",
+        output="Camels are great.",
+    )
+    parsed = AlpacaItem.from_string(item.to_string())
+    assert parsed.instruction == item.instruction
+    assert parsed.input == item.input
+    assert parsed.output == item.output
+
+
+def test_roundtrip_with_multiline_fields():
+    item = AlpacaItem(
+        instruction="Do the thing",
+        input="line one\nline two",
+        output="result one\nresult two",
+    )
+    parsed = AlpacaItem.from_string(item.to_string())
+    assert parsed.input == "line one\nline two"
+    assert parsed.output == "result one\nresult two"
+
+
+def test_from_string_without_input_section():
+    r"""The documented "without input" format (no ``### Input:`` section)
+    must parse with an empty input."""
+    text = "### Instruction:\nSay hi\n### Response:\nhi"
+    parsed = AlpacaItem.from_string(text)
+    assert parsed.instruction == "Say hi"
+    assert parsed.input == ""
+    assert parsed.output == "hi"
+
+
+def test_from_string_missing_required_sections_raises():
+    with pytest.raises(ValueError):
+        AlpacaItem.from_string("### Instruction:\nonly instruction")


### PR DESCRIPTION
### Description

`AlpacaItem.from_string()` does not round-trip an item whose `input` is empty — which is the documented "no input" case that `to_string()` itself produces.

Each section is parsed with `r'###\s*<Section>:\s*\n(.+?)(?=\n###|\Z)'`. For an empty `input`, `to_string()` emits:

```
### Instruction:
foo

### Input:

### Response:
bar
```

When matching `### Input:`, the `\s*` greedily consumes the blank body **and the newline that delimits the next section**. `(.+?)` then requires ≥1 character and, with no remaining `\n###` to stop at, expands all the way to `\Z`, capturing `### Response:\nbar` as the input. Because the `no_section_markers` validator only guards `instruction` and `output` (not `input`), the corrupted value passes silently:

```python
>>> item = AlpacaItem(instruction="foo", input="", output="bar")
>>> AlpacaItem.from_string(item.to_string()).input
'### Response:\nbar'      # expected ''
```

### Fix

Only consume trailing spaces/tabs on the header line (`[ \t]*` instead of `\s*`, so the delimiter newline is preserved) and allow an empty body (`.*?` instead of `.+?`, so an empty section is captured as `""`). Applied to all three section patterns for consistency. Public API is unchanged.

### Proof of testing

New regression tests fail on `master` and pass with the fix:

```
# master (unpatched)
$ pytest test/messages/test_alpaca_conversion.py::test_roundtrip_with_empty_input -q
E   AssertionError: assert '### Response:\nhi' == ''
1 failed

# with the fix
$ pytest test/messages/test_alpaca_conversion.py -q
5 passed
```

Coverage added in `test/messages/test_alpaca_conversion.py`: empty-input round-trip, populated-input round-trip, multiline fields, the "without input" parse format, and the missing-required-section error path. `ruff check` and `ruff format --check` are clean on both files.

### Note on CI

The `pytest_*` jobs error at collection time with `Missing or empty required API keys ... OPENAI_API_KEY` — fork PRs don't receive repository Secrets, so agent-instantiating tests error on import before any test runs. This is unrelated to this change (which touches only the messages-conversion module). `pre-commit` passes. Happy to re-run under a maintainer-triggered workflow with Secrets access.
