### PR TITLE
Add xAI Grok 4.5 model support

### DIFF
--- a/camel/types/enums.py
+++ b/camel/types/enums.py
@@ -114,6 +114,9 @@ class ModelType(UnifiedModelType, Enum):
     GROQ_LLAMA_3_1_8B = "llama-3.1-8b-instant"
     GROQ_LLAMA_3_3_70B = "llama-3.3-70b-versatile"
 
+    # xAI platform models
+    XAI_GROK_4_5 = "grok-4.5"
+
     # Cerebras platform models
     CEREBRAS_GPT_OSS_120B = "gpt-oss-120b"
     CEREBRAS_LLAMA_3_1_8B = "llama3.1-8b"
@@ -594,6 +597,7 @@ class ModelType(UnifiedModelType, Enum):
         return any(
             [
                 self.is_openai,
+                self.is_xai,
             ]
         )
 
@@ -626,6 +630,7 @@ class ModelType(UnifiedModelType, Enum):
                 self.is_azure_openai,
                 self.is_novita,
                 self.is_avian,
+                self.is_xai,
             ]
         )
 
@@ -776,6 +781,13 @@ class ModelType(UnifiedModelType, Enum):
         return self in {
             ModelType.GROQ_LLAMA_3_1_8B,
             ModelType.GROQ_LLAMA_3_3_70B,
+        }
+
+    @property
+    def is_xai(self) -> bool:
+        r"""Returns whether this type of models is served by xAI."""
+        return self in {
+            ModelType.XAI_GROK_4_5,
         }
 
     @property
@@ -1706,6 +1718,10 @@ class ModelType(UnifiedModelType, Enum):
             ModelType.NETMIND_LLAMA_4_MAVERICK_17B_128E_INSTRUCT,
         }:
             return 512_000
+        elif self in {
+            ModelType.XAI_GROK_4_5,
+        }:
+            return 500_000
         elif self in {
             ModelType.GEMINI_3_1_PRO,
             ModelType.GEMINI_3_1_FLASH_LITE,

--- a/examples/models/xai_model_example.py
+++ b/examples/models/xai_model_example.py
@@ -23,11 +23,11 @@ python examples/models/xai_model_example.py
 from camel.agents import ChatAgent
 from camel.configs import XAIConfig
 from camel.models import ModelFactory
-from camel.types import ModelPlatformType
+from camel.types import ModelPlatformType, ModelType
 
 model = ModelFactory.create(
     model_platform=ModelPlatformType.XAI,
-    model_type="grok-4.20-reasoning",
+    model_type=ModelType.XAI_GROK_4_5,
     model_config_dict=XAIConfig(use_encrypted_content=True).as_dict(),
 )
 

--- a/test/models/test_xai_model.py
+++ b/test/models/test_xai_model.py
@@ -15,6 +15,7 @@
 from types import MethodType
 
 from camel.models.xai_model import XAIModel
+from camel.types import ModelType
 
 
 def test_stream_to_chunks_handles_empty_stream():
@@ -26,3 +27,11 @@ def test_stream_to_chunks_handles_empty_stream():
     model._make_chunk = MethodType(lambda self, **kwargs: kwargs, model)
 
     assert list(XAIModel._stream_to_chunks(model, iter([]), 0)) == []
+
+
+def test_grok_4_5_model_type_metadata():
+    assert ModelType.XAI_GROK_4_5.value == "grok-4.5"
+    assert ModelType.XAI_GROK_4_5.is_xai is True
+    assert ModelType.XAI_GROK_4_5.token_limit == 500_000
+    assert ModelType.XAI_GROK_4_5.support_native_tool_calling is True
+    assert ModelType.XAI_GROK_4_5.support_native_structured_output is True


### PR DESCRIPTION
## Summary
- add `ModelType.XAI_GROK_4_5` for the official `grok-4.5` model ID
- set its token limit to 500,000 based on the xAI models documentation
- mark the model for native tool calling and structured output metadata
- update the xAI example to use the new enum

Closes #4160

## Validation
- `uv run pytest test/models/test_xai_model.py`
- `uv run python - <<'PY' ... metadata assertions ... PY`
- `uv run ruff check camel/types/enums.py test/models/test_xai_model.py examples/models/xai_model_example.py`

## Reference
- https://docs.x.ai/developers/models