### PR TITLE
fix(dedup): use global column indices in batched deduplication mask

### DIFF
--- a/camel/utils/deduplication.py
+++ b/camel/utils/deduplication.py
@@ -193,9 +193,11 @@ def deduplicate_internally(
             embeddings_array[i:batch_end], embeddings_array[:batch_end]
         )
 
-        # Create mask for lower triangle (avoid self-comparison and redundant
-        # checks)
-        tril_mask = np.tril(np.ones_like(batch_similarities), k=-1)
+        # Create mask keeping only comparisons against earlier texts. Rows are
+        # local to the batch (row r == global text i + r) but columns are global
+        # indices, so the diagonal must be offset by the batch start i: keep
+        # [r, c] only when c < i + r (i.e. k=i-1), not c < r.
+        tril_mask = np.tril(np.ones_like(batch_similarities), k=i - 1)
         batch_similarities = batch_similarities * tril_mask
 
         # Find duplicates in current batch

--- a/camel/utils/deduplication.py
+++ b/camel/utils/deduplication.py
@@ -193,10 +193,10 @@ def deduplicate_internally(
             embeddings_array[i:batch_end], embeddings_array[:batch_end]
         )
 
-        # Create mask keeping only comparisons against earlier texts. Rows are
-        # local to the batch (row r == global text i + r) but columns are global
-        # indices, so the diagonal must be offset by the batch start i: keep
-        # [r, c] only when c < i + r (i.e. k=i-1), not c < r.
+        # Create mask keeping only comparisons against earlier texts. Rows
+        # are local to the batch (row r == global text i + r) but columns
+        # are global indices, so the diagonal must be offset by the batch
+        # start i: keep [r, c] only when c < i + r (i.e. k=i-1), not c < r.
         tril_mask = np.tril(np.ones_like(batch_similarities), k=i - 1)
         batch_similarities = batch_similarities * tril_mask
 

--- a/test/utils/test_deduplication.py
+++ b/test/utils/test_deduplication.py
@@ -144,6 +144,30 @@ def test_deduplicate_internally_with_precomputed_embeddings():
         ), f"Missing embedding for unique id {uid}"
 
 
+def test_deduplicate_internally_cross_batch():
+    r"""Batching must not change results: a ``batch_size`` smaller than the
+    number of texts must find the same duplicates as a single batch.
+
+    Regression test for a mask that used batch-local indices, so cross-batch
+    duplicates (e.g. the first item of any batch after the first) were missed.
+    """
+    texts = ["A", "B", "C", "D"]
+    embeddings = [[0.5, 0.5, 0.5]] * 4  # all identical -> 1, 2, 3 duplicate 0
+
+    single: DeduplicationResult = deduplicate_internally(
+        texts=texts, threshold=0.9, embeddings=embeddings, batch_size=1000
+    )
+    batched: DeduplicationResult = deduplicate_internally(
+        texts=texts, threshold=0.9, embeddings=embeddings, batch_size=2
+    )
+
+    assert single.duplicate_to_target_map == {1: 0, 2: 0, 3: 0}
+    assert batched.duplicate_to_target_map == single.duplicate_to_target_map, (
+        "batched dedup must match single-batch; got "
+        f"{batched.duplicate_to_target_map}"
+    )
+
+
 def test_deduplicate_internally_chain_scenario():
     r"""Test scenario:
       - A <-> B similarity > threshold


### PR DESCRIPTION
## Problem

`deduplicate_internally` (`camel/utils/deduplication.py`) processes embeddings in batches. Within each batch the similarity matrix is rectangular — rows are **batch-local** (row `r` == global text `i + r`) but columns are **global** indices (`embeddings_array[:batch_end]`). The duplicate map is written with the global column index:

```python
for i in range(0, n, batch_size):
    batch_end = min(i + batch_size, n)
    batch_similarities = cosine_similarity(
        embeddings_array[i:batch_end], embeddings_array[:batch_end]
    )
    tril_mask = np.tril(np.ones_like(batch_similarities), k=-1)   # <-- masks by LOCAL indices
    ...
    duplicate_to_target_map[i + j] = max_indices[j]               # <-- columns are GLOBAL
```

`np.tril(..., k=-1)` keeps `[r, c]` only when `c < r` (local). For every batch after the first (`i > 0`), that wrongly zeroes out valid comparisons against earlier texts — in particular the first row of each later batch (`r = 0`) is compared against nothing, so those texts can never be flagged as duplicates. This silently corrupts results whenever `len(texts) > batch_size` (default **1000**) — exactly the large-input path the batching exists for.

## Reproduction

4 identical embeddings `[[0.5,0.5,0.5]]*4`, threshold 0.9:

| | `duplicate_to_target_map` |
|---|---|
| single batch (`batch_size=1000`, reference) | `{1: 0, 2: 0, 3: 0}` |
| batched (`batch_size=2`, current) | `{1: 0, 3: 0}` ❌ (index 2 missed) |

Mixed set `[[1,0,0],[0,1,0],[1,0,0],[0,1,0],[0,0,1]]`, threshold 0.95: reference `{2:0, 3:1}` vs batched `{}` ❌.

## Fix

Offset the diagonal by the batch start so the mask uses global column indices:

```python
tril_mask = np.tril(np.ones_like(batch_similarities), k=i - 1)
```

This keeps `[r, c]` when `c < i + r` (the intended "compare only against earlier texts"). For the first batch `i=0`, `k=-1`, identical to before — no change to the single-batch path. Verified: batched results now equal the single-batch reference (`{1:0,2:0,3:0}` and `{2:0,3:1}`).

## Test

Added `test_deduplicate_internally_cross_batch` — runs the same input at `batch_size=2` and `batch_size=1000` and asserts they match. It fails on the current code (batched drops `{2:0}`) and passes after the fix. Full `test/utils/test_deduplication.py`: 8 passed.
