### PR TITLE
fix: respect Anthropic strict tool limits

### DIFF
--- a/camel/models/anthropic_model.py
+++ b/camel/models/anthropic_model.py
@@ -13,6 +13,7 @@
 # ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
 import copy
 import json
+import logging
 import os
 import time
 from typing import Any, Dict, List, Optional, Type, Union, cast
@@ -45,6 +46,15 @@ elif os.environ.get("TRACEROOT_ENABLED", "False").lower() == "true":
         from camel.utils import observe
 else:
     from camel.utils import observe
+
+
+logger = logging.getLogger(__name__)
+
+# Anthropic structured-output schema complexity limits:
+# https://platform.claude.com/docs/en/build-with-claude/structured-outputs
+_MAX_STRICT_TOOLS = 20
+_MAX_STRICT_OPTIONAL_PARAMETERS = 24
+_MAX_STRICT_UNION_PARAMETERS = 16
 
 
 def strip_trailing_whitespace_from_messages(
@@ -196,6 +206,7 @@ class AnthropicModel(BaseModelBackend):
                 "ttl": cache_control,
             }
         self._tool_call_thinking_blocks: Dict[str, List[Dict[str, Any]]] = {}
+        self._strict_tools_downgrade_warning_emitted = False
 
     @property
     def token_counter(self) -> BaseTokenCounter:
@@ -1002,7 +1013,90 @@ class AnthropicModel(BaseModelBackend):
                     anthropic_tool["strict"] = func.get("strict", True)
                 anthropic_tools.append(anthropic_tool)
 
+        strict_limit_reason = self._get_strict_tools_limit_reason(
+            anthropic_tools
+        )
+        if strict_limit_reason is not None:
+            for anthropic_tool in anthropic_tools:
+                if anthropic_tool.get("strict") is True:
+                    anthropic_tool["strict"] = False
+
+            if not self._strict_tools_downgrade_warning_emitted:
+                logger.warning(
+                    "Disabling strict tool use for this Anthropic model "
+                    "because the request exceeds Anthropic's structured "
+                    "output limits: %s. Tool calling remains enabled, but "
+                    "tool inputs are not grammar-constrained.",
+                    strict_limit_reason,
+                )
+                self._strict_tools_downgrade_warning_emitted = True
+
         return anthropic_tools
