### PR TITLE
fix(utils): support Langfuse v3 API in configure_langfuse

### DIFF
--- a/camel/utils/langfuse.py
+++ b/camel/utils/langfuse.py
@@ -30,18 +30,20 @@ _agent_session_id_var: ContextVar[str | None] = ContextVar(
 _langfuse_configured = False
 _langfuse_client: Any | None = None
 
+_langfuse_sdk: Any | None = None
 try:
-    import langfuse as _langfuse_sdk
+    import langfuse
 
+    _langfuse_sdk = langfuse
     LANGFUSE_AVAILABLE = True
 except ImportError:
-    _langfuse_sdk = None
     LANGFUSE_AVAILABLE = False
 
+_langfuse_v2_context: Any | None = None
 try:
-    from langfuse.decorators import (
-        langfuse_context as _langfuse_v2_context,
-    )
+    from langfuse.decorators import langfuse_context
+
+    _langfuse_v2_context = langfuse_context
 except ImportError:
     _langfuse_v2_context = None
 
@@ -158,7 +160,7 @@ def configure_langfuse(
     )
 
     try:
-        if _is_langfuse_v3():
+        if _is_langfuse_v3() and _langfuse_sdk is not None:
             _langfuse_client = _langfuse_sdk.Langfuse(
                 public_key=public_key,
                 secret_key=secret_key,
@@ -177,7 +179,7 @@ def configure_langfuse(
             _langfuse_client = None
         else:
             raise RuntimeError('Installed Langfuse SDK has no supported API')
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         _langfuse_client = None
         _langfuse_configured = False
         logger.error(f'Failed to configure Langfuse: {exc}')

--- a/camel/utils/langfuse.py
+++ b/camel/utils/langfuse.py
@@ -11,108 +11,180 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+import inspect
 import os
+from collections.abc import Callable
 from contextvars import ContextVar
-from typing import Any, Dict, List, Optional
+from functools import wraps
+from typing import Any
 
 from camel.logger import get_logger
 from camel.utils import dependencies_required
 
 logger = get_logger(__name__)
 
-_agent_session_id_var: ContextVar[Optional[str]] = ContextVar(
+_agent_session_id_var: ContextVar[str | None] = ContextVar(
     'agent_session_id', default=None
 )
 
-# Global flag to track if Langfuse has been configured
 _langfuse_configured = False
+_langfuse_client: Any | None = None
 
 try:
-    from langfuse.decorators import langfuse_context
+    import langfuse as _langfuse_sdk
 
     LANGFUSE_AVAILABLE = True
 except ImportError:
+    _langfuse_sdk = None
     LANGFUSE_AVAILABLE = False
+
+try:
+    from langfuse.decorators import (
+        langfuse_context as _langfuse_v2_context,
+    )
+except ImportError:
+    _langfuse_v2_context = None
+
+
+def _is_langfuse_v3() -> bool:
+    r"""Return whether the installed SDK exposes the v3 client API."""
+    return _langfuse_v2_context is None and callable(
+        getattr(_langfuse_sdk, 'Langfuse', None)
+    )
+
+
+def _get_langfuse_client() -> Any | None:
+    r"""Return the configured v2 context or v3 client."""
+    if _is_langfuse_v3():
+        return _langfuse_client
+    return _langfuse_v2_context
+
+
+def _get_langfuse_observe() -> Callable[..., Any] | None:
+    r"""Return the SDK's observe decorator for either supported API."""
+    if _is_langfuse_v3():
+        return getattr(_langfuse_sdk, 'observe', None)
+
+    try:
+        from langfuse.decorators import observe as v2_observe
+
+        return v2_observe
+    except ImportError:
+        return None
+
+
+def _as_usage_details(usage: Any) -> dict[str, int] | None:
+    r"""Convert provider/OpenAI usage objects to Langfuse v3 details."""
+    if usage is None:
+        return None
+
+    if hasattr(usage, 'model_dump'):
+        usage = usage.model_dump(exclude_none=True)
+    elif not isinstance(usage, dict) and hasattr(usage, 'dict'):
+        usage = usage.dict(exclude_none=True)
+
+    if not isinstance(usage, dict):
+        return None
+
+    return {
+        str(key): value
+        for key, value in usage.items()
+        if isinstance(value, int) and not isinstance(value, bool)
+    }
 
 
 @dependencies_required('langfuse')
 def configure_langfuse(
-    public_key: Optional[str] = None,
-    secret_key: Optional[str] = None,
-    host: Optional[str] = None,
-    debug: Optional[bool] = None,
-    enabled: Optional[bool] = None,
-):
+    public_key: str | None = None,
+    secret_key: str | None = None,
+    host: str | None = None,
+    debug: bool | None = None,
+    enabled: bool | None = None,
+) -> None:
     r"""Configure Langfuse for CAMEL models.
 
+    Supports the legacy v2 ``langfuse_context`` API and the v3 client API.
+
     Args:
-        public_key(Optional[str]): Langfuse public key. Can be set via LANGFUSE_PUBLIC_KEY.
-            (default: :obj:`None`)
-        secret_key(Optional[str]): Langfuse secret key. Can be set via LANGFUSE_SECRET_KEY.
-            (default: :obj:`None`)
-        host(Optional[str]): Langfuse host URL. Can be set via LANGFUSE_HOST.
+        public_key(Optional[str]): Langfuse public key. Can be set via
+            ``LANGFUSE_PUBLIC_KEY``. (default: :obj:`None`)
+        secret_key(Optional[str]): Langfuse secret key. Can be set via
+            ``LANGFUSE_SECRET_KEY``. (default: :obj:`None`)
+        host(Optional[str]): Langfuse host URL. Can be set via
+            ``LANGFUSE_BASE_URL`` or ``LANGFUSE_HOST``.
             (default: :obj:`https://cloud.langfuse.com`)
-        debug(Optional[bool]): Enable debug mode. Can be set via LANGFUSE_DEBUG.
-            (default: :obj:`None`)
-        enabled(Optional[bool]): Enable/disable tracing. Can be set via LANGFUSE_ENABLED.
-            (default: :obj:`None`)
+        debug(Optional[bool]): Enable debug mode. Can be set via
+            ``LANGFUSE_DEBUG``. (default: :obj:`None`)
+        enabled(Optional[bool]): Enable/disable tracing. Can be set via
+            ``LANGFUSE_ENABLED``. (default: :obj:`None`)
+    """
+    global _langfuse_client, _langfuse_configured
 
-    Note:
-        This function configures the native langfuse_context which works with
-            @observe() decorators. Set enabled=False to disable all tracing.
-    """  # noqa: E501
-    global _langfuse_configured
-
-    # Get configuration from environment or parameters
-    public_key = public_key or os.environ.get("LANGFUSE_PUBLIC_KEY")
-    secret_key = secret_key or os.environ.get("LANGFUSE_SECRET_KEY")
-    host = host or os.environ.get(
-        "LANGFUSE_HOST", "https://cloud.langfuse.com"
+    public_key = public_key or os.environ.get('LANGFUSE_PUBLIC_KEY')
+    secret_key = secret_key or os.environ.get('LANGFUSE_SECRET_KEY')
+    host = (
+        host
+        or os.environ.get('LANGFUSE_BASE_URL')
+        or os.environ.get('LANGFUSE_HOST')
+        or 'https://cloud.langfuse.com'
     )
     debug = (
         debug
         if debug is not None
-        else os.environ.get("LANGFUSE_DEBUG", "False").lower() == "true"
+        else os.environ.get('LANGFUSE_DEBUG', 'false').lower() == 'true'
     )
 
-    # Handle enabled parameter
     if enabled is None:
-        env_enabled_str = os.environ.get("LANGFUSE_ENABLED")
-        if env_enabled_str is not None:
-            enabled = env_enabled_str.lower() == "true"
-        else:
-            enabled = False  # Default to disabled
+        enabled = os.environ.get('LANGFUSE_ENABLED', 'false').lower() == 'true'
 
-    # If not enabled, don't configure anything and don't call langfuse function
     if not enabled:
+        _langfuse_client = None
         _langfuse_configured = False
-        logger.info("Langfuse tracing disabled for CAMEL models")
+        logger.info('Langfuse tracing disabled for CAMEL models')
+        return
+
+    if not public_key or not secret_key:
+        _langfuse_client = None
+        _langfuse_configured = False
+        logger.warning(
+            'Langfuse tracing requires both a public key and a secret key'
+        )
         return
 
     logger.debug(
         f"Configuring Langfuse - enabled: {enabled}, "
-        f"public_key: {'***' + public_key[-4:] if public_key else None}, "
+        f"public_key: {'***' + public_key[-4:]}, "
         f"host: {host}, debug: {debug}"
     )
-    if enabled and public_key and secret_key and LANGFUSE_AVAILABLE:
-        _langfuse_configured = True
-    else:
-        _langfuse_configured = False
 
     try:
-        # Configure langfuse_context with native method
-        langfuse_context.configure(
-            public_key=public_key,
-            secret_key=secret_key,
-            host=host,
-            debug=debug,
-            enabled=True,  # Always True here since we checked enabled above
-        )
+        if _is_langfuse_v3():
+            _langfuse_client = _langfuse_sdk.Langfuse(
+                public_key=public_key,
+                secret_key=secret_key,
+                host=host,
+                debug=debug,
+                tracing_enabled=True,
+            )
+        elif _langfuse_v2_context is not None:
+            _langfuse_v2_context.configure(
+                public_key=public_key,
+                secret_key=secret_key,
+                host=host,
+                debug=debug,
+                enabled=True,
+            )
+            _langfuse_client = None
+        else:
+            raise RuntimeError('Installed Langfuse SDK has no supported API')
+    except Exception as exc:  # noqa: BLE001
+        _langfuse_client = None
+        _langfuse_configured = False
+        logger.error(f'Failed to configure Langfuse: {exc}')
+        return
 
-        logger.info("Langfuse tracing enabled for CAMEL models")
-
-    except Exception as e:
-        logger.error(f"Failed to configure Langfuse: {e}")
+    _langfuse_configured = True
+    logger.info('Langfuse tracing enabled for CAMEL models')
 
 
 def is_langfuse_available() -> bool:
@@ -123,8 +195,8 @@ def is_langfuse_available() -> bool:
 def set_current_agent_session_id(session_id: str) -> None:
     r"""Set the session ID for the current agent in context-local storage.
 
-    This is safe to use in both sync and async contexts.
-    In async contexts, each coroutine maintains its own value.
+    This is safe to use in both sync and async contexts. In async contexts,
+    each coroutine maintains its own value.
 
     Args:
         session_id(str): The session ID to set for the current agent.
@@ -132,91 +204,104 @@ def set_current_agent_session_id(session_id: str) -> None:
     _agent_session_id_var.set(session_id)
 
 
-def get_current_agent_session_id() -> Optional[str]:
-    r"""Get the session ID for the current agent from context-local storage.
-
-    This is safe to use in both sync and async contexts.
-    In async contexts, returns the value for the current coroutine.
+def get_current_agent_session_id() -> str | None:
+    r"""Get the session ID for the current agent.
 
     Returns:
-        Optional[str]: The session ID for the current agent.
+        Optional[str]: The current context-local session ID.
     """
     return _agent_session_id_var.get()
 
 
 def update_langfuse_trace(
-    session_id: Optional[str] = None,
-    user_id: Optional[str] = None,
-    metadata: Optional[Dict[str, Any]] = None,
-    tags: Optional[List[str]] = None,
+    session_id: str | None = None,
+    user_id: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    tags: list[str] | None = None,
 ) -> bool:
     r"""Update the current Langfuse trace with session ID and metadata.
 
     Args:
-        session_id(Optional[str]): Optional session ID to use. If :obj:`None`
-            uses the current agent's session ID. (default: :obj:`None`)
-        user_id(Optional[str]): Optional user ID for the trace.
+        session_id(Optional[str]): Session ID. Uses the current agent session
+            when omitted. (default: :obj:`None`)
+        user_id(Optional[str]): User ID for the trace.
             (default: :obj:`None`)
-        metadata(Optional[Dict[str, Any]]): Optional metadata dictionary.
+        metadata(Optional[Dict[str, Any]]): Trace metadata.
             (default: :obj:`None`)
-        tags(Optional[List[str]]): Optional list of tags.
-            (default: :obj:`None`)
+        tags(Optional[List[str]]): Trace tags. (default: :obj:`None`)
 
     Returns:
-        bool: True if update was successful, False otherwise.
+        bool: Whether an update was sent to Langfuse.
     """
-    if not is_langfuse_available():
+    client = _get_langfuse_client()
+    if not is_langfuse_available() or client is None:
         return False
 
-    # Use provided session_id or get from thread-local storage
     final_session_id = session_id or get_current_agent_session_id()
-
-    update_data: Dict[str, Any] = {}
+    update_data: dict[str, Any] = {}
     if final_session_id:
-        update_data["session_id"] = final_session_id
+        update_data['session_id'] = final_session_id
     if user_id:
-        update_data["user_id"] = user_id
+        update_data['user_id'] = user_id
     if metadata:
-        update_data["metadata"] = metadata
+        update_data['metadata'] = metadata
     if tags:
-        update_data["tags"] = tags
+        update_data['tags'] = tags
 
-    if update_data:
-        langfuse_context.update_current_trace(**update_data)
-        return True
+    if not update_data:
+        return False
 
-    return False
+    client.update_current_trace(**update_data)
+    return True
 
 
 def update_current_observation(
-    input: Optional[Dict[str, Any]] = None,
-    output: Optional[Dict[str, Any]] = None,
-    model: Optional[str] = None,
-    model_parameters: Optional[Dict[str, Any]] = None,
-    usage_details: Optional[Dict[str, Any]] = None,
-    **kwargs,
+    input: dict[str, Any] | None = None,
+    output: dict[str, Any] | None = None,
+    model: str | None = None,
+    model_parameters: dict[str, Any] | None = None,
+    usage_details: dict[str, Any] | None = None,
+    **kwargs: Any,
 ) -> None:
-    r"""Update the current Langfuse observation with input, output,
-    model, model_parameters, and usage_details.
+    r"""Update the current Langfuse generation.
+
+    CAMEL's model call sites are generation observations. Langfuse v2 exposes
+    a generic ``update_current_observation`` method, while v3 replaces it with
+    ``update_current_generation``.
 
     Args:
-        input(Optional[Dict[str, Any]]): Optional input dictionary.
+        input(Optional[Dict[str, Any]]): Generation input.
             (default: :obj:`None`)
-        output(Optional[Dict[str, Any]]): Optional output dictionary.
+        output(Optional[Dict[str, Any]]): Generation output.
             (default: :obj:`None`)
-        model(Optional[str]): Optional model name. (default: :obj:`None`)
-        model_parameters(Optional[Dict[str, Any]]): Optional model parameters
-            dictionary. (default: :obj:`None`)
-        usage_details(Optional[Dict[str, Any]]): Optional usage details
-            dictionary. (default: :obj:`None`)
-
-    Returns:
-        None
+        model(Optional[str]): Model name. (default: :obj:`None`)
+        model_parameters(Optional[Dict[str, Any]]): Model parameters.
+            (default: :obj:`None`)
+        usage_details(Optional[Dict[str, Any]]): Token usage details.
+            (default: :obj:`None`)
+        **kwargs(Any): Additional Langfuse fields. A legacy ``usage`` object
+            is normalized to v3 ``usage_details``.
     """
-    if not is_langfuse_available():
+    client = _get_langfuse_client()
+    if not is_langfuse_available() or client is None:
         return
 
-    langfuse_context.update_current_observation(
+    if _is_langfuse_v3():
+        legacy_usage = kwargs.pop('usage', None)
+        normalized_usage = _as_usage_details(
+            usage_details if usage_details is not None else legacy_usage
+        )
+        client.update_current_generation(
+            input=input,
+            output=output,
+            model=model,
+            model_parameters=model_parameters,
+            usage_details=normalized_usage,
+            **kwargs,
+        )
+        return
+
+    client.update_current_observation(
         input=input,
         output=output,
         model=model,
@@ -226,39 +311,79 @@ def update_current_observation(
     )
 
 
-def get_langfuse_status() -> Dict[str, Any]:
+def get_langfuse_status() -> dict[str, Any]:
     r"""Get detailed Langfuse configuration status for debugging.
 
     Returns:
         Dict[str, Any]: Status information including configuration state.
     """
-    env_enabled_str = os.environ.get("LANGFUSE_ENABLED")
+    env_enabled_str = os.environ.get('LANGFUSE_ENABLED')
     env_enabled = (
-        env_enabled_str.lower() == "true" if env_enabled_str else None
+        env_enabled_str.lower() == 'true' if env_enabled_str else None
     )
 
-    status = {
-        "configured": _langfuse_configured,
-        "has_public_key": bool(os.environ.get("LANGFUSE_PUBLIC_KEY")),
-        "has_secret_key": bool(os.environ.get("LANGFUSE_SECRET_KEY")),
-        "env_enabled": env_enabled,
-        "host": os.environ.get("LANGFUSE_HOST", "https://cloud.langfuse.com"),
-        "debug": os.environ.get("LANGFUSE_DEBUG", "false").lower() == "true",
-        "current_session_id": get_current_agent_session_id(),
+    return {
+        'configured': _langfuse_configured,
+        'has_public_key': bool(os.environ.get('LANGFUSE_PUBLIC_KEY')),
+        'has_secret_key': bool(os.environ.get('LANGFUSE_SECRET_KEY')),
+        'env_enabled': env_enabled,
+        'host': (
+            os.environ.get('LANGFUSE_BASE_URL')
+            or os.environ.get('LANGFUSE_HOST')
+            or 'https://cloud.langfuse.com'
+        ),
+        'debug': os.environ.get('LANGFUSE_DEBUG', 'false').lower() == 'true',
+        'current_session_id': get_current_agent_session_id(),
+        'client_available': _get_langfuse_client() is not None,
+        'sdk_api': 'v3' if _is_langfuse_v3() else 'v2',
     }
 
-    if _langfuse_configured:
-        try:
-            # Try to get some context information
-            status["langfuse_context_available"] = True
-        except Exception as e:
-            status["langfuse_context_error"] = str(e)
 
-    return status
+def observe(*decorator_args: Any, **decorator_kwargs: Any) -> Any:
+    r"""Lazily apply the installed Langfuse observe decorator.
 
+    Model modules import this function before applications usually call
+    :func:`configure_langfuse`. Delaying native decoration until the first
+    configured call avoids permanently replacing tracing with a no-op.
+    """
 
-def observe(*args, **kwargs):
-    def decorator(func):
-        return func
+    def decorate(func: Callable[..., Any]) -> Callable[..., Any]:
+        observed_func: Callable[..., Any] | None = None
 
-    return decorator
+        def resolve() -> Callable[..., Any]:
+            nonlocal observed_func
+            if not is_langfuse_available():
+                return func
+            if observed_func is None:
+                sdk_observe = _get_langfuse_observe()
+                if sdk_observe is None:
+                    return func
+                observed_func = sdk_observe(
+                    *decorator_args, **decorator_kwargs
+                )(func)
+            return observed_func
+
+        if inspect.iscoroutinefunction(func):
+
+            @wraps(func)
+            async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+                return await resolve()(*args, **kwargs)
+
+            return async_wrapper
+
+        @wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            return resolve()(*args, **kwargs)
+
+        return wrapper
+
+    if (
+        len(decorator_args) == 1
+        and callable(decorator_args[0])
+        and not decorator_kwargs
+    ):
+        func = decorator_args[0]
+        decorator_args = ()
+        return decorate(func)
+
+    return decorate

--- a/test/utils/test_langfuse.py
+++ b/test/utils/test_langfuse.py
@@ -1,0 +1,242 @@
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+import camel.utils.langfuse as langfuse_utils
+
+
+@pytest.fixture(autouse=True)
+def reset_langfuse_state(monkeypatch):
+    monkeypatch.setattr(langfuse_utils, '_langfuse_configured', False)
+    monkeypatch.setattr(langfuse_utils, '_langfuse_client', None)
+    monkeypatch.setattr(langfuse_utils, '_langfuse_v2_context', None)
+    for key in (
+        'LANGFUSE_PUBLIC_KEY',
+        'LANGFUSE_SECRET_KEY',
+        'LANGFUSE_BASE_URL',
+        'LANGFUSE_HOST',
+        'LANGFUSE_DEBUG',
+        'LANGFUSE_ENABLED',
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def configure(**kwargs):
+    return langfuse_utils.configure_langfuse.__wrapped__(**kwargs)
+
+
+def test_configure_v3_creates_client_with_explicit_settings(monkeypatch):
+    client = MagicMock()
+    constructor = MagicMock(return_value=client)
+    monkeypatch.setattr(
+        langfuse_utils,
+        '_langfuse_sdk',
+        SimpleNamespace(Langfuse=constructor, observe=MagicMock()),
+    )
+
+    configure(
+        public_key='pk-test',
+        secret_key='sk-test',
+        host='https://langfuse.example.com',
+        debug=True,
+        enabled=True,
+    )
+
+    constructor.assert_called_once_with(
+        public_key='pk-test',
+        secret_key='sk-test',
+        host='https://langfuse.example.com',
+        debug=True,
+        tracing_enabled=True,
+    )
+    assert langfuse_utils._langfuse_client is client
+    assert langfuse_utils.is_langfuse_available()
+
+
+def test_configure_v2_uses_legacy_context(monkeypatch):
+    context = MagicMock()
+    monkeypatch.setattr(langfuse_utils, '_langfuse_v2_context', context)
+    monkeypatch.setattr(langfuse_utils, '_langfuse_sdk', SimpleNamespace())
+
+    configure(
+        public_key='pk-test',
+        secret_key='sk-test',
+        host='https://langfuse.example.com',
+        enabled=True,
+    )
+
+    context.configure.assert_called_once_with(
+        public_key='pk-test',
+        secret_key='sk-test',
+        host='https://langfuse.example.com',
+        debug=False,
+        enabled=True,
+    )
+    assert langfuse_utils.is_langfuse_available()
+
+
+def test_configure_uses_base_url_and_rejects_missing_credentials(
+    monkeypatch,
+):
+    constructor = MagicMock()
+    monkeypatch.setattr(
+        langfuse_utils,
+        '_langfuse_sdk',
+        SimpleNamespace(Langfuse=constructor),
+    )
+    monkeypatch.setenv('LANGFUSE_BASE_URL', 'https://us.example.com')
+
+    configure(public_key='pk-test', enabled=True)
+
+    constructor.assert_not_called()
+    assert not langfuse_utils.is_langfuse_available()
+
+
+def test_update_trace_uses_context_session_id(monkeypatch):
+    client = MagicMock()
+    monkeypatch.setattr(langfuse_utils, '_langfuse_client', client)
+    monkeypatch.setattr(langfuse_utils, '_langfuse_configured', True)
+    monkeypatch.setattr(
+        langfuse_utils,
+        '_langfuse_sdk',
+        SimpleNamespace(Langfuse=MagicMock()),
+    )
+    langfuse_utils.set_current_agent_session_id('session-123')
+
+    updated = langfuse_utils.update_langfuse_trace(
+        user_id='user-7', metadata={'source': 'test'}, tags=['unit']
+    )
+
+    assert updated
+    client.update_current_trace.assert_called_once_with(
+        session_id='session-123',
+        user_id='user-7',
+        metadata={'source': 'test'},
+        tags=['unit'],
+    )
+
+
+def test_v3_observation_normalizes_legacy_usage(monkeypatch):
+    client = MagicMock()
+    usage = SimpleNamespace(
+        model_dump=lambda **kwargs: {
+            'prompt_tokens': 12,
+            'completion_tokens': 5,
+            'total_tokens': 17,
+            'ignored': None,
+        }
+    )
+    monkeypatch.setattr(langfuse_utils, '_langfuse_client', client)
+    monkeypatch.setattr(langfuse_utils, '_langfuse_configured', True)
+    monkeypatch.setattr(
+        langfuse_utils,
+        '_langfuse_sdk',
+        SimpleNamespace(Langfuse=MagicMock()),
+    )
+
+    langfuse_utils.update_current_observation(
+        input={'messages': []}, model='model-x', usage=usage
+    )
+
+    client.update_current_generation.assert_called_once_with(
+        input={'messages': []},
+        output=None,
+        model='model-x',
+        model_parameters=None,
+        usage_details={
+            'prompt_tokens': 12,
+            'completion_tokens': 5,
+            'total_tokens': 17,
+        },
+    )
+
+
+def test_v2_observation_preserves_legacy_usage(monkeypatch):
+    context = MagicMock()
+    usage = object()
+    monkeypatch.setattr(langfuse_utils, '_langfuse_v2_context', context)
+    monkeypatch.setattr(langfuse_utils, '_langfuse_configured', True)
+    monkeypatch.setattr(langfuse_utils, '_langfuse_sdk', SimpleNamespace())
+
+    langfuse_utils.update_current_observation(usage=usage)
+
+    context.update_current_observation.assert_called_once_with(
+        input=None,
+        output=None,
+        model=None,
+        model_parameters=None,
+        usage_details=None,
+        usage=usage,
+    )
+
+
+def test_observe_resolves_native_decorator_after_configuration(monkeypatch):
+    decorated_calls = []
+
+    def sdk_observe(*args, **kwargs):
+        def decorate(func):
+            def wrapped(value):
+                decorated_calls.append((args, kwargs, value))
+                return func(value)
+
+            return wrapped
+
+        return decorate
+
+    monkeypatch.setattr(
+        langfuse_utils,
+        '_langfuse_sdk',
+        SimpleNamespace(Langfuse=MagicMock(), observe=sdk_observe),
+    )
+
+    @langfuse_utils.observe(as_type='generation')
+    def double(value):
+        return value * 2
+
+    assert double(2) == 4
+    assert decorated_calls == []
+
+    monkeypatch.setattr(langfuse_utils, '_langfuse_configured', True)
+    assert double(3) == 6
+    assert decorated_calls == [
+        ((), {'as_type': 'generation'}, 3),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_observe_preserves_async_functions(monkeypatch):
+    def sdk_observe(*args, **kwargs):
+        def decorate(func):
+            async def wrapped(value):
+                return await func(value) + 1
+
+            return wrapped
+
+        return decorate
+
+    monkeypatch.setattr(
+        langfuse_utils,
+        '_langfuse_sdk',
+        SimpleNamespace(Langfuse=MagicMock(), observe=sdk_observe),
+    )
+    monkeypatch.setattr(langfuse_utils, '_langfuse_configured', True)
+
+    @langfuse_utils.observe()
+    async def double(value):
+        return value * 2
+
+    assert await double(4) == 9


### PR DESCRIPTION
## Summary
- Langfuse v3 removed `langfuse.decorators.langfuse_context`, so the module-level import raised `ImportError` and `LANGFUSE_AVAILABLE` was always `False` - tracing silently never configured.
- Version-aware fix (`_is_langfuse_v3()`):
  - On v3, `configure_langfuse` builds a `langfuse.Langfuse(...)` client directly, and the lazy `observe()` wrapper applies the native `langfuse.observe` decorator only once tracing is configured.
  - On v2, the original `langfuse_context.configure(...)` path is preserved unchanged.
- Trace/observation update helpers dispatch on the detected version: `update_current_generation` on v3 (with a legacy `usage` object normalized to `usage_details`), or `update_current_observation` on v2.

## Test plan
- [x] Module unit tests pass locally: `pytest test/utils/test_langfuse.py` (8 passed)
- [x] Langfuse v3: `configure_langfuse(...)` creates the v3 client; `@observe` resolves to the native decorator after configuration (unit tests)
- [x] Langfuse v2: `langfuse_context.configure(...)` path unchanged (unit test)
- [ ] Full `pytest` suite on CI: not runnable on fork PRs - the pytest workflow exposes secrets only to same-repo branches, so collection fails on missing API keys for fork PRs regardless of the change. Same failure as merged fork PR #4259. See the comment on this PR.

Closes #3876
