### PR TITLE
fix(models): map Cohere parallel tool calls to a single choice

### DIFF
--- a/camel/models/cohere_model.py
+++ b/camel/models/cohere_model.py
@@ -132,50 +132,41 @@ class CohereModel(BaseModelBackend):
             usage = {}
 
         tool_calls = response.message.tool_calls
-        choices = []
         if tool_calls:
-            for tool_call in tool_calls:
-                openai_tool_calls = [
-                    dict(
-                        id=tool_call.id,
-                        function={
-                            "name": tool_call.function.name,
-                            "arguments": tool_call.function.arguments,
-                        }
-                        if tool_call.function
-                        else {},
-                        type=tool_call.type,
-                    )
-                ]
-
-                choice = dict(
-                    index=None,
-                    message={
-                        "role": "assistant",
-                        "content": response.message.tool_plan,
-                        "tool_calls": openai_tool_calls,
-                    },
-                    finish_reason=response.finish_reason
-                    if response.finish_reason
-                    else None,
+            # A single Cohere turn may carry several parallel tool calls.
+            # Collect all of them into one choice so none are dropped by
+            # downstream code that only reads choices[0] (mirrors
+            # MistralModel._to_openai_response).
+            openai_tool_calls = [
+                dict(
+                    id=tool_call.id,
+                    function={
+                        "name": tool_call.function.name,
+                        "arguments": tool_call.function.arguments,
+                    }
+                    if tool_call.function
+                    else {},
+                    type=tool_call.type,
                 )
-                choices.append(choice)
-
+                for tool_call in tool_calls
+            ]
+            content = response.message.tool_plan
         else:
             openai_tool_calls = None
+            content = response.message.content[0].text  # type: ignore[union-attr,index]
 
-            choice = dict(
-                index=None,
-                message={
-                    "role": "assistant",
-                    "content": response.message.content[0].text,  # type: ignore[union-attr,index]
-                    "tool_calls": openai_tool_calls,
-                },
-                finish_reason=response.finish_reason
-                if response.finish_reason
-                else None,
-            )
-            choices.append(choice)
+        choice = dict(
+            index=0,
+            message={
+                "role": "assistant",
+                "content": content,
+                "tool_calls": openai_tool_calls,
+            },
+            finish_reason=response.finish_reason
+            if response.finish_reason
+            else None,
+        )
+        choices = [choice]
 
         obj = ChatCompletion.construct(
             id=response.id,

--- a/test/models/test_cohere_model.py
+++ b/test/models/test_cohere_model.py
@@ -12,12 +12,92 @@
 # limitations under the License.
 # ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
 
+from types import SimpleNamespace
+
 import pytest
 
 from camel.configs import CohereConfig
 from camel.models import CohereModel
 from camel.types import ModelType
 from camel.utils import OpenAITokenCounter
+
+
+def _mock_cohere_tool_call(call_id, name, arguments):
+    return SimpleNamespace(
+        id=call_id,
+        type="function",
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+def _mock_cohere_response(*, tool_calls=None, text=None):
+    message = SimpleNamespace(
+        tool_plan="calling tools" if tool_calls else None,
+        content=None if tool_calls else [SimpleNamespace(text=text)],
+        tool_calls=tool_calls,
+    )
+    return SimpleNamespace(
+        id="gen-1",
+        finish_reason="tool_call" if tool_calls else "complete",
+        usage=SimpleNamespace(
+            tokens=SimpleNamespace(input_tokens=11, output_tokens=7)
+        ),
+        message=message,
+    )
+
+
+def test_to_openai_response_preserves_parallel_tool_calls():
+    r"""A Cohere turn with several parallel tool calls must map to a single
+    choices[0] that carries all of them. Downstream code reads only
+    ``choices[0].message.tool_calls``, so splitting the calls across separate
+    choices silently drops every call after the first."""
+    model = CohereModel(ModelType.COHERE_COMMAND_R, api_key="dummy")
+    response = _mock_cohere_response(
+        tool_calls=[
+            _mock_cohere_tool_call("t1", "get_weather", '{"city": "Paris"}'),
+            _mock_cohere_tool_call("t2", "get_time", '{"tz": "UTC"}'),
+        ]
+    )
+
+    result = model._to_openai_response(response)
+
+    assert len(result.choices) == 1
+    assert result.choices[0].index == 0
+    tool_calls = result.choices[0].message.tool_calls
+    assert [tc.id for tc in tool_calls] == ["t1", "t2"]
+    assert [tc.function.name for tc in tool_calls] == [
+        "get_weather",
+        "get_time",
+    ]
+
+
+def test_to_openai_response_single_tool_call_unchanged():
+    r"""The common single-tool-call path still yields one choice, one call."""
+    model = CohereModel(ModelType.COHERE_COMMAND_R, api_key="dummy")
+    response = _mock_cohere_response(
+        tool_calls=[
+            _mock_cohere_tool_call("t1", "get_weather", '{"city": "Paris"}')
+        ]
+    )
+
+    result = model._to_openai_response(response)
+
+    assert len(result.choices) == 1
+    assert len(result.choices[0].message.tool_calls) == 1
+    assert result.choices[0].message.tool_calls[0].id == "t1"
+
+
+def test_to_openai_response_text_only():
+    r"""A plain text turn maps to one choice with no tool calls."""
+    model = CohereModel(ModelType.COHERE_COMMAND_R, api_key="dummy")
+    response = _mock_cohere_response(text="hello there")
+
+    result = model._to_openai_response(response)
+
+    assert len(result.choices) == 1
+    assert result.choices[0].index == 0
+    assert result.choices[0].message.content == "hello there"
+    assert result.choices[0].message.tool_calls is None
 
 
 @pytest.mark.model_backend


### PR DESCRIPTION
### Related Issue

Closes #4185

### Description

**Root cause.** `CohereModel._to_openai_response` appended one `choice` per tool call:

```python
tool_calls = response.message.tool_calls
choices = []
if tool_calls:
    for tool_call in tool_calls:          # one choice per call
        openai_tool_calls = [dict(id=tool_call.id, ...)]
        choice = dict(index=None, message={..., "tool_calls": openai_tool_calls}, ...)
        choices.append(choice)
```

Cohere's v2 API can return several tool calls in one turn ("The model can determine that more than one tool call is required", https://docs.cohere.com/v2/docs/tool-use-overview). `ChatAgent` reads tool calls only from `choices[0]` (`camel/agents/chat_agent.py:3959`), so a turn with N parallel calls produced N choices holding one call each, and calls 2..N were silently discarded: no error, no warning, the agent acted on the first tool only. Single-call responses map to one choice, which is why the existing tests did not catch this.

**Invariant.** One generation maps to one `choices[0]`, whose `message.tool_calls` holds every tool call from that turn. `MistralModel._to_openai_response` (`camel/models/mistral_model.py:152-166`) already does exactly this.

**Fix (one file).** Build `openai_tool_calls` as a comprehension over all of `response.message.tool_calls` and append a single choice, mirroring the Mistral adapter. The tool and text paths now share one choice construction, and `index` is the integer the OpenAI shape expects (both paths previously set `index=None`).

Scope note: apart from that `index`, the single-tool-call and text-only paths keep their current output. `index=None` is the second defect reported in #4185 and sits on the same lines, so it is fixed here rather than left behind; happy to split it out if you would rather keep this to the dropped-calls bug alone.

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Verification

Run in a clean `python:3.12-slim` container against master `0b9d986`, with the source mounted and imported from the mount (`camel.models.cohere_model.__file__` printed as `/src/camel/models/cohere_model.py` on both sides, so each run is against the source shown).

Three tests added to `test/models/test_cohere_model.py`. They build the Cohere response shape directly and call the mapping function, so they need no API key and no network.

On master (unfixed source, new tests applied):

```text
>       assert len(result.choices) == 1
E       assert 2 == 1
E        +  where 2 = len([Choice(finish_reason='tool_call', index=None, ...

>       assert result.choices[0].index == 0
E       AssertionError: assert None == 0

FAILED test/models/test_cohere_model.py::test_to_openai_response_preserves_parallel_tool_calls
FAILED test/models/test_cohere_model.py::test_to_openai_response_text_only
2 failed, 1 passed, 5 deselected in 1.54s
```

On this branch:

```text
...                                                                      [100%]
3 passed, 5 deselected in 1.49s
```

`test_to_openai_response_single_tool_call_unchanged` is the control: it passes on master and on this branch, since the common single-call path is unchanged.

Whole file, this branch: `5 failed, 3 passed`. The 5 failures are the pre-existing `test_cohere_model[...]` backend tests, which need a real key (`ValueError: Missing or empty required API keys in environment variables: COHERE_API_KEY`). They fail identically on unmodified master in the same container (`7 failed, 1 passed` there, the same 5 plus the 2 new tests this PR fixes), so they are unrelated to this change.

Hooks, on the two changed files: `ruff` Passed, `ruff-format` Passed, `codespell` Passed, license check exit 0 ("License updated in 0 files").

**What I did not verify.** No live Cohere API call (no key), so the multi-call response in the tests is constructed rather than captured from the wire; the parallel-call behavior itself is documented at the Cohere link above. I ran `mypy` only on the two changed files (`Success: no issues found`), not the full `uv run mypy -p camel -p test -p apps` that the hook runs, so I have not reproduced the whole type-check leg locally.

### Checklist

- [x] I have read and agree to the [AI-Generated Code Policy](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md#ai-generated-code-policy) (**required**)
- [x] I have linked this PR to an issue (#4185) (**required**)
- [ ] Dependencies: none added or changed, no `uv lock` needed
- [x] I have updated the tests accordingly
- [ ] Documentation: not needed
- [ ] Examples: not a new feature

Written with AI assistance, under my responsibility as the account owner: the root cause was traced in the source, every number and log above came from the container run described, and I reviewed the diff and this text before opening.
