### PR TITLE
docs: document browser console exec trust boundary

### DIFF
--- a/camel/toolkits/hybrid_browser_toolkit/hybrid_browser_toolkit_ts.py
+++ b/camel/toolkits/hybrid_browser_toolkit/hybrid_browser_toolkit_ts.py
@@ -1417,11 +1417,16 @@ class HybridBrowserToolkit(BaseToolkit, RegisteredAgentToolkit):
             return {"console_messages": []}
 
     async def browser_console_exec(self, code: str) -> Dict[str, Any]:
-        r"""Execute javascript code in the console of the current page and get
+        r"""Execute JavaScript code in the current page context and return
         results.
 
+        This tool is not a sandbox: code runs with the active page's DOM,
+        storage, cookies, and network access. Only enable or call it for
+        trusted pages, trusted tasks, and trusted agent policies.
+
         Args:
-            code (str): JavaScript code to execute in the browser console.
+            code (str): JavaScript code to execute in the current page
+                context.
 
         Returns:
             Dict[str, Any]: A dictionary with the result of the action:

--- a/camel/toolkits/hybrid_browser_toolkit/ts/src/hybrid-browser-toolkit.ts
+++ b/camel/toolkits/hybrid_browser_toolkit/ts/src/hybrid-browser-toolkit.ts
@@ -619,6 +619,8 @@ export class HybridBrowserToolkit {
 
           let result;
           try {
+            // Trust boundary: this intentionally executes caller-provided
+            // JavaScript in the active page context, not in a sandbox.
             result = eval(${JSON.stringify(code)});
           } catch (e) {
             try {

--- a/test/toolkits/test_hybrid_browser_toolkit.py
+++ b/test/toolkits/test_hybrid_browser_toolkit.py
@@ -580,6 +580,25 @@ class TestHybridBrowserToolkit:
         assert "tabs" in result
         assert "result" in result["result"].lower()
 
+    def test_console_exec_tool_schema_documents_trust_boundary(self):
+        """Test console_exec tool schema documents its trust boundary."""
+        toolkit = HybridBrowserToolkit(
+            headless=True,
+            enabled_tools=["browser_console_exec"],
+        )
+        tool = toolkit.get_tools()[0]
+        schema = tool.get_openai_tool_schema()
+
+        description = schema["function"]["description"].lower()
+        code_description = schema["function"]["parameters"]["properties"][
+            "code"
+        ]["description"].lower()
+
+        assert "current page context" in description
+        assert "not a sandbox" in description
+        assert "trusted" in description
+        assert "javascript" in code_description
+
     def test_get_tools(self, sync_browser_toolkit):
         """Test getting available tools with default configuration."""
         toolkit = sync_browser_toolkit


### PR DESCRIPTION
## Description

Documents the trust boundary for `HybridBrowserToolkit.browser_console_exec`.

The tool executes caller-provided JavaScript in the active page context, so this PR makes that behavior explicit in the agent-visible tool schema and adds a short source comment near the TypeScript `eval()` call.

This is documentation/schema wording only: no runtime behavior or public API changes.

Closes #4155.

## Tests

```bash
python -m pytest test\toolkits\test_hybrid_browser_toolkit.py -q
python -m py_compile camel\toolkits\hybrid_browser_toolkit\hybrid_browser_toolkit_ts.py test\toolkits\test_hybrid_browser_toolkit.py
git diff --check
cd camel\toolkits\hybrid_browser_toolkit\ts && npm ci --ignore-scripts && npm run build
```
