### PR TITLE
feat: add pluggable tool result externalization

### DIFF
--- a/camel/agents/__init__.py
+++ b/camel/agents/__init__.py
@@ -25,6 +25,10 @@ from .task_agent import (
     TaskPrioritizationAgent,
     TaskSpecifyAgent,
 )
+from .tool_result_externalization import (
+    ToolResultExternalizationConfig,
+    ToolResultExternalizer,
+)
 
 __all__ = [
     'BaseAgent',
@@ -39,4 +43,6 @@ __all__ = [
     'KnowledgeGraphAgent',
     'MCPAgent',
     'RepoAgent',
+    'ToolResultExternalizationConfig',
+    'ToolResultExternalizer',
 ]

--- a/camel/agents/chat_agent.py
+++ b/camel/agents/chat_agent.py
@@ -66,6 +66,10 @@ from camel.agents._utils import (
     safe_model_dump,
 )
 from camel.agents.base import BaseAgent
+from camel.agents.tool_result_externalization import (
+    ToolResultExternalizationConfig,
+    ToolResultExternalizer,
+)
 from camel.logger import get_logger
 from camel.memories import (
     AgentMemory,
@@ -171,6 +175,13 @@ class _ToolOutputHistoryEntry:
     record_uuids: List[str]
     record_timestamps: List[float]
     cached: bool = False
+
+
+@dataclass(frozen=True)
+class _PreparedToolResult:
+    value: Any
+    ref: Optional[str] = None
+    externalized: bool = False
 
 
 class StreamContentAccumulator:
@@ -468,6 +479,11 @@ class ChatAgent(BaseAgent):
             context window that can be occupied by summary information. Used
             to limit how much of the model's context is reserved for
             summarization results. (default: :obj:`0.6`)
+        tool_result_externalization
+            (Optional[ToolResultExternalizationConfig], optional): Move large
+            tool outputs to pluggable storage and keep a preview/reference in
+            model memory. The configuration can automatically register tools
+            for range reads, search, and listing. (default: :obj:`None`)
     """
 
     def __init__(
@@ -516,6 +532,9 @@ class ChatAgent(BaseAgent):
         on_request_usage: Optional[Callable[[Dict[str, Any]], Any]] = None,
         stream_accumulate: Optional[bool] = None,
         summary_window_ratio: float = 0.6,
+        tool_result_externalization: Optional[
+            ToolResultExternalizationConfig
+        ] = None,
     ) -> None:
         if isinstance(model, ModelManager):
             self.model_backend = model
@@ -530,6 +549,12 @@ class ChatAgent(BaseAgent):
 
         # Assign unique ID
         self.agent_id = agent_id if agent_id else str(uuid.uuid4())
+        self._tool_result_externalizer = (
+            ToolResultExternalizer(tool_result_externalization, self.agent_id)
+            if tool_result_externalization is not None
+            and tool_result_externalization.enabled
+            else None
+        )
 
         self._enable_snapshot_clean = enable_snapshot_clean
         self._tool_output_history: List[_ToolOutputHistoryEntry] = []
@@ -599,6 +624,19 @@ class ChatAgent(BaseAgent):
             ]
         }
 
+        if (
+            self._tool_result_externalizer is not None
+            and self._tool_result_externalizer.config.auto_register_tools
+        ):
+            for access_tool in self._tool_result_externalizer.get_tools():
+                tool_name = access_tool.get_function_name()
+                if tool_name in self._internal_tools:
+                    raise ValueError(
+                        f"Tool name '{tool_name}' is reserved by tool result "
+                        "externalization."
+                    )
+                self._internal_tools[tool_name] = access_tool
+
         # Register agent with toolkits that have RegisteredAgentToolkit mixin
         if toolkits_to_register_agent:
             for toolkit in toolkits_to_register_agent:
@@ -611,6 +649,20 @@ class ChatAgent(BaseAgent):
                 convert_to_schema(tool) for tool in (external_tools or [])
             ]
         }
+        if (
+            self._tool_result_externalizer is not None
+            and self._tool_result_externalizer.config.auto_register_tools
+        ):
+            conflicts = [
+                name
+                for name in self._external_tool_schemas
+                if self._tool_result_externalizer.is_access_tool(name)
+            ]
+            if conflicts:
+                raise ValueError(
+                    "External tool names conflict with CAMEL tool result "
+                    "access tools."
+                )
 
         # Set up other properties
         self.terminated = False
@@ -817,6 +869,11 @@ class ChatAgent(BaseAgent):
     def tool_dict(self) -> Dict[str, FunctionTool]:
         r"""Returns a dictionary of internal tools."""
         return self._internal_tools
+
+    @property
+    def tool_result_externalizer(self) -> Optional[ToolResultExternalizer]:
+        r"""Return the configured tool result externalizer, if enabled."""
+        return self._tool_result_externalizer
 
     @property
     def token_limit(self) -> int:
@@ -1229,6 +1286,35 @@ class ChatAgent(BaseAgent):
             return json.dumps(result, ensure_ascii=False)
         except (TypeError, ValueError):
             return str(result)
+
+    def _prepare_tool_result_for_memory(
+        self,
+        func_name: str,
+        result: Any,
+        tool_call_id: str,
+        mask_output: bool = False,
+    ) -> _PreparedToolResult:
+        r"""Externalize or truncate a tool result before writing memory."""
+        if self._tool_result_externalizer is not None and not mask_output:
+            serialized = self._serialize_tool_result(result)
+            externalized = self._tool_result_externalizer.externalize(
+                serialized,
+                tool_name=func_name,
+                tool_call_id=tool_call_id,
+            )
+            if externalized is not None:
+                return _PreparedToolResult(
+                    value=externalized.preview,
+                    ref=externalized.ref,
+                    externalized=True,
+                )
+
+        truncated_result, was_truncated = self._truncate_tool_result(
+            func_name, result
+        )
+        return _PreparedToolResult(
+            value=truncated_result if was_truncated else result
+        )
 
     def _truncate_tool_result(
         self, func_name: str, result: Any
@@ -4175,12 +4261,13 @@ class ChatAgent(BaseAgent):
             ToolCallingRecord: A struct containing information about
             this tool call.
         """
-        # Truncate tool result if it exceeds the maximum token limit
-        # This prevents single tool calls from exceeding context window
-        truncated_result, was_truncated = self._truncate_tool_result(
-            func_name, result
+        prepared_result = self._prepare_tool_result_for_memory(
+            func_name,
+            result,
+            tool_call_id,
+            mask_output=mask_output,
         )
-        result_for_memory = truncated_result if was_truncated else result
+        result_for_memory = prepared_result.value
 
         # Create the tool response message
         # Note: assistant message with tool_calls is already recorded by
@@ -4229,6 +4316,8 @@ class ChatAgent(BaseAgent):
             result=result,
             tool_call_id=tool_call_id,
             images=images,
+            result_ref=prepared_result.ref,
+            result_externalized=prepared_result.externalized,
         )
         self._update_last_tool_call_state(tool_record)
         return tool_record
@@ -5049,15 +5138,13 @@ class ChatAgent(BaseAgent):
                             " forward]"
                         )
 
-                    # Truncate tool result if it exceeds the maximum token
-                    # limit. This prevents single tool calls from exceeding
-                    # context window
-                    truncated_result, was_truncated = (
-                        self._truncate_tool_result(function_name, result)
+                    prepared_result = self._prepare_tool_result_for_memory(
+                        function_name,
+                        result,
+                        tool_call_id,
+                        mask_output=self.mask_tool_output,
                     )
-                    result_for_memory = (
-                        truncated_result if was_truncated else result
-                    )
+                    result_for_memory = prepared_result.value
 
                     # Create the tool response message
                     # Note: assistant message with tool_calls is already
@@ -5091,6 +5178,8 @@ class ChatAgent(BaseAgent):
                         result=result,
                         tool_call_id=tool_call_id,
                         images=images,
+                        result_ref=prepared_result.ref,
+                        result_externalized=prepared_result.externalized,
                     )
                     self._update_last_tool_call_state(tool_record)
                     return tool_record
@@ -5216,15 +5305,13 @@ class ChatAgent(BaseAgent):
                             " forward]"
                         )
 
-                    # Truncate tool result if it exceeds the maximum token
-                    # limit. This prevents single tool calls from exceeding
-                    # context window
-                    truncated_result, was_truncated = (
-                        self._truncate_tool_result(function_name, result)
+                    prepared_result = self._prepare_tool_result_for_memory(
+                        function_name,
+                        result,
+                        tool_call_id,
+                        mask_output=self.mask_tool_output,
                     )
-                    result_for_memory = (
-                        truncated_result if was_truncated else result
-                    )
+                    result_for_memory = prepared_result.value
 
                     # Create the tool response message
                     # Note: assistant message with tool_calls is already
@@ -5256,6 +5343,8 @@ class ChatAgent(BaseAgent):
                         result=result,
                         tool_call_id=tool_call_id,
                         images=images,
+                        result_ref=prepared_result.ref,
+                        result_externalized=prepared_result.externalized,
                     )
                     self._update_last_tool_call_state(tool_record)
                     return tool_record
