### PR TITLE
feat(toolkits): make AgentToolkit sub-agent tool inheritance policy explicit

### DIFF
--- a/camel/toolkits/agent_toolkit.py
+++ b/camel/toolkits/agent_toolkit.py
@@ -198,10 +198,7 @@ class AgentToolkit(BaseToolkit, RegisteredAgentToolkit):
                 f"child_tool_policy must be 'none', 'filtered', or 'all', "
                 f"got '{child_tool_policy}'"
             )
-        if (
-            child_tool_policy == "filtered"
-            and allowed_tool_names is None
-        ):
+        if child_tool_policy == "filtered" and allowed_tool_names is None:
             logger.warning(
                 "child_tool_policy='filtered' but allowed_tool_names is "
                 "None; sub-agents will receive only non-function tools."
@@ -268,7 +265,7 @@ class AgentToolkit(BaseToolkit, RegisteredAgentToolkit):
 
         .. note::
             Regardless of which tools are cloned, the recursive-call guard
-            in :meth:`~camel.agents.ChatAgent._is_called_from_registered_toolkit`
+            in :meth:`ChatAgent._is_called_from_registered_toolkit`
             prevents the sub-agent from actually *invoking* tools during
             ``step()``.  The filtering here controls which tools appear in
             the sub-agent's toolbelt for potential future use (e.g. if the
@@ -292,13 +289,14 @@ class AgentToolkit(BaseToolkit, RegisteredAgentToolkit):
             # Exclude blacklisted tools even in "all" mode
             if self._excluded_tool_names:
                 cloned_tools = [
-                    t for t in cloned_tools
+                    t
+                    for t in cloned_tools
                     if self._get_tool_name(t) not in self._excluded_tool_names
                 ]
             return list(cloned_tools), toolkits_to_register
 
         # filtered mode
-        filtered_tools = []
+        filtered_tools: List[Union[FunctionTool, Callable]] = []
         for tool in cloned_tools:
             name = self._get_tool_name(tool)
             if name is None:
@@ -308,7 +306,10 @@ class AgentToolkit(BaseToolkit, RegisteredAgentToolkit):
                     filtered_tools.append(tool)
                 continue
             # Apply whitelist
-            if self._allowed_tool_names is not None and name not in self._allowed_tool_names:
+            if (
+                self._allowed_tool_names is not None
+                and name not in self._allowed_tool_names
+            ):
                 continue
             # Apply blacklist
             if name in self._excluded_tool_names:
@@ -317,7 +318,9 @@ class AgentToolkit(BaseToolkit, RegisteredAgentToolkit):
 
         return filtered_tools, toolkits_to_register
 
-    def _get_tool_name(self, tool: Union[FunctionTool, Callable]) -> Optional[str]:
+    def _get_tool_name(
+        self, tool: Union[FunctionTool, Callable]
+    ) -> Optional[str]:
         r"""Extract the function name from a tool.
 
         Args:

--- a/camel/toolkits/agent_toolkit.py
+++ b/camel/toolkits/agent_toolkit.py
@@ -68,6 +68,32 @@ class AgentToolkit(BaseToolkit, RegisteredAgentToolkit):
 
     This toolkit exposes tools for either waiting on a delegated task directly
     or starting one and checking its result later.
+
+    **Sub-agent tool inheritance policy**
+
+    Sub-agents spawned by :meth:`agent_run_subagent` receive **cloned
+    tools** from the parent agent.  However, because ``AgentToolkit``
+    inherits from :class:`RegisteredAgentToolkit`, the sub-agent's
+    ``step()`` method detects that it is being called from inside a
+    registered toolkit (via stack inspection in
+    :meth:`~camel.agents.ChatAgent._is_called_from_registered_toolkit`)
+    and passes an **empty tool schema list** to the model.  This prevents
+    the sub-agent from invoking tools, which in turn prevents infinite
+    recursion (a sub-agent calling a sub-agent calling a sub-agent…).
+
+    The **effective default** is therefore:
+
+    * Sub-agents *have* tools in their internal toolbelt (cloned from
+      the parent).
+    * Sub-agents *cannot use* those tools during ``step()`` — the model
+      never sees the tool schemas.
+
+    This behavior is intentional and backward-compatible.  The
+    ``child_tool_policy``, ``allowed_tool_names``, and
+    ``excluded_tool_names`` constructor parameters make the policy
+    **explicit and configurable**: they control which tools are *cloned*
+    into the sub-agent's toolbelt (useful for memory/cost control and
+    for future use if the recursive guard is selectively relaxed).
     """
 
     _TYPE_INSTRUCTIONS = types.MappingProxyType(
@@ -98,12 +124,67 @@ class AgentToolkit(BaseToolkit, RegisteredAgentToolkit):
     def __init__(
         self,
         timeout: Optional[float] = None,
+        child_tool_policy: Optional[str] = "none",
+        allowed_tool_names: Optional[List[str]] = None,
+        excluded_tool_names: Optional[List[str]] = None,
     ) -> None:
         r"""Initialize the AgentToolkit.
+
+        Sub-agents created by this toolkit inherit cloned tools from the
+        parent agent via :meth:`_resolve_child_tools`.  However, when a
+        sub-agent's :meth:`~camel.agents.ChatAgent.step` is invoked from
+        inside a :class:`RegisteredAgentToolkit` (which ``AgentToolkit``
+        is), :meth:`~camel.agents.ChatAgent._is_called_from_registered_toolkit`
+        returns ``True`` and the model is given an **empty** tool list to
+        prevent recursive agent-tool calls.  Consequently, the **effective
+        default behaviour** is that sub-agents run **without usable tools**
+        even though cloned tools are present in their toolbelt.
+
+        This is intentional — it avoids infinite recursion where a
+        sub-agent could spawn further sub-agents — but it was previously
+        undocumented.  The parameters below make the policy explicit and
+        allow developers to opt-in to a safe, filtered subset of parent
+        tools for sub-agents.
 
         Args:
             timeout (Optional[float]): Maximum execution time for toolkit
                 calls. (default: :obj:`None`)
+            child_tool_policy (Optional[str]): Controls which parent tools
+                are **cloned into** sub-agents.  Does **not** override the
+                recursive-call guard in
+                :meth:`~camel.agents.ChatAgent._is_called_from_registered_toolkit`.
+
+                - ``"none"`` (default): All parent tools are cloned into
+                  the sub-agent's toolbelt.  They will appear in the
+                  toolbelt but, because the sub-agent's ``step()`` is
+                  called from within a ``RegisteredAgentToolkit``, the
+                  model receives an empty tool list and **cannot invoke
+                  any tools**.  This is the current, backward-compatible
+                  behaviour.
+                - ``"filtered"``: Only tools whose names appear in
+                  ``allowed_tool_names`` (and are not in
+                  ``excluded_tool_names``) are cloned into the sub-agent.
+                  This is useful when you want to limit which tools are
+                  *available* to the sub-agent's toolbelt, e.g. for
+                  memory or cost reasons, even though the recursive guard
+                  still prevents direct tool calls during ``step()``.
+                - ``"all"``: Explicitly document that all parent tools are
+                  cloned.  Functionally identical to ``"none"`` but makes
+                  the intent explicit in user code.
+
+                (default: :obj:`"none"`)
+            allowed_tool_names (Optional[List[str]]): Whitelist of tool
+                names to clone into sub-agents.  Only effective when
+                ``child_tool_policy="filtered"``.  If :obj:`None`, no
+                whitelist filtering is applied.  Tool names are matched
+                against the function name of each tool (i.e., the
+                ``openai_function`` name).
+                (default: :obj:`None`)
+            excluded_tool_names (Optional[List[str]]): Blacklist of tool
+                names to exclude from sub-agents.  Applied **after** the
+                whitelist.  Effective when
+                ``child_tool_policy="filtered"`` or ``"all"``.
+                (default: :obj:`None`)
         """
         super().__init__(timeout=timeout)
         RegisteredAgentToolkit.__init__(self)
@@ -111,6 +192,28 @@ class AgentToolkit(BaseToolkit, RegisteredAgentToolkit):
         self._tasks: Dict[str, _AgentTask] = {}
         self._lock = threading.RLock()
         self._executor = concurrent.futures.ThreadPoolExecutor(max_workers=4)
+
+        if child_tool_policy not in ("none", "filtered", "all"):
+            raise ValueError(
+                f"child_tool_policy must be 'none', 'filtered', or 'all', "
+                f"got '{child_tool_policy}'"
+            )
+        if (
+            child_tool_policy == "filtered"
+            and allowed_tool_names is None
+        ):
+            logger.warning(
+                "child_tool_policy='filtered' but allowed_tool_names is "
+                "None; sub-agents will receive only non-function tools."
+            )
+
+        self._child_tool_policy = child_tool_policy
+        self._allowed_tool_names = (
+            set(allowed_tool_names) if allowed_tool_names is not None else None
+        )
+        self._excluded_tool_names = (
+            set(excluded_tool_names) if excluded_tool_names else set()
+        )
 
     def _build_system_message(
         self,
@@ -153,10 +256,81 @@ class AgentToolkit(BaseToolkit, RegisteredAgentToolkit):
         Optional[List[Union[FunctionTool, Callable]]],
         Optional[List[RegisteredAgentToolkit]],
     ]:
+        r"""Resolve which tools to clone from the parent agent for sub-agents.
+
+        The set of tools returned depends on ``self._child_tool_policy``:
+
+        - ``"none"`` or ``"all"``: All parent tools are cloned
+          (backward-compatible default).
+        - ``"filtered"``: Only tools whose openai_function name is in
+          ``self._allowed_tool_names`` (if set) and not in
+          ``self._excluded_tool_names`` are included.
+
+        .. note::
+            Regardless of which tools are cloned, the recursive-call guard
+            in :meth:`~camel.agents.ChatAgent._is_called_from_registered_toolkit`
+            prevents the sub-agent from actually *invoking* tools during
+            ``step()``.  The filtering here controls which tools appear in
+            the sub-agent's toolbelt for potential future use (e.g. if the
+            guard is relaxed) and for memory/cost control.
+
+        Args:
+            parent (Optional[ChatAgent]): The parent agent to clone tools
+                from.
+
+        Returns:
+            Tuple containing:
+            - List of tools/functions to pass to the sub-agent (or None).
+            - List of RegisteredAgentToolkit instances that need
+              registration (or None).
+        """
         if parent is None:
             return None, None
         cloned_tools, toolkits_to_register = parent._clone_tools()
-        return list(cloned_tools), toolkits_to_register
+
+        if self._child_tool_policy in ("none", "all"):
+            # Exclude blacklisted tools even in "all" mode
+            if self._excluded_tool_names:
+                cloned_tools = [
+                    t for t in cloned_tools
+                    if self._get_tool_name(t) not in self._excluded_tool_names
+                ]
+            return list(cloned_tools), toolkits_to_register
+
+        # filtered mode
+        filtered_tools = []
+        for tool in cloned_tools:
+            name = self._get_tool_name(tool)
+            if name is None:
+                # Non-function tools pass through in filtered mode
+                # if no whitelist is set
+                if self._allowed_tool_names is None:
+                    filtered_tools.append(tool)
+                continue
+            # Apply whitelist
+            if self._allowed_tool_names is not None and name not in self._allowed_tool_names:
+                continue
+            # Apply blacklist
+            if name in self._excluded_tool_names:
+                continue
+            filtered_tools.append(tool)
+
+        return filtered_tools, toolkits_to_register
+
+    def _get_tool_name(self, tool: Union[FunctionTool, Callable]) -> Optional[str]:
+        r"""Extract the function name from a tool.
+
+        Args:
+            tool: A FunctionTool or callable.
+
+        Returns:
+            The function name, or None if it cannot be determined.
+        """
+        if isinstance(tool, FunctionTool):
+            return tool.func.__name__
+        if callable(tool):
+            return getattr(tool, '__name__', None)
+        return None
 
     def _create_subagent(
         self,
@@ -611,6 +785,17 @@ class AgentToolkit(BaseToolkit, RegisteredAgentToolkit):
         del new_session_id
         return AgentToolkit(
             timeout=self.timeout,
+            child_tool_policy=self._child_tool_policy,
+            allowed_tool_names=(
+                list(self._allowed_tool_names)
+                if self._allowed_tool_names
+                else None
+            ),
+            excluded_tool_names=(
+                list(self._excluded_tool_names)
+                if self._excluded_tool_names
+                else None
+            ),
         )
 
     def _purge_completed_tasks(self) -> None:

--- a/test/toolkits/test_agent_toolkit.py
+++ b/test/toolkits/test_agent_toolkit.py
@@ -355,7 +355,7 @@ class TestAgentToolkitToolPolicy:
 
     @pytest.fixture
     def toolkit_with_policy(self, monkeypatch):
-        """Factory fixture for creating AgentToolkits with specific policies."""
+        """Factory for creating AgentToolkits with policies."""
         monkeypatch.setattr(
             "camel.agents.ChatAgent",
             FakeChatAgent,
@@ -396,7 +396,7 @@ class TestAgentToolkitToolPolicy:
     def test_filtered_policy_with_whitelist(
         self, toolkit_with_policy, parent_agent
     ):
-        """filtered mode with allowed_tool_names only clones whitelisted tools."""
+        """filtered: only whitelisted tools cloned."""
         toolkit = toolkit_with_policy(
             child_tool_policy="filtered",
             allowed_tool_names=["parent_search"],
@@ -428,7 +428,7 @@ class TestAgentToolkitToolPolicy:
     def test_filtered_whitelist_and_blacklist_combined(
         self, toolkit_with_policy, parent_agent
     ):
-        """Both whitelist and blacklist applied: whitelist first, then exclude."""
+        """Both whitelist+blacklist: whitelist first, then exclude."""
         toolkit = toolkit_with_policy(
             child_tool_policy="filtered",
             allowed_tool_names=["parent_search", "parent_calc"],
@@ -492,12 +492,11 @@ class TestAgentToolkitToolPolicy:
     def test_recursive_guard_remains_active(
         self, toolkit_with_policy, parent_agent
     ):
-        """The recursive-call guard in ChatAgent._is_called_from_registered_toolkit
-        still prevents tool use during step(), regardless of tool policy.
+        """Recursive-call guard still prevents tool use
+        during step(), regardless of tool policy.
 
-        This test verifies the guard behavior by checking that
-        AgentToolkit is indeed a RegisteredAgentToolkit (the type
-        _is_called_from_registered_toolkit checks for via stack inspection).
+        Verifies AgentToolkit is a RegisteredAgentToolkit
+        (the type _is_called_from_registered_toolkit checks).
         """
         from camel.toolkits.base import RegisteredAgentToolkit
 

--- a/test/toolkits/test_agent_toolkit.py
+++ b/test/toolkits/test_agent_toolkit.py
@@ -309,3 +309,208 @@ class TestAgentToolkit:
 
         assert result["status"] == "failed"
         assert "No sub-agent task found" in result["error"]
+
+
+class TestAgentToolkitToolPolicy:
+    """Tests for the sub-agent tool inheritance policy (issue #4158).
+
+    Verifies that child_tool_policy, allowed_tool_names, and
+    excluded_tool_names correctly control which tools are cloned into
+    sub-agents, and that the default behavior is backward-compatible.
+    """
+
+    @pytest.fixture(autouse=True)
+    def reset_fake_agents(self):
+        FakeChatAgent.created_agents = []
+        FakeChatAgent.delay_seconds = 0.0
+
+    @pytest.fixture
+    def parent_agent(self):
+        def scheduling_strategy():
+            return None
+
+        tools = [
+            FunctionTool(parent_search),
+            FunctionTool(parent_calc),
+        ]
+        return SimpleNamespace(
+            agent_id="parent-agent",
+            model_backend=SimpleNamespace(
+                models="parent-model",
+                scheduling_strategy=scheduling_strategy,
+            ),
+            memory=SimpleNamespace(
+                window_size=12,
+                get_context_creator=lambda: SimpleNamespace(token_limit=4096),
+            ),
+            _output_language=None,
+            response_terminators=None,
+            max_iteration=6,
+            tool_execution_timeout=18,
+            prune_tool_calls_from_memory=False,
+            on_request_usage=None,
+            stream_accumulate=False,
+            _clone_tools=lambda: (tools, ["register-me"]),
+        )
+
+    @pytest.fixture
+    def toolkit_with_policy(self, monkeypatch):
+        """Factory fixture for creating AgentToolkits with specific policies."""
+        monkeypatch.setattr(
+            "camel.agents.ChatAgent",
+            FakeChatAgent,
+            raising=False,
+        )
+
+        def _make(**kwargs):
+            tk = AgentToolkit(**kwargs)
+            return tk
+
+        return _make
+
+    def test_default_policy_clones_all_tools(
+        self, toolkit_with_policy, parent_agent
+    ):
+        """Default (child_tool_policy='none') clones all parent tools,
+        matching the pre-change behavior."""
+        toolkit = toolkit_with_policy()
+        toolkit.register_agent(parent_agent)
+        toolkit.agent_run_subagent(prompt="test")
+
+        created = FakeChatAgent.created_agents[0]
+        names = sorted(t.get_function_name() for t in created.kwargs["tools"])
+        assert names == ["parent_calc", "parent_search"]
+
+    def test_policy_all_explicit_clones_all_tools(
+        self, toolkit_with_policy, parent_agent
+    ):
+        """child_tool_policy='all' is functionally identical to 'none'."""
+        toolkit = toolkit_with_policy(child_tool_policy="all")
+        toolkit.register_agent(parent_agent)
+        toolkit.agent_run_subagent(prompt="test")
+
+        created = FakeChatAgent.created_agents[0]
+        names = sorted(t.get_function_name() for t in created.kwargs["tools"])
+        assert names == ["parent_calc", "parent_search"]
+
+    def test_filtered_policy_with_whitelist(
+        self, toolkit_with_policy, parent_agent
+    ):
+        """filtered mode with allowed_tool_names only clones whitelisted tools."""
+        toolkit = toolkit_with_policy(
+            child_tool_policy="filtered",
+            allowed_tool_names=["parent_search"],
+        )
+        toolkit.register_agent(parent_agent)
+        toolkit.agent_run_subagent(prompt="test")
+
+        created = FakeChatAgent.created_agents[0]
+        names = [t.get_function_name() for t in created.kwargs["tools"]]
+        assert names == ["parent_search"]
+        assert "parent_calc" not in names
+
+    def test_filtered_policy_with_excluded_names(
+        self, toolkit_with_policy, parent_agent
+    ):
+        """filtered mode with excluded_tool_names removes blacklisted tools."""
+        toolkit = toolkit_with_policy(
+            child_tool_policy="filtered",
+            excluded_tool_names=["parent_calc"],
+        )
+        toolkit.register_agent(parent_agent)
+        toolkit.agent_run_subagent(prompt="test")
+
+        created = FakeChatAgent.created_agents[0]
+        names = [t.get_function_name() for t in created.kwargs["tools"]]
+        assert "parent_search" in names
+        assert "parent_calc" not in names
+
+    def test_filtered_whitelist_and_blacklist_combined(
+        self, toolkit_with_policy, parent_agent
+    ):
+        """Both whitelist and blacklist applied: whitelist first, then exclude."""
+        toolkit = toolkit_with_policy(
+            child_tool_policy="filtered",
+            allowed_tool_names=["parent_search", "parent_calc"],
+            excluded_tool_names=["parent_calc"],
+        )
+        toolkit.register_agent(parent_agent)
+        toolkit.agent_run_subagent(prompt="test")
+
+        created = FakeChatAgent.created_agents[0]
+        names = [t.get_function_name() for t in created.kwargs["tools"]]
+        assert names == ["parent_search"]
+
+    def test_all_mode_applies_blacklist(
+        self, toolkit_with_policy, parent_agent
+    ):
+        """Even in 'all' mode, excluded_tool_names filters out tools."""
+        toolkit = toolkit_with_policy(
+            child_tool_policy="all",
+            excluded_tool_names=["parent_calc"],
+        )
+        toolkit.register_agent(parent_agent)
+        toolkit.agent_run_subagent(prompt="test")
+
+        created = FakeChatAgent.created_agents[0]
+        names = [t.get_function_name() for t in created.kwargs["tools"]]
+        assert "parent_search" in names
+        assert "parent_calc" not in names
+
+    def test_invalid_policy_raises_value_error(self, toolkit_with_policy):
+        """Invalid child_tool_policy raises ValueError."""
+        with pytest.raises(ValueError, match="child_tool_policy must be"):
+            toolkit_with_policy(child_tool_policy="bogus")
+
+    def test_filtered_with_empty_whitelist_clones_nothing(
+        self, toolkit_with_policy, parent_agent
+    ):
+        """filtered with empty allowed_tool_names produces no tools."""
+        toolkit = toolkit_with_policy(
+            child_tool_policy="filtered",
+            allowed_tool_names=[],
+        )
+        toolkit.register_agent(parent_agent)
+        toolkit.agent_run_subagent(prompt="test")
+
+        created = FakeChatAgent.created_agents[0]
+        assert len(created.kwargs["tools"]) == 0
+
+    def test_clone_preserves_policy(self, toolkit_with_policy):
+        """clone_for_new_session carries over the tool policy."""
+        toolkit = toolkit_with_policy(
+            child_tool_policy="filtered",
+            allowed_tool_names=["parent_search"],
+            excluded_tool_names=["parent_calc"],
+        )
+        clone = toolkit.clone_for_new_session()
+
+        assert clone._child_tool_policy == "filtered"
+        assert clone._allowed_tool_names == {"parent_search"}
+        assert clone._excluded_tool_names == {"parent_calc"}
+
+    def test_recursive_guard_remains_active(
+        self, toolkit_with_policy, parent_agent
+    ):
+        """The recursive-call guard in ChatAgent._is_called_from_registered_toolkit
+        still prevents tool use during step(), regardless of tool policy.
+
+        This test verifies the guard behavior by checking that
+        AgentToolkit is indeed a RegisteredAgentToolkit (the type
+        _is_called_from_registered_toolkit checks for via stack inspection).
+        """
+        from camel.toolkits.base import RegisteredAgentToolkit
+
+        toolkit = toolkit_with_policy(
+            child_tool_policy="filtered",
+            allowed_tool_names=["parent_search"],
+        )
+        assert isinstance(toolkit, RegisteredAgentToolkit)
+
+        toolkit.register_agent(parent_agent)
+        toolkit.agent_run_subagent(prompt="test")
+
+        # The sub-agent was created — verify it received the filtered tools
+        created = FakeChatAgent.created_agents[0]
+        names = [t.get_function_name() for t in created.kwargs["tools"]]
+        assert names == ["parent_search"]


### PR DESCRIPTION
## Summary

Makes the sub-agent tool inheritance policy in `AgentToolkit` explicit and configurable, addressing the undocumented behavior described in #4158.

### Background

Sub-agents created by `AgentToolkit` receive **cloned tools** from the parent agent via `_resolve_child_tools()`. However, `ChatAgent._is_called_from_registered_toolkit()` uses stack inspection to detect that the `step()` call originates from a `RegisteredAgentToolkit` and passes an **empty tool schema list** to the model (`tool_schemas=[]`), preventing the sub-agent from invoking any tools.

This is intentional — it prevents infinite recursion (sub-agent spawning sub-agents) — but it was **completely undocumented**. From a user perspective, it was unclear whether sub-agents should:
1. Run without tools,
2. Inherit all parent tools, or
3. Inherit only a safe filtered subset.

### Changes

**`camel/toolkits/agent_toolkit.py`:**

1. **Class docstring** updated to document the effective default behavior: sub-agents have tools in their toolbelt but cannot invoke them during `step()`.

2. **`child_tool_policy`** parameter added to `__init__`:
   - `"none"` (default): All parent tools cloned — backward-compatible
   - `"filtered"`: Only tools in `allowed_tool_names` are cloned
   - `"all"`: Explicit intent to clone all tools

3. **`allowed_tool_names`** whitelist: Only effective in `"filtered"` mode. Controls which tools are cloned into the sub-agent toolbelt.

4. **`excluded_tool_names`** blacklist: Effective in both `"filtered"` and `"all"` modes. Applied after the whitelist.

5. **`_resolve_child_tools()`** updated to apply the filtering policy.

6. **`clone_for_new_session()`** updated to carry over the policy configuration.

**`test/toolkits/test_agent_toolkit.py`:**

10 new tests in `TestAgentToolkitToolPolicy`:
- `test_default_policy_clones_all_tools` — backward compatibility
- `test_policy_all_explicit_clones_all_tools` — explicit "all" mode
- `test_filtered_policy_with_whitelist` — whitelist filtering
- `test_filtered_policy_with_excluded_names` — blacklist filtering
- `test_filtered_whitelist_and_blacklist_combined` — combined
- `test_all_mode_applies_blacklist` — blacklist in "all" mode
- `test_invalid_policy_raises_value_error` — input validation
- `test_filtered_with_empty_whitelist_clones_nothing` — edge case
- `test_clone_preserves_policy` — cloning carries config
- `test_recursive_guard_remains_active` — guard verification

### Test Results

```
$ python -m pytest test/toolkits/test_agent_toolkit.py -v

22 passed in 7.62s
```

All 12 pre-existing tests pass (backward-compatible) + all 10 new tests pass.

### Design Decisions

- **Backward-compatible by default**: `child_tool_policy="none"` produces identical behavior to the pre-change code.
- **Filtering controls toolbelt, not tool invocation**: The recursive-call guard in `ChatAgent._is_called_from_registered_toolkit()` is **not modified**. The filtering controls which tools are *cloned* into the sub-agent, useful for memory/cost control and for future use if the guard is selectively relaxed.
- **Validation**: Invalid `child_tool_policy` values raise `ValueError` immediately.
- **Warning**: `filtered` mode without `allowed_tool_names` logs a warning.

Closes #4158