### PR TITLE
fix(utils): detect cross-batch duplicates in deduplicate_internally

### DIFF
--- a/camel/utils/deduplication.py
+++ b/camel/utils/deduplication.py
@@ -194,8 +194,13 @@ def deduplicate_internally(
         )
 
         # Create mask for lower triangle (avoid self-comparison and redundant
-        # checks)
-        tril_mask = np.tril(np.ones_like(batch_similarities), k=-1)
+        # checks). Local row ``r`` corresponds to global text index ``i + r``
+        # and the columns span global indices ``0..batch_end - 1``, so to keep
+        # only comparisons against strictly earlier texts we need columns
+        # ``c <= i + r - 1``, i.e. offset ``k = i - 1``. Using a fixed ``k=-1``
+        # is only correct for the first batch and would drop valid cross-batch
+        # comparisons (missing duplicates) when ``batch_size < len(texts)``.
+        tril_mask = np.tril(np.ones_like(batch_similarities), k=i - 1)
         batch_similarities = batch_similarities * tril_mask
 
         # Find duplicates in current batch

--- a/test/utils/test_deduplication.py
+++ b/test/utils/test_deduplication.py
@@ -209,6 +209,64 @@ def test_deduplicate_internally_chain_scenario():
     ], "Expected 'A' to have embedding [1.0, 0.0]."
 
 
+def test_deduplicate_internally_batch_size_detects_cross_batch_duplicate():
+    r"""A duplicate whose match lives in an earlier batch must still be
+    detected when ``batch_size < len(texts)``.
+
+    Regression test: the lower-triangular mask previously used a fixed
+    ``k=-1`` offset, which is only correct for the first batch. For later
+    batches it masked out valid comparisons against earlier texts, so
+    cross-batch duplicates were silently missed and the result depended on
+    ``batch_size``.
+    """
+    texts = ["x0", "x1", "x2", "x3"]
+    # x3 is identical to x2, which sits in the first batch.
+    embeddings = [
+        [1.0, 0.0],
+        [0.0, 1.0],
+        [0.7, 0.7],
+        [0.7, 0.7],
+    ]
+
+    full = deduplicate_internally(
+        texts=texts, threshold=0.95, embeddings=embeddings
+    )
+    batched = deduplicate_internally(
+        texts=texts, threshold=0.95, embeddings=embeddings, batch_size=2
+    )
+
+    # The result must not depend on the batch size.
+    assert batched.duplicate_to_target_map == full.duplicate_to_target_map
+    assert batched.duplicate_to_target_map == {3: 2}
+    assert batched.unique_ids == [0, 1, 2]
+
+
+def test_deduplicate_internally_batch_size_matches_single_batch():
+    r"""For a chain of duplicates, batched and single-batch runs must agree."""
+    texts = ["A", "B", "C", "D"]
+    embeddings = [
+        [1.0, 0.0],
+        [0.87, 0.5],
+        [0.50, 0.87],
+        [0.0, 1.0],
+    ]
+
+    full = deduplicate_internally(
+        texts=texts, threshold=0.8, embeddings=embeddings
+    )
+    for batch_size in (1, 2, 3):
+        batched = deduplicate_internally(
+            texts=texts,
+            threshold=0.8,
+            embeddings=embeddings,
+            batch_size=batch_size,
+        )
+        assert (
+            batched.duplicate_to_target_map == full.duplicate_to_target_map
+        ), f"Mismatch at batch_size={batch_size}"
+        assert batched.unique_ids == full.unique_ids
+
+
 def test_deduplicate_internally_with_llm_supervision():
     with pytest.raises(NotImplementedError):
         deduplicate_internally(


### PR DESCRIPTION
### Description

`deduplicate_internally()` can silently miss duplicates when the corpus is processed in more than one batch — which happens by default for any input larger than `batch_size` (default **1000**), or whenever a smaller `batch_size` is passed.

Inside the batched loop, comparisons are masked with a fixed lower-triangular offset:

```python
for i in range(0, n, batch_size):
    batch_end = min(i + batch_size, n)
    batch_similarities = cosine_similarity(
        embeddings_array[i:batch_end], embeddings_array[:batch_end]
    )
    tril_mask = np.tril(np.ones_like(batch_similarities), k=-1)  # <-- bug
```

`batch_similarities` has shape `(batch_end - i, batch_end)`. Local row `r` corresponds to **global** text index `i + r`, and the columns span global indices `0..batch_end - 1`. To keep only comparisons against strictly-earlier texts, the mask must keep columns `c <= i + r - 1`, i.e. offset `k = i - 1`. The hardcoded `k = -1` is correct only for the first batch (`i = 0`); for every later batch it drops legitimate comparisons against texts in earlier batches, so a duplicate whose match lives in a previous batch is never detected.

Result: the output depends on `batch_size`.

```python
texts = ["x0", "x1", "x2", "x3"]           # x3 is identical to x2
emb   = [[1,0], [0,1], [0.7,0.7], [0.7,0.7]]

deduplicate_internally(texts, threshold=0.95, embeddings=emb).duplicate_to_target_map
# {3: 2}  ✅  (single batch)

deduplicate_internally(texts, threshold=0.95, embeddings=emb, batch_size=2).duplicate_to_target_map
# {}      ❌  (duplicate missed)
```

### Fix

Use `k = i - 1`, which restores the dropped cross-batch comparisons and reduces to the original `k = -1` for the first batch. No other change is needed — `max_indices` / `duplicate_to_target_map` already use global column indices.

### Proof of testing

Two regression tests assert the result is invariant to `batch_size`. They fail on `master` and pass with the fix:

```
# master (unpatched)
$ pytest test/utils/test_deduplication.py -k batch_size -q
2 failed

# with the fix
$ pytest test/utils/test_deduplication.py -q
9 passed
```

`ruff check` and `ruff format --check` (pinned `v0.7.4`) are clean on both files.

### Note on CI

The `pytest_*` jobs error at collection time with `Missing or empty required API keys ... OPENAI_API_KEY` — fork PRs don't receive repository Secrets, so agent-instantiating tests error on import before any test runs. This is unrelated to this change (a pure numpy masking fix in `camel/utils/deduplication.py`). `pre-commit` passes. Happy to re-run under a maintainer-triggered workflow with Secrets access.