@@ -6187,6 +6276,11 @@ class ChatAgent(BaseAgent):
             retry_delay=self.retry_delay,
             step_timeout=self.step_timeout,
             summary_window_ratio=self.summary_window_ratio,
+            tool_result_externalization=(
+                self._tool_result_externalizer.config_for_clone(with_memory)
+                if self._tool_result_externalizer is not None
+                else None
+            ),
         )
 
         # Copy memory if requested
@@ -6219,6 +6313,13 @@ class ChatAgent(BaseAgent):
         # Cache for cloned toolkits by original toolkit id
 
         for tool in self._internal_tools.values():
+            if (
+                self._tool_result_externalizer is not None
+                and self._tool_result_externalizer.is_access_tool(
+                    tool.get_function_name()
+                )
+            ):
+                continue
             # Check if this tool is a method bound to a toolkit instance
             if hasattr(tool.func, '__self__'):
                 toolkit_instance = tool.func.__self__

--- a/camel/agents/chat_agent.py
+++ b/camel/agents/chat_agent.py
@@ -5122,104 +5122,30 @@ class ChatAgent(BaseAgent):
             args = json.loads(tool_call_data['function']['arguments'])
             tool_call_id = tool_call_data['id']
             extra_content = tool_call_data.get('extra_content')
+        except Exception as e:
+            logger.error(f"Error processing tool call: {e}")
+            return None
 
-            if function_name in self._internal_tools:
-                tool = self._internal_tools[function_name]
-                try:
-                    result = tool(**args)
+        if function_name in self._internal_tools:
+            tool = self._internal_tools[function_name]
+            try:
+                result = tool(**args)
 
