### PR TITLE
fix: handle ChatAgent context overflow before model call

### DIFF
--- a/camel/agents/chat_agent.py
+++ b/camel/agents/chat_agent.py
@@ -1006,13 +1006,40 @@ class ChatAgent(BaseAgent):
     def _reset_summary_state(self) -> None:
         self._summary_token_count = 0  # Total tokens in summary messages
 
+    def _ensure_context_under_token_limit(
+        self,
+        openai_messages: List[OpenAIMessage],
+        num_tokens: int,
+    ) -> Tuple[List[OpenAIMessage], int]:
+        if num_tokens <= self.token_limit:
+            return openai_messages, num_tokens
+        raise RuntimeError("Context size exceeded", num_tokens)
+
     def _get_context_with_summarization(
         self,
     ) -> Tuple[List[OpenAIMessage], int]:
         r"""Get context and trigger summarization if needed."""
         openai_messages, num_tokens = self.memory.get_context()
 
-        if self.summarize_threshold is None or num_tokens > self.token_limit:
+        if num_tokens > self.token_limit:
+            if self.summarize_threshold is None:
+                return self._ensure_context_under_token_limit(
+                    openai_messages, num_tokens
+                )
+            logger.warning(
+                f"Token count ({num_tokens}) exceeds token limit "
+                f"({self.token_limit}). Triggering full compression."
+            )
+            summary = self.summarize(include_summaries=True)
+            self._update_memory_with_summary(
+                summary.get("summary", ""), include_summaries=True
+            )
+            openai_messages, num_tokens = self.memory.get_context()
+            return self._ensure_context_under_token_limit(
+                openai_messages, num_tokens
+            )
+
+        if self.summarize_threshold is None:
             return openai_messages, num_tokens
 
         summary_token_count = self._summary_token_count
@@ -1026,7 +1053,10 @@ class ChatAgent(BaseAgent):
             self._update_memory_with_summary(
                 summary.get("summary", ""), include_summaries=True
             )
-            return self.memory.get_context()
+            openai_messages, num_tokens = self.memory.get_context()
+            return self._ensure_context_under_token_limit(
+                openai_messages, num_tokens
+            )
 
         threshold = self._calculate_next_summary_threshold()
         if num_tokens > threshold:
@@ -1038,7 +1068,10 @@ class ChatAgent(BaseAgent):
             self._update_memory_with_summary(
                 summary.get("summary", ""), include_summaries=False
             )
-            return self.memory.get_context()
+            openai_messages, num_tokens = self.memory.get_context()
+            return self._ensure_context_under_token_limit(
+                openai_messages, num_tokens
+            )
 
         return openai_messages, num_tokens
 
@@ -1048,7 +1081,25 @@ class ChatAgent(BaseAgent):
         r"""Async version: get context and trigger summarization if needed."""
         openai_messages, num_tokens = self.memory.get_context()
 
-        if self.summarize_threshold is None or num_tokens > self.token_limit:
+        if num_tokens > self.token_limit:
+            if self.summarize_threshold is None:
+                return self._ensure_context_under_token_limit(
+                    openai_messages, num_tokens
+                )
+            logger.warning(
+                f"Token count ({num_tokens}) exceeds token limit "
+                f"({self.token_limit}). Triggering full compression."
+            )
+            summary = await self.asummarize(include_summaries=True)
+            self._update_memory_with_summary(
+                summary.get("summary", ""), include_summaries=True
+            )
+            openai_messages, num_tokens = self.memory.get_context()
+            return self._ensure_context_under_token_limit(
+                openai_messages, num_tokens
+            )
+
+        if self.summarize_threshold is None:
             return openai_messages, num_tokens
 
         summary_token_count = self._summary_token_count
@@ -1062,7 +1113,10 @@ class ChatAgent(BaseAgent):
             self._update_memory_with_summary(
                 summary.get("summary", ""), include_summaries=True
             )
-            return self.memory.get_context()
+            openai_messages, num_tokens = self.memory.get_context()
+            return self._ensure_context_under_token_limit(
+                openai_messages, num_tokens
+            )
 
         threshold = self._calculate_next_summary_threshold()
         if num_tokens > threshold:
@@ -1074,7 +1128,10 @@ class ChatAgent(BaseAgent):
             self._update_memory_with_summary(
                 summary.get("summary", ""), include_summaries=False
             )
-            return self.memory.get_context()
+            openai_messages, num_tokens = self.memory.get_context()
+            return self._ensure_context_under_token_limit(
+                openai_messages, num_tokens
+            )
 
         return openai_messages, num_tokens
 

--- a/test/agents/test_chat_agent.py
+++ b/test/agents/test_chat_agent.py
@@ -1090,7 +1090,6 @@ def test_chat_agent_step_exceed_token_number(step_call_count=3):
         assert response.terminated, f"Error in calling round {i + 1}"
 
 
