### PR TITLE
feat: add Requesty as a model platform

### DIFF
--- a/camel/configs/__init__.py
+++ b/camel/configs/__init__.py
@@ -49,6 +49,7 @@ from .ppio_config import PPIO_API_PARAMS, PPIOConfig
 from .qianfan_config import QIANFAN_API_PARAMS, QianfanConfig
 from .qwen_config import QWEN_API_PARAMS, QwenConfig
 from .reka_config import REKA_API_PARAMS, RekaConfig
+from .requesty_config import REQUESTY_API_PARAMS, RequestyConfig
 from .samba_config import (
     SAMBA_CLOUD_API_PARAMS,
     SAMBA_VERSE_API_PARAMS,
@@ -99,6 +100,7 @@ __all__ = [
     'QIANFAN_API_PARAMS',
     'QWEN_API_PARAMS',
     'REKA_API_PARAMS',
+    'REQUESTY_API_PARAMS',
     'SAMBA_CLOUD_API_PARAMS',
     'SAMBA_VERSE_API_PARAMS',
     'SGLANG_API_PARAMS',
@@ -146,6 +148,7 @@ __all__ = [
     'QianfanConfig',
     'QwenConfig',
     'RekaConfig',
+    'RequestyConfig',
     'SGLangConfig',
     'SambaCloudAPIConfig',
     'SambaVerseAPIConfig',

--- a/camel/configs/requesty_config.py
+++ b/camel/configs/requesty_config.py
@@ -1,0 +1,106 @@
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+from __future__ import annotations
+
+from typing import Dict, Optional, Sequence, Union
+
+from camel.configs.base_config import BaseConfig
+from camel.types import NotGiven
+
+
+class RequestyConfig(BaseConfig):
+    r"""Defines the parameters for generating chat completions using the
+    Requesty API, which is OpenAI-compatible.
+
+    Reference: https://docs.requesty.ai
+
+    Args:
+        temperature (float, optional): Sampling temperature to use, between
+            :obj:`0` and :obj:`2`. Higher values make the output more random,
+            while lower values make it more focused and deterministic.
+            (default: :obj:`None`)
+        top_p (float, optional): An alternative to sampling with temperature,
+            called nucleus sampling, where the model considers the results of
+            the tokens with top_p probability mass. So :obj:`0.1` means only
+            the tokens comprising the top 10% probability mass are considered.
+            (default: :obj:`None`)
+        n (int, optional): How many chat completion choices to generate for
+            each input message. (default: :obj:`None`)
+        response_format (object, optional): An object specifying the format
+            that the model must output. Compatible with GPT-4 Turbo and all
+            GPT-3.5 Turbo models newer than gpt-3.5-turbo-1106. Setting to
+            {"type": "json_object"} enables JSON mode, which guarantees the
+            message the model generates is valid JSON. Important: when using
+            JSON mode, you must also instruct the model to produce JSON
+            yourself via a system or user message. Without this, the model
+            may generate an unending stream of whitespace until the generation
+            reaches the token limit, resulting in a long-running and seemingly
+            "stuck" request. Also note that the message content may be
+            partially cut off if finish_reason="length", which indicates the
+            generation exceeded max_tokens or the conversation exceeded the
+            max context length.
+        stream (bool, optional): If True, partial message deltas will be sent
+            as data-only server-sent events as they become available.
+            (default: :obj:`None`)
+        stop (str or list, optional): Up to :obj:`4` sequences where the API
+            will stop generating further tokens. (default: :obj:`None`)
+        max_tokens (int, optional): The maximum number of tokens to generate
+            in the chat completion. The total length of input tokens and
+            generated tokens is limited by the model's context length.
+            (default: :obj:`None`)
+        presence_penalty (float, optional): Number between :obj:`-2.0` and
+            :obj:`2.0`. Positive values penalize new tokens based on whether
+            they appear in the text so far, increasing the model's likelihood
+            to talk about new topics. See more information about frequency and
+            presence penalties. (default: :obj:`None`)
+        frequency_penalty (float, optional): Number between :obj:`-2.0` and
+            :obj:`2.0`. Positive values penalize new tokens based on their
+            existing frequency in the text so far, decreasing the model's
+            likelihood to repeat the same line verbatim. See more information
+            about frequency and presence penalties. (default: :obj:`None`)
+        user (str, optional): A unique identifier representing your end-user,
+            which can help the provider to monitor and detect abuse.
+            (default: :obj:`None`)
+        tools (list[FunctionTool], optional): A list of tools the model may
+            call. Currently, only functions are supported as a tool. Use this
+            to provide a list of functions the model may generate JSON inputs
+            for. A max of 128 functions are supported. (default: :obj:`None`)
+        tool_choice (Union[dict[str, str], str], optional): Controls which (if
+            any) tool is called by the model. :obj:`"none"` means the model
+            will not call any tool and instead generates a message.
+            :obj:`"auto"` means the model can pick between generating a
+            message or calling one or more tools.  :obj:`"required"` means the
+            model must call one or more tools. Specifying a particular tool
+            via {"type": "function", "function": {"name": "my_function"}}
+            forces the model to call that tool. :obj:`"none"` is the default
+            when no tools are present. :obj:`"auto"` is the default if tools
+            are present. (default: :obj:`None`)
+    """
+
+    temperature: Optional[float] = None
+    top_p: Optional[float] = None
+    n: Optional[int] = None
+    stream: Optional[bool] = None
+    stop: Optional[Union[str, Sequence[str], NotGiven]] = None
+    max_tokens: Optional[Union[int, NotGiven]] = None
+    presence_penalty: Optional[float] = None
+    response_format: Optional[Union[dict, NotGiven]] = None
+    frequency_penalty: Optional[float] = None
+    user: Optional[str] = None
+    tool_choice: Optional[
+        Union[Dict[str, Union[str, Dict[str, str]]], str]
+    ] = None
+
+
+REQUESTY_API_PARAMS = {param for param in RequestyConfig.model_fields.keys()}

--- a/camel/models/__init__.py
+++ b/camel/models/__init__.py
@@ -55,6 +55,7 @@ from .ppio_model import PPIOModel
 from .qianfan_model import QianfanModel
 from .qwen_model import QwenModel
 from .reka_model import RekaModel
+from .requesty_model import RequestyModel
 from .samba_model import SambaModel
 from .sglang_model import SGLangModel
 from .siliconflow_model import SiliconFlowModel
@@ -113,6 +114,7 @@ __all__ = [
     'QianfanModel',
     'QwenModel',
     'RekaModel',
+    'RequestyModel',
     'SGLangModel',
     'SambaModel',
     'SiliconFlowModel',

--- a/camel/models/model_factory.py
+++ b/camel/models/model_factory.py
@@ -53,6 +53,7 @@ from camel.models.ppio_model import PPIOModel
 from camel.models.qianfan_model import QianfanModel
 from camel.models.qwen_model import QwenModel
 from camel.models.reka_model import RekaModel
+from camel.models.requesty_model import RequestyModel
 from camel.models.samba_model import SambaModel
 from camel.models.sglang_model import SGLangModel
 from camel.models.siliconflow_model import SiliconFlowModel
@@ -104,6 +105,7 @@ class ModelFactory:
         ModelPlatformType.MINIMAX: MinimaxModel,
         ModelPlatformType.OPENROUTER: OpenRouterModel,
         ModelPlatformType.ORCAROUTER: OrcaRouterModel,
+        ModelPlatformType.REQUESTY: RequestyModel,
         ModelPlatformType.ATLASCLOUD: AtlasCloudModel,
         ModelPlatformType.ZHIPU: ZhipuAIModel,
         ModelPlatformType.GEMINI: GeminiModel,

--- a/camel/models/requesty_model.py
+++ b/camel/models/requesty_model.py
@@ -1,0 +1,110 @@
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+import os
+from typing import Any, Dict, Optional, Union
+
+from camel.configs import RequestyConfig
+from camel.models.openai_compatible_model import OpenAICompatibleModel
+from camel.types import ModelType
+from camel.utils import (
+    BaseTokenCounter,
+    api_keys_required,
+)
+
+
+class RequestyModel(OpenAICompatibleModel):
+    r"""LLM API served by Requesty in a unified OpenAICompatibleModel
+    interface.
+
+    Requesty is an OpenAI-compatible LLM router. Models are addressed using
+    the ``provider/model`` naming scheme (e.g. ``openai/gpt-4o-mini``,
+    ``anthropic/claude-sonnet-4-5``), the same scheme used by OpenRouter.
+
+    Args:
+        model_type (Union[ModelType, str]): Model for which a backend is
+            created.
+        model_config_dict (Optional[Dict[str, Any]], optional): A dictionary
+            that will be fed into:obj:`openai.ChatCompletion.create()`.
+            If:obj:`None`, :obj:`RequestyConfig().as_dict()` will be used.
+            (default: :obj:`None`)
+        api_key (Optional[str], optional): The API key for authenticating
+            with the Requesty service. (default: :obj:`None`).
+        url (Optional[str], optional): The url to the Requesty service.
+            (default: :obj:`None`)
+        token_counter (Optional[BaseTokenCounter], optional): Token counter to
+            use for the model. If not provided, :obj:`OpenAITokenCounter(
+            ModelType.GPT_4O_MINI)` will be used.
+            (default: :obj:`None`)
+        timeout (Optional[float], optional): The timeout value in seconds for
+            API calls. If not provided, will fall back to the MODEL_TIMEOUT
+            environment variable or default to 180 seconds.
+            (default: :obj:`None`)
+        max_retries (int, optional): Maximum number of retries for API calls.
+            (default: :obj:`3`)
+        app_referer (Optional[str], optional): The HTTP-Referer header value
+            for Requesty App Attribution. If not provided, defaults to
+            'https://www.camel-ai.org/'. Set to :obj:`None` to disable.
+            (default: :obj:`'https://www.camel-ai.org/'`)
+        app_title (Optional[str], optional): The X-Title header value for
+            Requesty App Attribution. If not provided, defaults to 'CAMEL-AI'.
+            Set to :obj:`None` to disable. (default: :obj:`'CAMEL-AI'`)
+        **kwargs (Any): Additional arguments to pass to the client
+            initialization.
+    """
+
+    @api_keys_required([("api_key", "REQUESTY_API_KEY")])
+    def __init__(
+        self,
+        model_type: Union[ModelType, str],
+        model_config_dict: Optional[Dict[str, Any]] = None,
+        api_key: Optional[str] = None,
+        url: Optional[str] = None,
+        token_counter: Optional[BaseTokenCounter] = None,
+        timeout: Optional[float] = None,
+        max_retries: int = 3,
+        app_referer: Optional[str] = 'https://www.camel-ai.org/',
+        app_title: Optional[str] = 'CAMEL-AI',
+        **kwargs: Any,
+    ) -> None:
+        if model_config_dict is None:
+            model_config_dict = RequestyConfig().as_dict()
+        api_key = api_key or os.environ.get("REQUESTY_API_KEY")
+        url = url or os.environ.get(
+            "REQUESTY_API_BASE_URL", "https://router.requesty.ai/v1"
+        )
+        timeout = timeout or float(os.environ.get("MODEL_TIMEOUT", 180))
+
+        # Add Requesty App Attribution headers
+        # Merge with any existing headers to preserve user-provided headers
+        attribution_headers = {}
+        if app_referer is not None:
+            attribution_headers['HTTP-Referer'] = app_referer
+        if app_title is not None:
+            attribution_headers['X-Title'] = app_title
+
+        kwargs["default_headers"] = {
+            **attribution_headers,
+            **(kwargs.get("default_headers") or {}),
+        }
+
+        super().__init__(
+            model_type=model_type,
+            model_config_dict=model_config_dict,
+            api_key=api_key,
+            url=url,
+            token_counter=token_counter,
+            timeout=timeout,
+            max_retries=max_retries,
+            **kwargs,
+        )

--- a/camel/types/enums.py
+++ b/camel/types/enums.py
@@ -1982,6 +1982,7 @@ class ModelPlatformType(Enum):
     COMETAPI = "cometapi"
     OPENROUTER = "openrouter"
     ORCAROUTER = "orcarouter"
+    REQUESTY = "requesty"
     OLLAMA = "ollama"
     LITELLM = "litellm"
     LMSTUDIO = "lmstudio"
@@ -2066,6 +2067,11 @@ class ModelPlatformType(Enum):
     def is_orcarouter(self) -> bool:
         r"""Returns whether this platform is orcarouter."""
         return self is ModelPlatformType.ORCAROUTER
+
+    @property
+    def is_requesty(self) -> bool:
+        r"""Returns whether this platform is requesty."""
+        return self is ModelPlatformType.REQUESTY
 
     @property
     def is_lmstudio(self) -> bool:

--- a/docs/key_modules/models.md
+++ b/docs/key_modules/models.md
@@ -68,6 +68,7 @@ CAMEL supports a wide range of models, including [OpenAI’s GPT series](https:/
 | **Nebius**       | [supported models](https://studio.nebius.com/) |
 | **OpenRouter**   | [supported models](https://openrouter.ai/models) |
 | **OrcaRouter**   | [supported models](https://www.orcarouter.ai/models) |
+| **Requesty**     | [supported models](https://app.requesty.ai/router/list) |
 | **PPIO**         | [supported models](https://ppio.com/model-api/console) |
 | **LiteLLM**      | [supported models](https://docs.litellm.ai/docs/providers) |
 | **OpenAI Compatible** | custom OpenAI-compatible endpoints via `OPENAI_COMPATIBLE_MODEL` |
@@ -428,6 +429,41 @@ Integrate your favorite models into CAMEL-AI with straightforward Python calls. 
   ```
 
   **Available Models:** View the full list of models available through OpenRouter at [openrouter.ai/models](https://openrouter.ai/models).
+
+  </Tab>
+
+   <Tab title="Requesty">
+  Access a wide variety of models through [Requesty](https://requesty.ai/)'s unified, OpenAI-compatible API:
+
+  **Setup:** Set your Requesty API key as an environment variable:
+  ```bash
+  export REQUESTY_API_KEY="your-api-key-here"
+  ```
+
+  ```python
+  from camel.models import ModelFactory
+  from camel.types import ModelPlatformType
+  from camel.configs import RequestyConfig
+  from camel.agents import ChatAgent
+
+  model = ModelFactory.create(
+      model_platform=ModelPlatformType.REQUESTY,
+      model_type="openai/gpt-4o-mini",
+      model_config_dict=RequestyConfig(temperature=0.2).as_dict(),
+  )
+
+  agent = ChatAgent(
+      system_message="You are a helpful assistant.",
+      model=model
+  )
+
+  response = agent.step("Say hi to CAMEL AI community.")
+  print(response.msgs[0].content)
+  ```
+
+  Requesty uses `provider/model` naming (e.g. `openai/gpt-4o-mini`, `anthropic/claude-sonnet-4-5`, `google/gemini-2.5-flash`), the same scheme as OpenRouter.
+
+  **Available Models:** View the full list of models available through Requesty at [app.requesty.ai/router/list](https://app.requesty.ai/router/list).
 
   </Tab>
 

--- a/examples/models/requesty_example.py
+++ b/examples/models/requesty_example.py
@@ -1,0 +1,50 @@
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+
+from camel.agents import ChatAgent
+from camel.configs import RequestyConfig
+from camel.models import ModelFactory
+from camel.types import ModelPlatformType
+
+# Requesty is an OpenAI-compatible router. Models are addressed with the
+# provider/model naming scheme (e.g. openai/gpt-4o-mini).
+model = ModelFactory.create(
+    model_platform=ModelPlatformType.REQUESTY,
+    model_type="openai/gpt-4o-mini",
+    model_config_dict=RequestyConfig(temperature=0.2).as_dict(),
+)
+
+# Define system message
+sys_msg = "You are a helpful AI assistant."
+
+# Set agent
+camel_agent = ChatAgent(system_message=sys_msg, model=model)
+
+user_msg = "Say hi to CAMEL AI, one open-source community dedicated to the "
+"study of autonomous and communicative agents."
+
+# Get response information
+response = camel_agent.step(user_msg)
+print(response.msgs[0].content)
+
+'''
+===============================================================================
+This example demonstrates how to use a model served by Requesty with the
+CAMEL AI framework through the OpenAI-compatible interface.
+
+Note: Set your REQUESTY_API_KEY environment variable before running this
+example. You can obtain a key at https://app.requesty.ai/api-keys and browse
+available models at https://app.requesty.ai/router/list.
+===============================================================================
+'''


### PR DESCRIPTION
## Summary

Adds [Requesty](https://requesty.ai) — an OpenAI-compatible LLM router — as a model platform, mirroring the existing OpenRouter integration. Requesty exposes 400+ models through one OpenAI-compatible endpoint, addressed as `provider/model` (the same scheme as OpenRouter).

## Changes

- `camel/models/requesty_model.py` — `RequestyModel(OpenAICompatibleModel)`: base URL `https://router.requesty.ai/v1` (overridable via `REQUESTY_API_BASE_URL`), env `REQUESTY_API_KEY`, `@api_keys_required`, `HTTP-Referer` / `X-Title` attribution headers. Mirrors `openrouter_model.py`.
- `camel/configs/requesty_config.py` — `RequestyConfig(BaseConfig)` + `REQUESTY_API_PARAMS`, mirrors `openrouter_config.py`.
- `camel/types/enums.py` — `ModelPlatformType.REQUESTY` + `is_requesty` property.
- `camel/models/model_factory.py` — factory registration.
- `camel/models/__init__.py`, `camel/configs/__init__.py` — exports (alphabetical).
- `examples/models/requesty_example.py` — usage example.
- `docs/key_modules/models.md` — provider table row + a Requesty tab.

The generated Mintlify reference docs under `docs/mintlify/` are auto-generated, so I left them untouched.

## Testing

- Verified a live chat completion through the `RequestyModel.run()` code path against `https://router.requesty.ai/v1` (model `openai/gpt-4o-mini`).
- `ruff check` clean on all touched files.

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.