-                    # Handle mask_tool_output
-                    if self.mask_tool_output:
-                        with self._secure_result_store_lock:
-                            self._secure_result_store[tool_call_id] = result
-                        result = (
-                            "[The tool has been executed successfully, but the"
-                            " output from the tool is masked. You can move"
-                            " forward]"
-                        )
-
-                    prepared_result = self._prepare_tool_result_for_memory(
-                        function_name,
-                        result,
-                        tool_call_id,
-                        mask_output=self.mask_tool_output,
+                # Handle mask_tool_output
+                if self.mask_tool_output:
+                    with self._secure_result_store_lock:
+                        self._secure_result_store[tool_call_id] = result
+                    result = (
+                        "[The tool has been executed successfully, but the"
+                        " output from the tool is masked. You can move"
+                        " forward]"
                     )
-                    result_for_memory = prepared_result.value
-
-                    # Create the tool response message
-                    # Note: assistant message with tool_calls is already
-                    # recorded by _record_assistant_tool_calls_message
-                    func_msg = FunctionCallingMessage(
-                        role_name=self.role_name,
-                        role_type=self.role_type,
-                        meta_dict=None,
-                        content="",
-                        func_name=function_name,
-                        result=result_for_memory,
-                        tool_call_id=tool_call_id,
-                        mask_output=self.mask_tool_output,
-                        extra_content=extra_content,
-                    )
-
-                    # Record only the tool result message
-                    self.update_memory(func_msg, OpenAIBackendRole.FUNCTION)
-
-                    # Extract and inject images if result is ToolResult
-                    images = None
-                    if isinstance(result, ToolResult) and result.images:
-                        images = result.images
-                        self._inject_tool_images_into_memory(
-                            function_name, result.images
-                        )
-
-                    tool_record = ToolCallingRecord(
-                        tool_name=function_name,
-                        args=args,
-                        result=result,
-                        tool_call_id=tool_call_id,
-                        images=images,
-                        result_ref=prepared_result.ref,
-                        result_externalized=prepared_result.externalized,
-                    )
-                    self._update_last_tool_call_state(tool_record)
-                    return tool_record
-
-                except Exception as e:
-                    error_msg = (
-                        f"Error executing tool '{function_name}': {e!s}"
-                    )
-                    result = {"error": error_msg}
-                    logger.warning(f"{error_msg} with result: {result}")
-
-                    # Record error response
-                    func_msg = FunctionCallingMessage(
-                        role_name=self.role_name,
-                        role_type=self.role_type,
-                        meta_dict=None,
-                        content="",
-                        func_name=function_name,
-                        result=result,
-                        tool_call_id=tool_call_id,
-                        extra_content=extra_content,
-                    )
-
-                    self.update_memory(func_msg, OpenAIBackendRole.FUNCTION)
-
-                    tool_record = ToolCallingRecord(
-                        tool_name=function_name,
-                        args=args,
-                        result=result,
-                        tool_call_id=tool_call_id,
-                    )
-                    self._update_last_tool_call_state(tool_record)
-                    return tool_record
-            else:
-                error_msg = (
-                    f"Tool '{function_name}' not found in registered tools"
-                )
+            except Exception as e:
+                error_msg = f"Error executing tool '{function_name}': {e!s}"
                 result = {"error": error_msg}
-                logger.warning(error_msg)
+                logger.warning(f"{error_msg} with result: {result}")
 
+                # Record error response
                 func_msg = FunctionCallingMessage(
                     role_name=self.role_name,
                     role_type=self.role_type,
@@ -5241,9 +5167,76 @@ class ChatAgent(BaseAgent):
                 self._update_last_tool_call_state(tool_record)
                 return tool_record
 
-        except Exception as e:
-            logger.error(f"Error processing tool call: {e}")
-            return None
+            prepared_result = self._prepare_tool_result_for_memory(
+                function_name,
+                result,
+                tool_call_id,
+                mask_output=self.mask_tool_output,
+            )
+            result_for_memory = prepared_result.value
+
+            # Create the tool response message
+            # Note: assistant message with tool_calls is already
+            # recorded by _record_assistant_tool_calls_message
+            func_msg = FunctionCallingMessage(
+                role_name=self.role_name,
+                role_type=self.role_type,
+                meta_dict=None,
+                content="",
+                func_name=function_name,
+                result=result_for_memory,
+                tool_call_id=tool_call_id,
+                mask_output=self.mask_tool_output,
+                extra_content=extra_content,
+            )
+
+            # Record only the tool result message
+            self.update_memory(func_msg, OpenAIBackendRole.FUNCTION)
+
+            # Extract and inject images if result is ToolResult
+            images = None
+            if isinstance(result, ToolResult) and result.images:
+                images = result.images
+                self._inject_tool_images_into_memory(
+                    function_name, result.images
+                )
+
+            tool_record = ToolCallingRecord(
+                tool_name=function_name,
+                args=args,
+                result=result,
+                tool_call_id=tool_call_id,
+                images=images,
+                result_ref=prepared_result.ref,
+                result_externalized=prepared_result.externalized,
+            )
+            self._update_last_tool_call_state(tool_record)
+            return tool_record
+
+        error_msg = f"Tool '{function_name}' not found in registered tools"
+        result = {"error": error_msg}
+        logger.warning(error_msg)
+
+        func_msg = FunctionCallingMessage(
+            role_name=self.role_name,
+            role_type=self.role_type,
+            meta_dict=None,
+            content="",
+            func_name=function_name,
+            result=result,
+            tool_call_id=tool_call_id,
+            extra_content=extra_content,
+        )
+        self.update_memory(func_msg, OpenAIBackendRole.FUNCTION)
+
+        tool_record = ToolCallingRecord(
+            tool_name=function_name,
+            args=args,
+            result=result,
+            tool_call_id=tool_call_id,
+        )
+        self._update_last_tool_call_state(tool_record)
+        return tool_record
 
     async def _aexecute_tool_from_stream_data(
         self, tool_call_data: Dict[str, Any]
@@ -5260,130 +5253,57 @@ class ChatAgent(BaseAgent):
             args = json.loads(tool_call_data['function']['arguments'])
             tool_call_id = tool_call_data['id']
             extra_content = tool_call_data.get('extra_content')
+        except Exception as e:
+            logger.error(f"Error processing async tool call: {e}")
+            return None
 
-            if function_name in self._internal_tools:
-                tool = self._internal_tools[function_name]
-                try:
-                    # Try different invocation paths in order of preference
-                    if hasattr(tool, 'func') and hasattr(
-                        tool.func, 'async_call'
-                    ):
-                        # Case: FunctionTool wrapping an MCP tool
-                        result = await tool.func.async_call(**args)
+        if function_name in self._internal_tools:
+            tool = self._internal_tools[function_name]
+            try:
+                # Try different invocation paths in order of preference
+                if hasattr(tool, 'func') and hasattr(tool.func, 'async_call'):
+                    # Case: FunctionTool wrapping an MCP tool
+                    result = await tool.func.async_call(**args)
 
-                    elif hasattr(tool, 'async_call') and callable(
-                        tool.async_call
-                    ):
-                        # Case: tool itself has async_call
-                        result = await tool.async_call(**args)
+                elif hasattr(tool, 'async_call') and callable(tool.async_call):
+                    # Case: tool itself has async_call
+                    result = await tool.async_call(**args)
 
-                    elif hasattr(tool, 'func') and asyncio.iscoroutinefunction(
-                        tool.func
-                    ):
-                        # Case: tool wraps a direct async function
-                        result = await tool.func(**args)
+                elif hasattr(tool, 'func') and asyncio.iscoroutinefunction(
+                    tool.func
+                ):
+                    # Case: tool wraps a direct async function
+                    result = await tool.func(**args)
 
-                    elif asyncio.iscoroutinefunction(tool):
-                        # Case: tool is itself a coroutine function
-                        result = await tool(**args)
+                elif asyncio.iscoroutinefunction(tool):
+                    # Case: tool is itself a coroutine function
+                    result = await tool(**args)
 
-                    else:
-                        # Fallback: synchronous call
-                        # Use functools.partial to properly capture args
-                        loop = asyncio.get_running_loop()
-                        result = await loop.run_in_executor(
-                            None, functools.partial(tool, **args)
-                        )
-
-                    # Handle mask_tool_output
-                    if self.mask_tool_output:
-                        with self._secure_result_store_lock:
-                            self._secure_result_store[tool_call_id] = result
-                        result = (
-                            "[The tool has been executed successfully, but the"
-                            " output from the tool is masked. You can move"
-                            " forward]"
-                        )
-
-                    prepared_result = self._prepare_tool_result_for_memory(
-                        function_name,
-                        result,
-                        tool_call_id,
-                        mask_output=self.mask_tool_output,
+                else:
+                    # Fallback: synchronous call
+                    # Use functools.partial to properly capture args
+                    loop = asyncio.get_running_loop()
+                    result = await loop.run_in_executor(
+                        None, functools.partial(tool, **args)
                     )
-                    result_for_memory = prepared_result.value
 
-                    # Create the tool response message
-                    # Note: assistant message with tool_calls is already
-                    # recorded by _record_assistant_tool_calls_message
-                    func_msg = FunctionCallingMessage(
-                        role_name=self.role_name,
-                        role_type=self.role_type,
-                        meta_dict=None,
-                        content="",
-                        func_name=function_name,
-                        result=result_for_memory,
-                        tool_call_id=tool_call_id,
-                        mask_output=self.mask_tool_output,
-                        extra_content=extra_content,
+                # Handle mask_tool_output
+                if self.mask_tool_output:
+                    with self._secure_result_store_lock:
+                        self._secure_result_store[tool_call_id] = result
+                    result = (
+                        "[The tool has been executed successfully, but the"
+                        " output from the tool is masked. You can move"
+                        " forward]"
                     )
-                    self.update_memory(func_msg, OpenAIBackendRole.FUNCTION)
-
-                    # Extract and inject images if result is ToolResult
-                    images = None
-                    if isinstance(result, ToolResult) and result.images:
-                        images = result.images
-                        self._inject_tool_images_into_memory(
-                            function_name, result.images
-                        )
-
-                    tool_record = ToolCallingRecord(
-                        tool_name=function_name,
-                        args=args,
-                        result=result,
-                        tool_call_id=tool_call_id,
-                        images=images,
-                        result_ref=prepared_result.ref,
-                        result_externalized=prepared_result.externalized,
-                    )
-                    self._update_last_tool_call_state(tool_record)
-                    return tool_record
-
-                except Exception as e:
-                    error_msg = (
-                        f"Error executing async tool '{function_name}': {e!s}"
-                    )
-                    result = {"error": error_msg}
-                    logger.warning(f"{error_msg} with result: {result}")
-
-                    # Record error response
-                    func_msg = FunctionCallingMessage(
-                        role_name=self.role_name,
-                        role_type=self.role_type,
-                        meta_dict=None,
-                        content="",
-                        func_name=function_name,
-                        result=result,
-                        tool_call_id=tool_call_id,
-                        extra_content=extra_content,
-                    )
-                    self.update_memory(func_msg, OpenAIBackendRole.FUNCTION)
-
-                    tool_record = ToolCallingRecord(
-                        tool_name=function_name,
-                        args=args,
-                        result=result,
-                        tool_call_id=tool_call_id,
-                    )
-                    self._update_last_tool_call_state(tool_record)
-                    return tool_record
-            else:
+            except Exception as e:
                 error_msg = (
-                    f"Tool '{function_name}' not found in registered tools"
+                    f"Error executing async tool '{function_name}': {e!s}"
                 )
                 result = {"error": error_msg}
-                logger.warning(error_msg)
+                logger.warning(f"{error_msg} with result: {result}")
 
+                # Record error response
                 func_msg = FunctionCallingMessage(
                     role_name=self.role_name,
                     role_type=self.role_type,
@@ -5405,9 +5325,74 @@ class ChatAgent(BaseAgent):
                 self._update_last_tool_call_state(tool_record)
                 return tool_record
 
-        except Exception as e:
-            logger.error(f"Error processing async tool call: {e}")
-            return None
+            prepared_result = self._prepare_tool_result_for_memory(
+                function_name,
+                result,
+                tool_call_id,
+                mask_output=self.mask_tool_output,
+            )
+            result_for_memory = prepared_result.value
+
+            # Create the tool response message
+            # Note: assistant message with tool_calls is already
+            # recorded by _record_assistant_tool_calls_message
+            func_msg = FunctionCallingMessage(
+                role_name=self.role_name,
+                role_type=self.role_type,
+                meta_dict=None,
+                content="",
+                func_name=function_name,
+                result=result_for_memory,
+                tool_call_id=tool_call_id,
+                mask_output=self.mask_tool_output,
+                extra_content=extra_content,
+            )
+            self.update_memory(func_msg, OpenAIBackendRole.FUNCTION)
+
+            # Extract and inject images if result is ToolResult
+            images = None
+            if isinstance(result, ToolResult) and result.images:
+                images = result.images
+                self._inject_tool_images_into_memory(
+                    function_name, result.images
+                )
+
+            tool_record = ToolCallingRecord(
+                tool_name=function_name,
+                args=args,
+                result=result,
+                tool_call_id=tool_call_id,
+                images=images,
+                result_ref=prepared_result.ref,
+                result_externalized=prepared_result.externalized,
+            )
+            self._update_last_tool_call_state(tool_record)
+            return tool_record
+
+        error_msg = f"Tool '{function_name}' not found in registered tools"
+        result = {"error": error_msg}
+        logger.warning(error_msg)
+
+        func_msg = FunctionCallingMessage(
+            role_name=self.role_name,
+            role_type=self.role_type,
+            meta_dict=None,
+            content="",
+            func_name=function_name,
+            result=result,
+            tool_call_id=tool_call_id,
+            extra_content=extra_content,
+        )
+        self.update_memory(func_msg, OpenAIBackendRole.FUNCTION)
+
+        tool_record = ToolCallingRecord(
+            tool_name=function_name,
+            args=args,
+            result=result,
+            tool_call_id=tool_call_id,
+        )
+        self._update_last_tool_call_state(tool_record)
+        return tool_record
 
     def _create_error_response(
         self, error_message: str, tool_call_records: List[ToolCallingRecord]

--- a/camel/agents/tool_result_externalization.py
+++ b/camel/agents/tool_result_externalization.py
@@ -1,0 +1,470 @@
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+
+from __future__ import annotations
+
+import hashlib
+import re
+import time
+from dataclasses import dataclass, replace
+from typing import Any, Dict, List, Literal, Optional
+
+from camel.logger import get_logger
+from camel.storages.tool_result_storages import (
+    BaseToolResultStore,
+    InMemoryToolResultStore,
+    ToolResultRecord,
+)
+from camel.toolkits.function_tool import FunctionTool
+
+logger = get_logger(__name__)
+
+TOOL_RESULT_READ_TOOL_NAME = "camel_tool_result_read"
+TOOL_RESULT_SEARCH_TOOL_NAME = "camel_tool_result_search"
+TOOL_RESULT_LIST_TOOL_NAME = "camel_tool_result_list"
+TOOL_RESULT_ACCESS_TOOL_NAMES = frozenset(
+    {
+        TOOL_RESULT_READ_TOOL_NAME,
+        TOOL_RESULT_SEARCH_TOOL_NAME,
+        TOOL_RESULT_LIST_TOOL_NAME,
+    }
+)
+
+_REF_PATTERN = re.compile(
+    r"^camel://tool-results/(?P<scope_id>[A-Za-z0-9_.-]+)/"
+    r"(?P<result_id>[A-Za-z0-9_.-]+)$"
+)
+_UNSAFE_ID_PATTERN = re.compile(r"[^A-Za-z0-9_.-]+")
+
+
+def _safe_id(value: str, fallback: str) -> str:
+    safe = _UNSAFE_ID_PATTERN.sub("_", value or "").strip("._-")
+    return (safe or fallback)[:96]
+
+
+@dataclass(frozen=True)
+class ToolResultExternalizationConfig:
+    r"""Configuration for moving large tool outputs out of model context.
+
+    Passing this configuration to :class:`~camel.agents.ChatAgent` enables
+    externalization. The default store is process-local; provide a
+    :class:`~camel.storages.BaseToolResultStore` implementation for durable or
+    shared storage.
+
+    Args:
+        enabled (bool): Whether externalization is active.
+        threshold_chars (int): Externalize outputs larger than this size.
+        preview_chars (int): Number of original characters retained across
+            the head and tail preview.
+        ttl_seconds (Optional[int]): Lifetime of stored results. ``None`` keeps
+            them until explicitly deleted.
+        max_read_chars (int): Maximum characters returned by one read call.
+        max_search_matches (int): Maximum matches returned by one search.
+        max_search_context_chars (int): Maximum context characters on each
+            side of a search match.
+        max_list_results (int): Maximum results returned by one list call.
+        auto_register_tools (bool): Add read/search/list tools to the agent.
+        failure_mode (Literal["inline", "raise"]): Keep the original result
+            inline or raise when storage fails.
+        scope_id (Optional[str]): Optional stable namespace for sharing results
+            across agents. Defaults to the owning agent ID.
+        store (Optional[BaseToolResultStore]): Pluggable result storage.
+    """
+
+    enabled: bool = True
+    threshold_chars: int = 20_000
+    preview_chars: int = 2_000
+    ttl_seconds: Optional[int] = 86_400
+    max_read_chars: int = 20_000
+    max_search_matches: int = 20
+    max_search_context_chars: int = 500
+    max_list_results: int = 50
+    auto_register_tools: bool = True
+    failure_mode: Literal["inline", "raise"] = "inline"
+    scope_id: Optional[str] = None
+    store: Optional[BaseToolResultStore] = None
+
+    def __post_init__(self) -> None:
+        if self.threshold_chars <= 0:
+            raise ValueError("threshold_chars must be greater than 0")
+        if self.preview_chars < 0:
+            raise ValueError(
+                "preview_chars must be greater than or equal to 0"
+            )
+        if self.preview_chars >= self.threshold_chars:
+            raise ValueError(
+                "preview_chars must be smaller than threshold_chars"
+            )
+        if self.ttl_seconds is not None and self.ttl_seconds <= 0:
+            raise ValueError("ttl_seconds must be greater than 0 or None")
+        if self.max_read_chars <= 0:
+            raise ValueError("max_read_chars must be greater than 0")
+        if self.max_search_matches <= 0:
+            raise ValueError("max_search_matches must be greater than 0")
+        if self.max_search_context_chars < 0:
+            raise ValueError(
+                "max_search_context_chars must be greater than or equal to 0"
+            )
+        if self.max_list_results <= 0:
+            raise ValueError("max_list_results must be greater than 0")
+
+
+@dataclass(frozen=True)
+class ExternalizedToolResult:
+    r"""Result of successfully externalizing one tool output."""
+
+    ref: str
+    preview: str
+    record: ToolResultRecord
+
+
+class ToolResultExternalizer:
+    r"""Store large tool results and expose range read and search tools."""
+
+    def __init__(
+        self,
+        config: ToolResultExternalizationConfig,
+        default_scope_id: str,
+    ) -> None:
+        store = (
+            config.store
+            if config.store is not None
+            else InMemoryToolResultStore()
+        )
+        self.config = replace(config, store=store)
+        self.scope_id = _safe_id(
+            config.scope_id or default_scope_id, fallback="agent"
+        )
+        self.store = store
+
+    @staticmethod
+    def is_access_tool(tool_name: str) -> bool:
+        r"""Return whether a tool is one of the built-in access tools."""
+        return tool_name in TOOL_RESULT_ACCESS_TOOL_NAMES
+
+    def get_tools(self) -> List[FunctionTool]:
+        r"""Return model-callable read, search, and list tools."""
+        return [
+            FunctionTool(self.camel_tool_result_read),
+            FunctionTool(self.camel_tool_result_search),
+            FunctionTool(self.camel_tool_result_list),
+        ]
+
+    def config_for_clone(
+        self, preserve_scope: bool
+    ) -> ToolResultExternalizationConfig:
+        r"""Return a config that shares storage and optionally the scope."""
+        if self.config.scope_id is not None or preserve_scope:
+            return replace(self.config, scope_id=self.scope_id)
+        return self.config
+
+    def externalize(
+        self,
+        content: str,
+        tool_name: str,
+        tool_call_id: str,
+        mime_type: str = "text/plain",
+    ) -> Optional[ExternalizedToolResult]:
+        r"""Externalize content when it exceeds the configured threshold."""
+        if (
+            not self.config.enabled
+            or len(content) <= self.config.threshold_chars
+        ):
+            return None
+        if self.is_access_tool(tool_name):
+            return None
+
+        digest = hashlib.sha256(content.encode("utf-8")).hexdigest()
+        safe_call_id = _safe_id(tool_call_id, fallback="tool")
+        result_id = f"tr_{safe_call_id}_{digest[:16]}"
+        ref = f"camel://tool-results/{self.scope_id}/{result_id}"
+        created_at = time.time()
+        expires_at = (
+            created_at + self.config.ttl_seconds
+            if self.config.ttl_seconds is not None
+            else None
+        )
+        record = ToolResultRecord(
+            result_id=result_id,
+            scope_id=self.scope_id,
+            ref=ref,
+            tool_name=tool_name,
+            tool_call_id=tool_call_id,
+            content=content,
+            created_at=created_at,
+            expires_at=expires_at,
+            original_chars=len(content),
+            sha256=digest,
+            mime_type=mime_type,
+        )
+        preview = self._make_preview(record)
+        if len(preview) >= len(content):
+            return None
+        try:
+            self.store.save(record)
+        except Exception:
+            if self.config.failure_mode == "raise":
+                raise
+            logger.warning(
+                "Failed to externalize output from tool '%s'; "
+                "keeping it inline",
+                tool_name,
+                exc_info=True,
+            )
+            return None
+
+        return ExternalizedToolResult(
+            ref=ref,
+            preview=preview,
+            record=record,
+        )
+
+    def _make_preview(self, record: ToolResultRecord) -> str:
+        preview_chars = self.config.preview_chars
+        if preview_chars <= 0:
+            body = ""
+        elif len(record.content) <= preview_chars:
+            body = record.content
+        else:
+            head_chars = (preview_chars + 1) // 2
+            tail_chars = preview_chars // 2
+            body = (
+                "--- BEGIN PREVIEW HEAD ---\n"
+                f"{record.content[:head_chars]}\n"
+                "--- END PREVIEW HEAD ---\n\n"
+                "--- BEGIN PREVIEW TAIL ---\n"
+                f"{record.content[-tail_chars:] if tail_chars else ''}\n"
+                "--- END PREVIEW TAIL ---"
+            )
+
+        header = [
+            "[CAMEL tool result externalized]",
+            f"tool_name: {record.tool_name}",
+            f"original_chars: {record.original_chars}",
+            f"ref: {record.ref}",
+            f"sha256: {record.sha256[:16]}",
+            (
+                "Use camel_tool_result_search to locate relevant text, then "
+                "camel_tool_result_read to read only the needed range."
+            ),
+        ]
+        return "\n".join(header) + (f"\n\n{body}" if body else "")
+
+    def _parse_ref(self, ref: str) -> tuple[str, str]:
+        match = _REF_PATTERN.fullmatch(str(ref).strip())
+        if match is None:
+            raise ValueError(
+                "ref must be a camel://tool-results/<scope>/<result> URI"
+            )
+        scope_id = match.group("scope_id")
+        result_id = match.group("result_id")
+        if scope_id != self.scope_id:
+            raise PermissionError("tool result belongs to another scope")
+        return scope_id, result_id
+
+    def _get_record(self, ref: str) -> ToolResultRecord:
+        scope_id, result_id = self._parse_ref(ref)
+        record = self.store.get(scope_id, result_id)
+        if record is None:
+            raise KeyError(f"tool result not found or expired: {ref}")
+        return record
+
+    def read(
+        self, ref: str, offset: int = 0, limit: int = 20_000
+    ) -> Dict[str, Any]:
+        r"""Read a bounded character range from an externalized result."""
+        if offset < 0:
+            raise ValueError("offset must be greater than or equal to 0")
+        if limit <= 0:
+            raise ValueError("limit must be greater than 0")
+        record = self._get_record(ref)
+        effective_limit = min(limit, self.config.max_read_chars)
+        content = record.content[offset : offset + effective_limit]
+        next_offset = offset + len(content)
+        return {
+            "ref": ref,
+            "content": content,
+            "offset": offset,
+            "offset_unit": "unicode_code_point",
+            "limit": effective_limit,
+            "returned_chars": len(content),
+            "total_chars": record.original_chars,
+            "has_more": next_offset < record.original_chars,
+            "next_offset": (
+                next_offset if next_offset < record.original_chars else None
+            ),
+            "metadata": record.metadata_dict(),
+        }
+
+    def search(
+        self,
+        ref: str,
+        query: str,
+        limit: int = 20,
+        context_chars: int = 300,
+        case_sensitive: bool = False,
+    ) -> Dict[str, Any]:
+        r"""Search exact text inside an externalized result."""
+        if not query:
+            raise ValueError("query must not be empty")
+        if limit <= 0:
+            raise ValueError("limit must be greater than 0")
+        if context_chars < 0:
+            raise ValueError(
+                "context_chars must be greater than or equal to 0"
+            )
+
+        record = self._get_record(ref)
+        effective_limit = min(limit, self.config.max_search_matches)
+        effective_context = min(
+            context_chars, self.config.max_search_context_chars
+        )
+        haystack = record.content if case_sensitive else record.content.lower()
+        needle = query if case_sensitive else query.lower()
+        matches: List[Dict[str, Any]] = []
+        start = 0
+        while len(matches) < effective_limit:
+            offset = haystack.find(needle, start)
+            if offset < 0:
+                break
+            left = max(0, offset - effective_context)
+            right = min(
+                len(record.content), offset + len(query) + effective_context
+            )
+            matches.append(
+                {
+                    "offset": offset,
+                    "offset_unit": "unicode_code_point",
+                    "snippet_start": left,
+                    "snippet_end": right,
+                    "snippet": record.content[left:right],
+                }
+            )
+            start = offset + max(1, len(query))
+        return {"ref": ref, "query": query, "matches": matches}
+
+    def list(
+        self, tool_name: Optional[str] = None, limit: int = 50
+    ) -> Dict[str, Any]:
+        r"""List externalized results in this scope without their bodies."""
+        if limit <= 0:
+            raise ValueError("limit must be greater than 0")
+        effective_limit = min(limit, self.config.max_list_results)
+        records = self.store.list(self.scope_id, tool_name, effective_limit)
+        return {
+            "scope_id": self.scope_id,
+            "tool_results": records,
+        }
+
+    def camel_tool_result_read(
+        self, ref: str, offset: int = 0, limit: int = 20_000
+    ) -> str:
+        r"""Read part of an externalized tool result by its CAMEL reference.
+
+        Use this after a tool response says it was externalized. Prefer a
+        bounded range, and use search first when the needed offset is unknown.
+
+        Args:
+            ref (str): Exact ``camel://tool-results/...`` reference.
+            offset (int): Unicode character offset to start reading from.
+            limit (int): Maximum characters to return. The configured safety
+                cap still applies.
+
+        Returns:
+            str: The requested content and pagination metadata.
+        """
+        try:
+            result = self.read(ref, offset=offset, limit=limit)
+        except (KeyError, PermissionError, ValueError) as error:
+            return f"Error reading externalized tool result: {error}"
+        header = [
+            "[CAMEL externalized tool result chunk]",
+            f"ref: {result['ref']}",
+            f"offset: {result['offset']}",
+            f"returned_chars: {result['returned_chars']}",
+            f"total_chars: {result['total_chars']}",
+            f"has_more: {str(result['has_more']).lower()}",
+            f"next_offset: {result['next_offset']}",
+        ]
+        return "\n".join(header) + "\n\n" + result["content"]
+
+    def camel_tool_result_search(
+        self,
+        ref: str,
+        query: str,
+        limit: int = 20,
+        context_chars: int = 300,
+        case_sensitive: bool = False,
+    ) -> str:
+        r"""Search within an externalized tool result and return snippets.
+
+        Args:
+            ref (str): Exact ``camel://tool-results/...`` reference.
+            query (str): Exact text to find.
+            limit (int): Maximum number of matches.
+            context_chars (int): Context characters around each match.
+            case_sensitive (bool): Whether matching should preserve case.
+
+        Returns:
+            str: Matching snippets and offsets for follow-up range reads.
+        """
+        try:
+            result = self.search(
+                ref,
+                query,
+                limit=limit,
+                context_chars=context_chars,
+                case_sensitive=case_sensitive,
+            )
+        except (KeyError, PermissionError, ValueError) as error:
+            return f"Error searching externalized tool result: {error}"
+        matches = result["matches"]
+        if not matches:
+            return f'No matches found for "{query}" in {ref}.'
+        sections = [f'Found {len(matches)} match(es) for "{query}" in {ref}:']
+        for index, match in enumerate(matches, start=1):
+            sections.append(
+                f"## Match {index} (offset {match['offset']})\n"
+                f"{match['snippet']}"
+            )
+        return "\n\n".join(sections)
+
+    def camel_tool_result_list(
+        self, tool_name: Optional[str] = None, limit: int = 50
+    ) -> str:
+        r"""List externalized tool results available to this agent.
+
+        Args:
+            tool_name (Optional[str]): Optional exact tool-name filter.
+            limit (int): Maximum number of results.
+
+        Returns:
+            str: Result references and lightweight metadata.
+        """
+        try:
+            result = self.list(tool_name=tool_name, limit=limit)
+        except ValueError as error:
+            return f"Error listing externalized tool results: {error}"
+        items = result["tool_results"]
+        if not items:
+            suffix = f' for tool "{tool_name}"' if tool_name else ""
+            return f"No externalized tool results found{suffix}."
+        lines = [f"Found {len(items)} externalized tool result(s):"]
+        for index, item in enumerate(items, start=1):
+            lines.append(
+                f"{index}. {item['tool_name']} "
+                f"original_chars={item['original_chars']}\n"
+                f"ref: {item['ref']}"
+            )
+        return "\n\n".join(lines)

--- a/camel/storages/__init__.py
+++ b/camel/storages/__init__.py
@@ -20,6 +20,12 @@ from .key_value_storages.in_memory import InMemoryKeyValueStorage
 from .key_value_storages.json import JsonStorage
 from .key_value_storages.mem0_cloud import Mem0Storage
 from .key_value_storages.redis import RedisStorage
+from .tool_result_storages import (
+    BaseToolResultStore,
+    FileToolResultStore,
+    InMemoryToolResultStore,
+    ToolResultRecord,
+)
 from .vectordb_storages.base import (
     BaseVectorStorage,
     VectorDBQuery,
@@ -40,6 +46,10 @@ __all__ = [
     'InMemoryKeyValueStorage',
     'JsonStorage',
     'RedisStorage',
+    'BaseToolResultStore',
+    'FileToolResultStore',
+    'InMemoryToolResultStore',
+    'ToolResultRecord',
     'VectorRecord',
     'BaseVectorStorage',
     'VectorDBQuery',

--- a/camel/storages/tool_result_storages.py
+++ b/camel/storages/tool_result_storages.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 _SAFE_ID_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+$")
+_RESERVED_PATH_PARTS = {".", ".."}
 
 
 @dataclass(frozen=True)
@@ -168,13 +169,23 @@ class FileToolResultStore(BaseToolResultStore):
 
     @staticmethod
     def _validate_id(value: str, label: str) -> None:
-        if _SAFE_ID_PATTERN.fullmatch(value) is None:
+        if (
+            value in _RESERVED_PATH_PARTS
+            or _SAFE_ID_PATTERN.fullmatch(value) is None
+        ):
             raise ValueError(f"Invalid {label}: {value!r}")
 
     def _result_dir(self, scope_id: str, result_id: str) -> Path:
         self._validate_id(scope_id, "scope_id")
         self._validate_id(result_id, "result_id")
-        return self.directory / scope_id / result_id
+        result_dir = (self.directory / scope_id / result_id).resolve()
+        try:
+            result_dir.relative_to(self.directory)
+        except ValueError as exc:
+            raise ValueError(
+                "Tool result path must stay within the storage directory"
+            ) from exc
+        return result_dir
 
     @staticmethod
     def _validate_record_identity(
@@ -244,7 +255,13 @@ class FileToolResultStore(BaseToolResultStore):
         limit: int = 50,
     ) -> List[Dict[str, Any]]:
         self._validate_id(scope_id, "scope_id")
-        scope_dir = self.directory / scope_id
+        scope_dir = (self.directory / scope_id).resolve()
+        try:
+            scope_dir.relative_to(self.directory)
+        except ValueError as exc:
+            raise ValueError(
+                "Tool result path must stay within the storage directory"
+            ) from exc
         if not scope_dir.exists():
             return []
 

--- a/camel/storages/tool_result_storages.py
+++ b/camel/storages/tool_result_storages.py
@@ -1,0 +1,297 @@
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import tempfile
+import threading
+import time
+from abc import ABC, abstractmethod
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+_SAFE_ID_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+$")
+
+
+@dataclass(frozen=True)
+class ToolResultRecord:
+    r"""A complete externalized tool result and its metadata.
+
+    Args:
+        result_id (str): Storage-safe identifier for this result.
+        scope_id (str): Agent or application scope that owns the result.
+        ref (str): Stable reference shown in model context.
+        tool_name (str): Name of the tool that produced the result.
+        tool_call_id (str): Identifier of the originating tool call.
+        content (str): Complete serialized tool output.
+        created_at (float): UNIX timestamp when the result was stored.
+        expires_at (Optional[float]): Optional UNIX expiration timestamp.
+        original_chars (int): Character length of the complete output.
+        sha256 (str): SHA-256 digest of ``content``.
+        mime_type (str): MIME type of the stored output.
+    """
+
+    result_id: str
+    scope_id: str
+    ref: str
+    tool_name: str
+    tool_call_id: str
+    content: str
+    created_at: float
+    expires_at: Optional[float]
+    original_chars: int
+    sha256: str
+    mime_type: str = "text/plain"
+
+    @property
+    def expired(self) -> bool:
+        r"""Return whether this record has expired."""
+        return self.expires_at is not None and time.time() >= self.expires_at
+
+    def metadata_dict(self) -> Dict[str, Any]:
+        r"""Serialize metadata without including the potentially large body."""
+        data = asdict(self)
+        data.pop("content")
+        return data
+
+    @classmethod
+    def from_metadata(
+        cls, metadata: Dict[str, Any], content: str
+    ) -> "ToolResultRecord":
+        r"""Build a record from separately stored metadata and content."""
+        return cls(content=content, **metadata)
+
+
+class BaseToolResultStore(ABC):
+    r"""Storage interface for externalized tool results."""
+
+    @abstractmethod
+    def save(self, record: ToolResultRecord) -> None:
+        r"""Persist a complete tool result."""
+
+    @abstractmethod
+    def get(self, scope_id: str, result_id: str) -> Optional[ToolResultRecord]:
+        r"""Load a result, or return ``None`` when it does not exist."""
+
+    @abstractmethod
+    def list(
+        self,
+        scope_id: str,
+        tool_name: Optional[str] = None,
+        limit: int = 50,
+    ) -> List[Dict[str, Any]]:
+        r"""List newest result metadata in one scope."""
+
+    @abstractmethod
+    def delete(self, scope_id: str, result_id: str) -> None:
+        r"""Delete one result if it exists."""
+
+
+class InMemoryToolResultStore(BaseToolResultStore):
+    r"""Thread-safe, process-local tool result storage."""
+
+    def __init__(self) -> None:
+        self._records: Dict[tuple[str, str], ToolResultRecord] = {}
+        self._lock = threading.RLock()
+
+    def save(self, record: ToolResultRecord) -> None:
+        with self._lock:
+            self._records[(record.scope_id, record.result_id)] = record
+
+    def get(self, scope_id: str, result_id: str) -> Optional[ToolResultRecord]:
+        key = (scope_id, result_id)
+        with self._lock:
+            record = self._records.get(key)
+            if record is not None and record.expired:
+                self._records.pop(key, None)
+                return None
+            return record
+
+    def list(
+        self,
+        scope_id: str,
+        tool_name: Optional[str] = None,
+        limit: int = 50,
+    ) -> List[Dict[str, Any]]:
+        with self._lock:
+            expired_keys = [
+                key
+                for key, record in self._records.items()
+                if key[0] == scope_id and record.expired
+            ]
+            for key in expired_keys:
+                self._records.pop(key, None)
+            records = [
+                record
+                for (record_scope, _), record in self._records.items()
+                if record_scope == scope_id
+                and (tool_name is None or record.tool_name == tool_name)
+            ]
+        records.sort(key=lambda record: record.created_at, reverse=True)
+        return [record.metadata_dict() for record in records[:limit]]
+
+    def delete(self, scope_id: str, result_id: str) -> None:
+        with self._lock:
+            self._records.pop((scope_id, result_id), None)
+
+
+class FileToolResultStore(BaseToolResultStore):
+    r"""File-backed tool result storage for persistence across processes.
+
+    Each result is stored as an ``output.txt`` payload and a separate
+    ``metadata.json`` file below ``directory/<scope_id>/<result_id>``.
+
+    Args:
+        directory (Union[str, Path]): Root directory for stored results.
+    """
+
+    def __init__(self, directory: str | Path) -> None:
+        self.directory = Path(directory).expanduser().resolve()
+        self.directory.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.RLock()
+
+    @staticmethod
+    def _validate_id(value: str, label: str) -> None:
+        if _SAFE_ID_PATTERN.fullmatch(value) is None:
+            raise ValueError(f"Invalid {label}: {value!r}")
+
+    def _result_dir(self, scope_id: str, result_id: str) -> Path:
+        self._validate_id(scope_id, "scope_id")
+        self._validate_id(result_id, "result_id")
+        return self.directory / scope_id / result_id
+
+    @staticmethod
+    def _validate_record_identity(
+        record: ToolResultRecord, scope_id: str, result_id: str
+    ) -> None:
+        if record.scope_id != scope_id or record.result_id != result_id:
+            raise ValueError(
+                "Tool result metadata identity does not match its path"
+            )
+
+    @staticmethod
+    def _atomic_write(path: Path, content: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temporary_path: Optional[Path] = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                encoding="utf-8",
+                dir=path.parent,
+                delete=False,
+            ) as temporary:
+                temporary.write(content)
+                temporary.flush()
+                os.fsync(temporary.fileno())
+                temporary_path = Path(temporary.name)
+            os.replace(temporary_path, path)
+        finally:
+            if temporary_path is not None and temporary_path.exists():
+                temporary_path.unlink()
+
+    def save(self, record: ToolResultRecord) -> None:
+        result_dir = self._result_dir(record.scope_id, record.result_id)
+        metadata = json.dumps(
+            record.metadata_dict(), ensure_ascii=False, indent=2
+        )
+        with self._lock:
+            self._atomic_write(result_dir / "output.txt", record.content)
+            self._atomic_write(result_dir / "metadata.json", metadata)
+
+    def get(self, scope_id: str, result_id: str) -> Optional[ToolResultRecord]:
+        result_dir = self._result_dir(scope_id, result_id)
+        try:
+            with self._lock:
+                metadata = json.loads(
+                    (result_dir / "metadata.json").read_text(encoding="utf-8")
+                )
+                content = (result_dir / "output.txt").read_text(
+                    encoding="utf-8"
+                )
+        except FileNotFoundError:
+            return None
+
+        record = ToolResultRecord.from_metadata(metadata, content)
+        self._validate_record_identity(record, scope_id, result_id)
+        if record.expired:
+            self.delete(scope_id, result_id)
+            return None
+        digest = hashlib.sha256(content.encode("utf-8")).hexdigest()
+        if digest != record.sha256:
+            raise ValueError(f"Tool result {record.ref} failed SHA-256 check")
+        return record
+
+    def list(
+        self,
+        scope_id: str,
+        tool_name: Optional[str] = None,
+        limit: int = 50,
+    ) -> List[Dict[str, Any]]:
+        self._validate_id(scope_id, "scope_id")
+        scope_dir = self.directory / scope_id
+        if not scope_dir.exists():
+            return []
+
+        records: List[Dict[str, Any]] = []
+        with self._lock:
+            for result_dir in scope_dir.iterdir():
+                if not result_dir.is_dir():
+                    continue
+                try:
+                    metadata = json.loads(
+                        (result_dir / "metadata.json").read_text(
+                            encoding="utf-8"
+                        )
+                    )
+                    record = ToolResultRecord.from_metadata(metadata, "")
+                    self._validate_record_identity(
+                        record, scope_id, result_dir.name
+                    )
+                    expired = record.expired
+                except (
+                    FileNotFoundError,
+                    ValueError,
+                    json.JSONDecodeError,
+                    TypeError,
+                ):
+                    continue
+                if expired:
+                    self.delete(scope_id, result_dir.name)
+                    continue
+                if tool_name is None or record.tool_name == tool_name:
+                    records.append(record.metadata_dict())
+        records.sort(key=lambda record: record["created_at"], reverse=True)
+        return records[:limit]
+
+    def delete(self, scope_id: str, result_id: str) -> None:
+        result_dir = self._result_dir(scope_id, result_id)
+        with self._lock:
+            for name in ("output.txt", "metadata.json"):
+                try:
+                    (result_dir / name).unlink()
+                except FileNotFoundError:
+                    pass
+            try:
+                result_dir.rmdir()
+            except (FileNotFoundError, OSError):
+                pass
+            try:
+                result_dir.parent.rmdir()
+            except (FileNotFoundError, OSError):
+                pass

--- a/camel/types/agents/tool_calling_record.py
+++ b/camel/types/agents/tool_calling_record.py
@@ -26,6 +26,10 @@ class ToolCallingRecord(BaseModel):
         tool_call_id (str): The ID of the tool call, if available.
         images (Optional[List[str]]): List of base64-encoded images returned
             by the tool, if any.
+        result_ref (Optional[str]): Reference to the complete result when the
+            memory copy was externalized.
+        result_externalized (bool): Whether the result stored in model memory
+            was replaced by an external reference preview.
     """
 
     tool_name: str
@@ -33,6 +37,8 @@ class ToolCallingRecord(BaseModel):
     result: Any
     tool_call_id: str
     images: Optional[List[str]] = None
+    result_ref: Optional[str] = None
+    result_externalized: bool = False
 
     def __str__(self) -> str:
         r"""Overridden version of the string function.

--- a/test/agents/test_tool_result_externalization.py
+++ b/test/agents/test_tool_result_externalization.py
@@ -188,6 +188,43 @@ def test_file_store_persists_payload_and_metadata_separately(tmp_path):
         second_store.get("test-scope", externalized.record.result_id)
 
 
+@pytest.mark.parametrize(
+    ("scope_id", "result_id"),
+    [
+        (".", "safe-result"),
+        ("..", "safe-result"),
+        ("safe-scope", "."),
+        ("safe-scope", ".."),
+    ],
+)
+def test_file_store_rejects_reserved_path_components(
+    tmp_path, scope_id, result_id
+):
+    store = FileToolResultStore(tmp_path / "store")
+    record = ToolResultRecord(
+        result_id=result_id,
+        scope_id=scope_id,
+        ref=f"camel://tool-results/{scope_id}/{result_id}",
+        tool_name="tool",
+        tool_call_id="call-path",
+        content="payload",
+        created_at=time.time(),
+        expires_at=None,
+        original_chars=7,
+        sha256="unused-before-save",
+    )
+
+    with pytest.raises(ValueError, match="Invalid"):
+        store.save(record)
+    with pytest.raises(ValueError, match="Invalid"):
+        store.get(scope_id, result_id)
+    with pytest.raises(ValueError, match="Invalid"):
+        store.delete(scope_id, result_id)
+    if scope_id in {".", ".."}:
+        with pytest.raises(ValueError, match="Invalid"):
+            store.list(scope_id)
+
+
 def test_in_memory_store_lazily_removes_expired_results():
     store = InMemoryToolResultStore()
     record = ToolResultRecord(
@@ -331,6 +368,32 @@ def test_masked_stream_tool_result_is_not_externalized():
     assert store.list("test-scope") == []
 
 
+def test_stream_tool_externalization_raise_mode_propagates_storage_failure():
+    store = MagicMock()
+    store.save.side_effect = OSError("storage unavailable")
+    agent = ChatAgent(
+        model=_mock_model(),
+        tools=[FunctionTool(_streaming_large_tool)],
+        tool_result_externalization=ToolResultExternalizationConfig(
+            threshold_chars=100,
+            preview_chars=20,
+            failure_mode="raise",
+            scope_id="test-scope",
+            store=store,
+        ),
+    )
+    tool_call = {
+        "id": "call-stream-raise",
+        "function": {
+            "name": "_streaming_large_tool",
+            "arguments": "{}",
+        },
+    }
+
+    with pytest.raises(OSError, match="storage unavailable"):
+        agent._execute_tool_from_stream_data(tool_call)
+
+
 @pytest.mark.asyncio
 async def test_async_stream_tool_execution_externalizes_result():
     agent = ChatAgent(
@@ -351,3 +414,30 @@ async def test_async_stream_tool_execution_externalizes_result():
     assert record is not None
     assert record.result_externalized is True
     assert record.result_ref is not None
+
+
+@pytest.mark.asyncio
+async def test_async_stream_raise_mode_propagates_storage_failure():
+    store = MagicMock()
+    store.save.side_effect = OSError("storage unavailable")
+    agent = ChatAgent(
+        model=_mock_model(),
+        tools=[FunctionTool(_streaming_large_tool)],
+        tool_result_externalization=ToolResultExternalizationConfig(
+            threshold_chars=100,
+            preview_chars=20,
+            failure_mode="raise",
+            scope_id="test-scope",
+            store=store,
+        ),
+    )
+    tool_call = {
+        "id": "call-async-stream-raise",
+        "function": {
+            "name": "_streaming_large_tool",
+            "arguments": "{}",
+        },
+    }
+
+    with pytest.raises(OSError, match="storage unavailable"):
+        await agent._aexecute_tool_from_stream_data(tool_call)

--- a/test/agents/test_tool_result_externalization.py
+++ b/test/agents/test_tool_result_externalization.py
@@ -1,0 +1,353 @@
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+
+import json
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from camel.agents import ChatAgent, ToolResultExternalizationConfig
+from camel.agents.tool_result_externalization import (
+    TOOL_RESULT_LIST_TOOL_NAME,
+    TOOL_RESULT_READ_TOOL_NAME,
+    TOOL_RESULT_SEARCH_TOOL_NAME,
+    ToolResultExternalizer,
+)
+from camel.models import BaseModelBackend
+from camel.storages import (
+    FileToolResultStore,
+    InMemoryToolResultStore,
+    ToolResultRecord,
+)
+from camel.toolkits import FunctionTool
+from camel.types import ModelType, OpenAIBackendRole
+
+
+def _mock_model() -> BaseModelBackend:
+    model = MagicMock(spec=BaseModelBackend)
+    model.model_type = ModelType.DEFAULT
+    model.token_limit = 4096
+    model.token_counter = MagicMock()
+    return model
+
+
+def _config(store=None, scope_id="test-scope"):
+    return ToolResultExternalizationConfig(
+        threshold_chars=100,
+        preview_chars=20,
+        max_read_chars=40,
+        store=store,
+        scope_id=scope_id,
+    )
+
+
+def _large_output() -> str:
+    return "HEAD-" + ("x" * 1_000) + "-Needle-" + ("y" * 1_000) + "-TAIL"
+
+
+def test_externalizer_round_trip_search_and_list():
+    externalizer = ToolResultExternalizer(_config(), "unused-agent-id")
+    original = _large_output()
+
+    externalized = externalizer.externalize(
+        original, tool_name="shell_view", tool_call_id="call-1"
+    )
+
+    assert externalized is not None
+    assert externalized.ref.startswith(
+        "camel://tool-results/test-scope/tr_call-1_"
+    )
+    assert original not in externalized.preview
+    assert "HEAD-" in externalized.preview
+    assert "-TAIL" in externalized.preview
+
+    read_result = externalizer.read(externalized.ref, offset=990, limit=1000)
+    assert read_result["returned_chars"] == 40
+    assert read_result["has_more"] is True
+    assert read_result["offset_unit"] == "unicode_code_point"
+
+    search_result = externalizer.search(
+        externalized.ref, "needle", context_chars=10
+    )
+    assert search_result["matches"][0]["offset"] == original.index("Needle")
+    assert "Needle" in search_result["matches"][0]["snippet"]
+
+    listed = externalizer.list(tool_name="shell_view")
+    assert listed["tool_results"][0]["ref"] == externalized.ref
+    assert "content" not in listed["tool_results"][0]
+
+
+def test_externalizer_keeps_result_inline_when_preview_is_larger():
+    externalizer = ToolResultExternalizer(_config(), "unused-agent-id")
+
+    externalized = externalizer.externalize(
+        "x" * 101, tool_name="shell_view", tool_call_id="call-small"
+    )
+
+    assert externalized is None
+    assert externalizer.list()["tool_results"] == []
+
+
+def test_externalizer_caps_list_results():
+    externalizer = ToolResultExternalizer(
+        ToolResultExternalizationConfig(
+            threshold_chars=100,
+            preview_chars=20,
+            max_list_results=2,
+            scope_id="test-scope",
+        ),
+        "unused-agent-id",
+    )
+    for index in range(3):
+        assert externalizer.externalize(
+            _large_output() + str(index),
+            tool_name="shell_view",
+            tool_call_id=f"call-{index}",
+        )
+
+    assert len(externalizer.list(limit=100)["tool_results"]) == 2
+
+
+def test_externalizer_storage_failure_modes():
+    store = MagicMock()
+    store.save.side_effect = OSError("storage unavailable")
+    inline_externalizer = ToolResultExternalizer(
+        _config(store=store), "unused-agent-id"
+    )
+
+    assert (
+        inline_externalizer.externalize(
+            _large_output(),
+            tool_name="shell_view",
+            tool_call_id="call-inline",
+        )
+        is None
+    )
+
+    raise_externalizer = ToolResultExternalizer(
+        ToolResultExternalizationConfig(
+            threshold_chars=100,
+            preview_chars=20,
+            failure_mode="raise",
+            scope_id="test-scope",
+            store=store,
+        ),
+        "unused-agent-id",
+    )
+    with pytest.raises(OSError, match="storage unavailable"):
+        raise_externalizer.externalize(
+            _large_output(),
+            tool_name="shell_view",
+            tool_call_id="call-raise",
+        )
+
+
+def test_file_store_persists_payload_and_metadata_separately(tmp_path):
+    first_store = FileToolResultStore(tmp_path)
+    externalizer = ToolResultExternalizer(
+        _config(store=first_store), "unused-agent-id"
+    )
+    original = _large_output()
+    externalized = externalizer.externalize(
+        original, tool_name="pytest", tool_call_id="call-file"
+    )
+    assert externalized is not None
+
+    result_dir = tmp_path / "test-scope" / externalized.record.result_id
+    assert (result_dir / "output.txt").read_text() == original
+    metadata = json.loads((result_dir / "metadata.json").read_text())
+    assert "content" not in metadata
+    assert metadata["sha256"] == externalized.record.sha256
+
+    second_store = FileToolResultStore(tmp_path)
+    restored = second_store.get("test-scope", externalized.record.result_id)
+    assert restored is not None
+    assert restored.content == original
+
+    (result_dir / "output.txt").write_text("corrupted")
+    listed = second_store.list("test-scope")
+    assert listed[0]["ref"] == externalized.ref
+    with pytest.raises(ValueError, match="SHA-256"):
+        second_store.get("test-scope", externalized.record.result_id)
+
+    metadata["scope_id"] = "other-scope"
+    (result_dir / "metadata.json").write_text(json.dumps(metadata))
+    with pytest.raises(ValueError, match="identity"):
+        second_store.get("test-scope", externalized.record.result_id)
+
+
+def test_in_memory_store_lazily_removes_expired_results():
+    store = InMemoryToolResultStore()
+    record = ToolResultRecord(
+        result_id="tr_expired",
+        scope_id="test-scope",
+        ref="camel://tool-results/test-scope/tr_expired",
+        tool_name="tool",
+        tool_call_id="call-expired",
+        content="expired",
+        created_at=time.time() - 10,
+        expires_at=time.time() - 1,
+        original_chars=7,
+        sha256="unused-in-memory",
+    )
+    store.save(record)
+
+    assert store.get("test-scope", "tr_expired") is None
+    assert store.list("test-scope") == []
+
+
+def test_chat_agent_externalizes_only_the_memory_copy_and_registers_tools():
+    agent = ChatAgent(
+        model=_mock_model(), tool_result_externalization=_config()
+    )
+    original = _large_output()
+
+    tool_record = agent._record_tool_calling(
+        "shell_view", {"path": "large.log"}, original, "call-agent"
+    )
+
+    assert tool_record.result == original
+    assert tool_record.result_externalized is True
+    assert tool_record.result_ref is not None
+    assert {
+        TOOL_RESULT_READ_TOOL_NAME,
+        TOOL_RESULT_SEARCH_TOOL_NAME,
+        TOOL_RESULT_LIST_TOOL_NAME,
+    }.issubset(agent.tool_dict)
+
+    memory_records = agent.memory.retrieve()
+    tool_messages = [
+        record.memory_record.message
+        for record in memory_records
+        if record.memory_record.role_at_backend == OpenAIBackendRole.FUNCTION
+    ]
+    assert len(tool_messages) == 1
+    assert original not in str(tool_messages[0].result)
+    assert tool_record.result_ref in str(tool_messages[0].result)
+
+
+def test_read_tool_result_is_not_externalized_again():
+    agent = ChatAgent(
+        model=_mock_model(), tool_result_externalization=_config()
+    )
+    original_record = agent._record_tool_calling(
+        "shell_view", {}, _large_output(), "call-original"
+    )
+    assert original_record.result_ref is not None
+
+    read_output = agent.tool_dict[TOOL_RESULT_READ_TOOL_NAME](
+        ref=original_record.result_ref, offset=0, limit=40
+    )
+    read_record = agent._record_tool_calling(
+        TOOL_RESULT_READ_TOOL_NAME,
+        {"ref": original_record.result_ref, "offset": 0, "limit": 40},
+        read_output,
+        "call-read",
+    )
+
+    assert read_record.result_externalized is False
+    assert read_record.result_ref is None
+    assert "[CAMEL externalized tool result chunk]" in read_output
+
+
+def test_clone_with_memory_preserves_result_scope_and_store():
+    agent = ChatAgent(
+        model=_mock_model(), tool_result_externalization=_config(scope_id=None)
+    )
+    tool_record = agent._record_tool_calling(
+        "shell_view", {}, _large_output(), "call-clone"
+    )
+    assert tool_record.result_ref is not None
+
+    cloned = agent.clone(with_memory=True)
+    read_output = cloned.tool_dict[TOOL_RESULT_READ_TOOL_NAME](
+        ref=tool_record.result_ref, offset=0, limit=20
+    )
+
+    assert not read_output.startswith("Error reading")
+    assert "HEAD-" in read_output
+
+
+def _streaming_large_tool() -> str:
+    r"""Return a large result for stream-path tests."""
+    return _large_output()
+
+
+def test_stream_tool_execution_externalizes_result():
+    agent = ChatAgent(
+        model=_mock_model(),
+        tools=[FunctionTool(_streaming_large_tool)],
+        tool_result_externalization=_config(),
+    )
+    tool_call = {
+        "id": "call-stream",
+        "function": {
+            "name": "_streaming_large_tool",
+            "arguments": "{}",
+        },
+    }
+
+    record = agent._execute_tool_from_stream_data(tool_call)
+
+    assert record is not None
+    assert record.result_externalized is True
+    assert record.result_ref is not None
+
+
+def test_masked_stream_tool_result_is_not_externalized():
+    store = InMemoryToolResultStore()
+    agent = ChatAgent(
+        model=_mock_model(),
+        tools=[FunctionTool(_streaming_large_tool)],
+        mask_tool_output=True,
+        tool_result_externalization=_config(store=store),
+    )
+    tool_call = {
+        "id": "call-masked-stream",
+        "function": {
+            "name": "_streaming_large_tool",
+            "arguments": "{}",
+        },
+    }
+
+    record = agent._execute_tool_from_stream_data(tool_call)
+
+    assert record is not None
+    assert record.result_externalized is False
+    assert record.result_ref is None
+    assert "output from the tool is masked" in record.result
+    assert store.list("test-scope") == []
+
+
+@pytest.mark.asyncio
+async def test_async_stream_tool_execution_externalizes_result():
+    agent = ChatAgent(
+        model=_mock_model(),
+        tools=[FunctionTool(_streaming_large_tool)],
+        tool_result_externalization=_config(),
+    )
+    tool_call = {
+        "id": "call-async-stream",
+        "function": {
+            "name": "_streaming_large_tool",
+            "arguments": "{}",
+        },
+    }
+
+    record = await agent._aexecute_tool_from_stream_data(tool_call)
+
+    assert record is not None
+    assert record.result_externalized is True
+    assert record.result_ref is not None


### PR DESCRIPTION
## Description

Fixes #3376
Related to #3616 and #3675.

This PR adds opt-in tool result externalization to `ChatAgent`.

When a tool result exceeds a configurable threshold, CAMEL stores the complete
serialized result outside model memory and keeps a deterministic head/tail
preview plus a stable `camel://tool-results/...` reference in the conversation.
The agent can inspect the original result through automatically registered,
bounded read, exact search, and list tools.

## Why this approach?

Existing proposals cover parts of the problem:

- #3296 automatically offloads large outputs, but couples the feature to a
  file-only cache. Review feedback requested a pluggable storage abstraction.
- #3725 asks the model to summarize and offload after seeing the full output.
  This adds an extra model decision and can leave older large outputs inline.
  Its review also found quality loss when useful content was outside the
  generated prefix summary.
- The current truncation path prevents context overflow, but discards the
  truncated portion and cannot recover it (#3616).

This implementation keeps offloading deterministic and lossless while allowing
the model to retrieve only the relevant range instead of restoring the entire
output.

## Changes

- Add `ToolResultExternalizationConfig` to `ChatAgent`; behavior remains
  unchanged unless the config is supplied.
- Add `BaseToolResultStore` with thread-safe in-memory and durable file-backed
  implementations.
- Store full output and metadata separately, with TTL support, SHA-256 integrity
  metadata, scoped references, and atomic file writes.
- Keep the original result in `ToolCallingRecord`, while replacing only the
  model-memory copy with a preview/reference.
- Auto-register bounded read, exact search, and list tools.
- Apply the same behavior to sync, async, and streaming tool execution paths.
- Preserve references and storage when cloning an agent with memory.
- Fall back to the existing inline/truncation behavior if persistence fails.
- Skip externalization when the generated preview would be no smaller than the
  original result.

## Usage

```python
from camel.agents import ChatAgent, ToolResultExternalizationConfig
from camel.storages import FileToolResultStore

agent = ChatAgent(
    model=model,
    tools=[large_output_tool],
    tool_result_externalization=ToolResultExternalizationConfig(
        store=FileToolResultStore(".camel/tool-results"),
    ),
)
```

## Safety and compatibility

- Disabled by default.
- Masked tool outputs are never persisted.
- References are scoped to the owning agent or an explicitly configured scope.
- Read/search/list responses have configurable hard limits.
- Existing tool-result truncation remains the fallback.
- No new dependencies are introduced.

## Tests

- In-memory round trip, TTL expiry, search, range reads, and list limits.
- File persistence, metadata separation, and integrity metadata.
- ChatAgent memory replacement while preserving the original return value.
- Access-tool loop prevention.
- Clone behavior.
- Sync and async streaming execution paths.
- Preview-size guard.

Local verification:

- `uv run ruff format camel/agents/tool_result_externalization.py camel/storages/tool_result_storages.py test/agents/test_tool_result_externalization.py`
- `uv run ruff check camel/agents/tool_result_externalization.py camel/storages/tool_result_storages.py camel/agents/chat_agent.py camel/types/agents/tool_calling_record.py camel/agents/__init__.py camel/storages/__init__.py test/agents/test_tool_result_externalization.py`
- `uv run mypy camel/agents/tool_result_externalization.py camel/storages/tool_result_storages.py camel/types/agents/tool_calling_record.py`
- `uv run python -m pytest test/agents/test_tool_result_externalization.py -q`
- `TIKTOKEN_CACHE_DIR=/tmp/tiktoken-cache OPENAI_API_KEY=dummy .venv/bin/python -m pytest test/agents/test_chat_agent.py -q -m 'not model_backend'`

## Checklist

- [x] Tests added
- [x] Documentation added through public API docstrings
- [x] No dependency or lockfile changes
- [x] Backward-compatible default behavior