+
+    @staticmethod
+    def _get_strict_tools_limit_reason(
+        tools: List[Dict[str, Any]],
+    ) -> Optional[str]:
+        r"""Return why Anthropic strict tool limits are exceeded, if any.
+
+        Anthropic compiles all strict tool schemas in a request into a single
+        grammar. Its documented request-wide limits apply to the number of
+        strict tools, optional parameters, and parameters using union types.
+        """
+        strict_tools = [tool for tool in tools if tool.get("strict") is True]
+        if len(strict_tools) > _MAX_STRICT_TOOLS:
+            return (
+                f"{len(strict_tools)} strict tools "
+                f"(maximum {_MAX_STRICT_TOOLS})"
+            )
+
+        optional_parameters = 0
+        union_parameters = 0
+
+        def count_schema_complexity(schema: Any) -> None:
+            nonlocal optional_parameters, union_parameters
+
+            if isinstance(schema, list):
+                for item in schema:
+                    count_schema_complexity(item)
+                return
+            if not isinstance(schema, dict):
+                return
+
+            schema_type = schema.get("type")
+            if isinstance(schema_type, list) or isinstance(
+                schema.get("anyOf"), list
+            ):
+                union_parameters += 1
+
+            properties = schema.get("properties")
+            if isinstance(properties, dict):
+                required = schema.get("required")
+                required_names = (
+                    set(required) if isinstance(required, list) else set()
+                )
+                optional_parameters += len(
+                    set(properties).difference(required_names)
+                )
+
+            for value in schema.values():
+                count_schema_complexity(value)
+
+        for tool in strict_tools:
+            count_schema_complexity(tool.get("input_schema", {}))
+
+        if optional_parameters > _MAX_STRICT_OPTIONAL_PARAMETERS:
+            return (
+                f"{optional_parameters} optional parameters across strict "
+                f"schemas (maximum {_MAX_STRICT_OPTIONAL_PARAMETERS})"
+            )
+        if union_parameters > _MAX_STRICT_UNION_PARAMETERS:
+            return (
+                f"{union_parameters} union parameters across strict schemas "
+                f"(maximum {_MAX_STRICT_UNION_PARAMETERS})"
+            )
+
+        return None
 
     @observe()
     def _run(

--- a/test/models/test_anthropic_model.py
+++ b/test/models/test_anthropic_model.py
@@ -34,6 +34,27 @@ class TravelResponse(BaseModel):
     city: str
 
 
+def _make_strict_openai_tool(
+    name: str,
+    properties=None,
+    required=None,
+):
+    properties = properties or {}
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": "Test tool",
+            "parameters": {
+                "type": "object",
+                "properties": properties,
+                "required": required or [],
+            },
+            "strict": True,
+        },
+    }
+
+
 @pytest.mark.model_backend
 @pytest.mark.parametrize(
     "model_type",
@@ -632,6 +653,80 @@ def test_convert_tools_preserves_strict_flag():
 
     result = model._convert_openai_tools_to_anthropic(openai_tools)
 
+    assert result[0]["strict"] is False
+
+
+def test_convert_tools_preserves_strict_within_anthropic_limits():
+    """Strict mode remains enabled when the request is within limits."""
+    model = AnthropicModel(
+        "claude-sonnet-5",
+        api_key="dummy_api_key",
+    )
+    openai_tools = [
+        _make_strict_openai_tool(f"tool_{index}") for index in range(20)
+    ]
+
+    result = model._convert_openai_tools_to_anthropic(openai_tools)
+
+    assert result is not None
+    assert all(tool["strict"] is True for tool in result)
+
+
+def test_convert_tools_disables_strict_above_anthropic_tool_limit(caplog):
+    """All tools remain available when strict tool count exceeds 20."""
+    model = AnthropicModel(
+        "claude-sonnet-5",
+        api_key="dummy_api_key",
+    )
+    openai_tools = [
+        _make_strict_openai_tool(f"tool_{index}") for index in range(21)
+    ]
+
+    result = model._convert_openai_tools_to_anthropic(openai_tools)
+
+    assert result is not None
+    assert len(result) == 21
+    assert all(tool["strict"] is False for tool in result)
+    assert all(tool["function"]["strict"] is True for tool in openai_tools)
+    assert "21 strict tools (maximum 20)" in caplog.text
+
+
+def test_convert_tools_disables_strict_above_anthropic_union_limit():
+    """Union-heavy schemas fall back to non-strict tool use."""
+    model = AnthropicModel(
+        ModelType.CLAUDE_FABLE_5,
+        api_key="dummy_api_key",
+    )
+    properties = {
+        f"value_{index}": {"anyOf": [{"type": "string"}, {"type": "null"}]}
+        for index in range(17)
+    }
+    openai_tools = [
+        _make_strict_openai_tool(
+            "union_heavy_tool", properties, list(properties)
+        )
+    ]
+
+    result = model._convert_openai_tools_to_anthropic(openai_tools)
+
+    assert result is not None
+    assert result[0]["strict"] is False
+
+
+def test_convert_tools_disables_strict_above_anthropic_optional_limit():
+    """Schemas with too many optional parameters use non-strict tools."""
+    model = AnthropicModel(
+        ModelType.CLAUDE_FABLE_5,
+        api_key="dummy_api_key",
+    )
+    properties = {f"value_{index}": {"type": "string"} for index in range(25)}
+    openai_tools = [
+        _make_strict_openai_tool("optional_heavy_tool", properties)
+    ]
+
+    result = model._convert_openai_tools_to_anthropic(openai_tools)
+
+    assert result is not None
     assert result[0]["strict"] is False
 
 


### PR DESCRIPTION
### Related Issue

Refs #1695. Follow-up to #4003.

### Description

Anthropic limits a request to 20 strict tools, 24 optional parameters, and
16 union parameters across strict schemas. CAMEL-generated function tools are
strict by default, so agents with large tool sets can be rejected before
inference with `Too many strict tools`.

This change:

- checks converted Anthropic tools against the documented request limits;
- preserves every tool but downgrades strict tools to non-strict for an
  over-limit request;
- emits one warning per model instance explaining that tool inputs are no
  longer grammar-constrained; and
- leaves strict tool use unchanged when the request remains within limits.

This restores tool calling for large agents while making the validation
tradeoff visible instead of failing the entire request with HTTP 400.

### Developer impact

No API or dependency changes are required. Requests that exceed Anthropic's
strict-schema limits keep all tool capabilities, but tool arguments must be
validated at execution time because constrained decoding is disabled for that
request.

### Validation

- `.venv/bin/pytest -q test/models/test_anthropic_model.py` — 53 passed
- Ruff check and format check on both changed files
- Replayed a real 49-tool Eigent request through the patched CAMEL backend:
  all 49 tools reached the mocked Anthropic request boundary, with strict
  tools reduced from 49 to 0 and the input schemas left unmodified

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Checklist

- [ ] I have read and agree to the AI-Generated Code Policy (please confirm
  before marking this draft ready for review)
- [x] I have linked this PR to a related issue
- [x] No dependencies need to be added or updated
- [x] I have updated the tests accordingly
- [x] Documentation and examples are not required for this bug fix