-@pytest.mark.model_backend
 def test_chat_agent_step_over_limit_context_terminates_before_model():
     system_msg = BaseMessage(
         role_name="assistant",
@@ -1122,7 +1121,6 @@ def test_chat_agent_step_over_limit_context_terminates_before_model():
     assistant.model_backend.run.assert_not_called()
 
 
-@pytest.mark.model_backend
 def test_chat_agent_over_limit_context_triggers_full_compression():
     system_msg = BaseMessage(
         role_name="assistant",

--- a/test/agents/test_chat_agent.py
+++ b/test/agents/test_chat_agent.py
@@ -1154,6 +1154,42 @@ def test_chat_agent_over_limit_context_triggers_full_compression():
     )
 
 
+@pytest.mark.asyncio
+async def test_chat_agent_async_over_limit_context_triggers_full_compression():
+    system_msg = BaseMessage(
+        role_name="assistant",
+        role_type=RoleType.ASSISTANT,
+        meta_dict=None,
+        content="You are a help assistant.",
+    )
+    assistant = ChatAgent(
+        system_message=system_msg,
+        token_limit=10,
+        summarize_threshold=50,
+    )
+    openai_messages = [{"role": "system", "content": system_msg.content}]
+
+    assistant.memory.get_context = MagicMock(
+        side_effect=[
+            (openai_messages, assistant.token_limit + 1),
+            (openai_messages, assistant.token_limit),
+        ]
+    )
+    assistant.asummarize = AsyncMock(return_value={"summary": "short"})
+    assistant._update_memory_with_summary = MagicMock()
+
+    messages, num_tokens = (
+        await assistant._get_context_with_summarization_async()
+    )
+
+    assert messages == openai_messages
+    assert num_tokens == assistant.token_limit
+    assistant.asummarize.assert_awaited_once_with(include_summaries=True)
+    assistant._update_memory_with_summary.assert_called_once_with(
+        "short", include_summaries=True
+    )
+
+
 @pytest.mark.model_backend
 @pytest.mark.parametrize('n', [1, 2, 3])
 def test_chat_agent_multiple_return_messages(n, step_call_count=3):

--- a/test/agents/test_chat_agent.py
+++ b/test/agents/test_chat_agent.py
@@ -1091,6 +1091,72 @@ def test_chat_agent_step_exceed_token_number(step_call_count=3):
 
 
 @pytest.mark.model_backend
+def test_chat_agent_step_over_limit_context_terminates_before_model():
+    system_msg = BaseMessage(
+        role_name="assistant",
+        role_type=RoleType.ASSISTANT,
+        meta_dict=None,
+        content="You are a help assistant.",
+    )
+    assistant = ChatAgent(
+        system_message=system_msg,
+        token_limit=1,
+        summarize_threshold=None,
+    )
+
+    original_get_context = assistant.memory.get_context
+
+    def mock_get_context():
+        messages, _ = original_get_context()
+        return messages, assistant.token_limit + 1
+
+    assistant.memory.get_context = mock_get_context
+    assistant.model_backend.run = MagicMock(
+        return_value=model_backend_rsp_base
+    )
+
+    response = assistant.step("Tell me a joke.")
+
+    assert len(response.msgs) == 0
+    assert response.terminated
+    assistant.model_backend.run.assert_not_called()
+
+
+@pytest.mark.model_backend
+def test_chat_agent_over_limit_context_triggers_full_compression():
+    system_msg = BaseMessage(
+        role_name="assistant",
+        role_type=RoleType.ASSISTANT,
+        meta_dict=None,
+        content="You are a help assistant.",
+    )
+    assistant = ChatAgent(
+        system_message=system_msg,
+        token_limit=10,
+        summarize_threshold=50,
+    )
+    openai_messages = [{"role": "system", "content": system_msg.content}]
+
+    assistant.memory.get_context = MagicMock(
+        side_effect=[
+            (openai_messages, assistant.token_limit + 1),
+            (openai_messages, assistant.token_limit),
+        ]
+    )
+    assistant.summarize = MagicMock(return_value={"summary": "short"})
+    assistant._update_memory_with_summary = MagicMock()
+
+    messages, num_tokens = assistant._get_context_with_summarization()
+
+    assert messages == openai_messages
+    assert num_tokens == assistant.token_limit
+    assistant.summarize.assert_called_once_with(include_summaries=True)
+    assistant._update_memory_with_summary.assert_called_once_with(
+        "short", include_summaries=True
+    )
+
+
+@pytest.mark.model_backend
 @pytest.mark.parametrize('n', [1, 2, 3])
 def test_chat_agent_multiple_return_messages(n, step_call_count=3):
     model_config = ChatGPTConfig(temperature=1.4, n=n)


### PR DESCRIPTION
## Summary
- handle `ChatAgent` contexts whose returned token count already exceeds `token_limit`
- run the existing full summarization path before retrying context construction when summarization is enabled
- raise through the existing `max_tokens_exceeded` termination path when context still cannot fit
- add regression coverage for both no-summarization termination and full-compression retry

Fixes #4143

## Testing
- `OPENAI_API_KEY=sk-test python -m pytest test/agents/test_chat_agent.py::test_chat_agent_step_over_limit_context_terminates_before_model test/agents/test_chat_agent.py::test_chat_agent_over_limit_context_triggers_full_compression -q`
- `python -m py_compile camel/agents/chat_agent.py test/agents/test_chat_agent.py`