### PR TITLE
feat: add append-only chat stack for training rollouts

### DIFF
--- a/camel/agents/__init__.py
+++ b/camel/agents/__init__.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 # ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
 from .base import BaseAgent
+from .base_chat_agent import BaseChatAgent
 from .chat_agent import ChatAgent
 from .critic_agent import CriticAgent
 from .knowledge_graph_agent import KnowledgeGraphAgent
@@ -28,6 +29,7 @@ from .task_agent import (
 
 __all__ = [
     'BaseAgent',
+    'BaseChatAgent',
     'ChatAgent',
     'TaskSpecifyAgent',
     'TaskPlannerAgent',

--- a/camel/agents/base_chat_agent.py
+++ b/camel/agents/base_chat_agent.py
@@ -1,0 +1,666 @@
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+"""Minimal append-only chat agent for reproducible training rollouts."""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import functools
+import json
+import random
+import time
+import uuid
+from enum import StrEnum
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
+
+from openai import RateLimitError
+from pydantic import BaseModel
+
+from camel.agents._types import ModelResponse, ToolCallRequest
+from camel.agents._utils import (
+    convert_to_function_tool,
+    get_info_dict,
+    handle_logprobs,
+    safe_model_dump,
+)
+from camel.agents.base import BaseAgent
+from camel.logger import get_logger
+from camel.memories import (
+    AgentMemory,
+    BaseContextCreator,
+    ChatHistoryMemory,
+    ContextRecord,
+    MemoryRecord,
+)
+from camel.messages import BaseMessage, OpenAIMessage
+from camel.models import BaseModelBackend, ModelManager, ModelProcessingError
+from camel.responses import ChatAgentResponse
+from camel.toolkits import FunctionTool, RegisteredAgentToolkit
+from camel.types import ChatCompletion, OpenAIBackendRole, RoleType
+from camel.types.agents import ToolCallingRecord
+from camel.utils import BaseTokenCounter
+from camel.utils.agent_context import set_current_agent_id
+from camel.utils.tool_result import ToolResult
+
+logger = get_logger(__name__)
+
+_RAW_OPENAI_MESSAGE_KEY = "_base_chat_agent_raw_openai_message"
+
+
+class _AppendOnlyContextCreator(BaseContextCreator):
+    """Return memory records in storage order without filtering or sorting."""
+
+    def __init__(
+        self,
+        token_limit: int,
+        token_counter: Optional[BaseTokenCounter] = None,
+    ) -> None:
+        """Create exact-order context with optional token counting."""
+        self._token_limit = token_limit
+        self._token_counter = token_counter
+
+    @property
+    def token_counter(self) -> BaseTokenCounter:
+        """Return the configured counter or fail when none is available."""
+        if self._token_counter is None:
+            raise RuntimeError("No local token counter is configured")
+        return self._token_counter
+
+    @property
+    def token_limit(self) -> int:
+        """Return the model context limit associated with this creator."""
+        return self._token_limit
+
+    def create_context(
+        self, records: List[ContextRecord]
+    ) -> Tuple[List[OpenAIMessage], int]:
+        """Convert every record to its exact stored OpenAI message."""
+        messages: List[OpenAIMessage] = []
+        for record in records:
+            memory_record = record.memory_record
+            meta = memory_record.message.meta_dict or {}
+            raw_message = meta.get(_RAW_OPENAI_MESSAGE_KEY)
+            if isinstance(raw_message, dict):
+                messages.append(copy.deepcopy(raw_message))
+            else:
+                messages.append(memory_record.to_openai_message())
+
+        num_tokens = (
+            self._token_counter.count_tokens_from_messages(messages)
+            if self._token_counter is not None and messages
+            else 0
+        )
+        return messages, num_tokens
+
+
+class TerminationReason(StrEnum):
+    """Why a training step ended.
+
+    Values and cause-chain behaviour mirror
+    ``strands_env.core.types.TerminationReason`` without introducing a Strands
+    runtime dependency into CAMEL.
+    """
+
+    NOT_TERMINATED = "not_terminated"
+    TASK_COMPLETE = "task_complete"
+    MAX_TOKENS_REACHED = "max_tokens_reached"
+    CONTEXT_WINDOW_OVERFLOW = "context_window_overflow"
+    MAX_TOOL_ITERATIONS_REACHED = "max_tool_iterations_reached"
+    MAX_TOOL_CALLS_REACHED = "max_tool_calls_reached"
+    MAX_MESSAGES_REACHED = "max_messages_reached"
+    RECURSION_DEPTH_EXCEEDED = "recursion_depth_exceeded"
+    TIMEOUT = "timeout"
+    CONNECTION_ERROR = "connection_error"
+    UNCLASSIFIED_ERROR = "unclassified_error"
+
+    @staticmethod
+    def _cause_chain(error: BaseException):
+        """Yield each unique exception through explicit and implicit causes."""
+        seen: set[int] = set()
+        current: Optional[BaseException] = error
+        while current is not None and id(current) not in seen:
+            seen.add(id(current))
+            yield current
+            current = current.__cause__ or current.__context__
+
+    @classmethod
+    def from_error(cls, error: Optional[BaseException]) -> "TerminationReason":
+        """Classify an exception and its causes into a training termination."""
+        if error is None:
+            return cls.TASK_COMPLETE
+
+        chain = list(cls._cause_chain(error))
+        names = " ".join(type(exc).__name__.lower() for exc in chain)
+        if "contextwindow" in names or "contextlength" in names:
+            return cls.CONTEXT_WINDOW_OVERFLOW
+        if "maxtoken" in names:
+            return cls.MAX_TOKENS_REACHED
+        if "maxtooliteration" in names:
+            return cls.MAX_TOOL_ITERATIONS_REACHED
+        if "maxtoolcall" in names:
+            return cls.MAX_TOOL_CALLS_REACHED
+        if "maxmessage" in names:
+            return cls.MAX_MESSAGES_REACHED
+        if any(isinstance(exc, RecursionError) for exc in chain):
+            return cls.RECURSION_DEPTH_EXCEEDED
+        if "timeout" in names:
+            return cls.TIMEOUT
+        if any(
+            marker in names
+            for marker in ("connection", "disconnected", "connecterror")
+        ):
+            return cls.CONNECTION_ERROR
+        return cls.UNCLASSIFIED_ERROR
+
+
+class BaseChatAgent(BaseAgent):
+    """An async-only CAMEL agent with raw append-only memory.
+
+    This class deliberately inherits directly from :class:`BaseAgent`. It has
+    an ``AgentMemory`` but bypasses score-based context processing, windows,
+    pruning, and automatic summarization. Internal CAMEL ``FunctionTool``
+    objects and async MCP tools remain supported.
+    """
+
+    def __init__(
+        self,
+        system_message: Optional[Union[BaseMessage, str]] = None,
+        model: Optional[Union[BaseModelBackend, ModelManager]] = None,
+        memory: Optional[AgentMemory] = None,
+        tools: Optional[List[Union[FunctionTool, Callable[..., Any]]]] = None,
+        toolkits_to_register_agent: Optional[
+            List[RegisteredAgentToolkit]
+        ] = None,
+        token_limit: Optional[int] = None,
+        max_iteration: Optional[int] = None,
+        agent_id: Optional[str] = None,
+        tool_execution_timeout: Optional[float] = None,
+        retry_attempts: int = 3,
+        retry_delay: float = 1.0,
+        step_timeout: Optional[float] = None,
+    ) -> None:
+        """Configure an async agent whose ``AgentMemory`` is never processed.
+
+        Tools are normalized to CAMEL ``FunctionTool`` objects. ``token_limit``
+        defaults to the model limit, while tool and whole-step timeouts remain
+        optional so training frameworks can choose their own limits.
+        """
+        if model is None:
+            raise ValueError("BaseChatAgent requires a model backend")
+        if not isinstance(model, (BaseModelBackend, ModelManager)):
+            raise TypeError("model must be a BaseModelBackend or ModelManager")
+        self.model_backend = (
+            model if isinstance(model, ModelManager) else ModelManager(model)
+        )
+        if self.model_backend.model_config_dict.get("stream", False):
+            raise ValueError(
+                "BaseChatAgent only supports non-streaming models"
+            )
+
+        self.agent_id = agent_id or str(uuid.uuid4())
+        self._original_system_message = (
+            BaseMessage.make_system_message(system_message)
+            if isinstance(system_message, str)
+            else system_message
+        )
+        self.role_name = (
+            getattr(self._original_system_message, "role_name", None)
+            or "assistant"
+        )
+        self.role_type = (
+            getattr(self._original_system_message, "role_type", None)
+            or RoleType.ASSISTANT
+        )
+
+        self._internal_tools: Dict[str, FunctionTool] = {
+            tool.get_function_name(): tool
+            for tool in [
+                convert_to_function_tool(tool) for tool in (tools or [])
+            ]
+        }
+        for toolkit in toolkits_to_register_agent or []:
+            toolkit.register_agent(self)
+
+        self._token_limit = (
+            token_limit
+            if token_limit is not None
+            else self.model_backend.token_limit
+        )
+        try:
+            token_counter = self.model_backend.token_counter
+        except (NotImplementedError, RuntimeError):
+            token_counter = None
+        self._context_creator = _AppendOnlyContextCreator(
+            token_limit=self._token_limit,
+            token_counter=token_counter,
+        )
+        self._memory = memory or ChatHistoryMemory(
+            context_creator=self._context_creator,
+            window_size=None,
+            agent_id=self.agent_id,
+        )
+        self._memory.agent_id = self.agent_id
+        self.max_iteration = max_iteration
+        self.tool_execution_timeout = tool_execution_timeout
+        self.retry_attempts = max(1, retry_attempts)
+        self.retry_delay = max(0.0, retry_delay)
+        self.step_timeout = step_timeout
+        self.terminated = False
+        self.termination_reason = TerminationReason.NOT_TERMINATED
+        self.last_error: Optional[BaseException] = None
+        self.meta_info_record: Dict[str, Any] = {}
+        self.reset()
+
+    def step(self, *args: Any, **kwargs: Any) -> Any:
+        """Reject synchronous use; training rollouts must call ``astep``."""
+        raise NotImplementedError("BaseChatAgent is async-only; use astep()")
+
+    def reset(self) -> None:
+        """Clear the trajectory and reset all stateful model backends."""
+        self.memory.clear()
+        if self._original_system_message is not None:
+            self._write_openai_message(
+                self._original_system_message.to_openai_system_message()
+            )
+        self.terminated = False
+        self.termination_reason = TerminationReason.NOT_TERMINATED
+        self.last_error = None
+        self.meta_info_record = self._new_meta_info()
+        for backend in self.model_backend.models:
+            reset = getattr(backend, "reset", None)
+            if callable(reset):
+                reset()
+
+    @property
+    def memory(self) -> AgentMemory:
+        """Return the canonical append-only agent memory."""
+        return self._memory
+
+    @property
+    def message_list(self) -> List[OpenAIMessage]:
+        """Return the exact unprocessed messages currently stored in memory."""
+        messages, _ = self._context_creator.create_context(
+            self.memory.retrieve()
+        )
+        return messages
+
+    @property
+    def chat_history(self) -> List[OpenAIMessage]:
+        """Return a defensive view of the raw training trajectory."""
+        return self.message_list
+
+    def _write_openai_message(self, message: OpenAIMessage) -> None:
+        """Append one exact OpenAI message to ``AgentMemory``."""
+        raw_message = copy.deepcopy(dict(message))
+        role = str(raw_message.get("role", "assistant"))
+        backend_role = {
+            "system": OpenAIBackendRole.SYSTEM,
+            "developer": OpenAIBackendRole.DEVELOPER,
+            "user": OpenAIBackendRole.USER,
+            "assistant": OpenAIBackendRole.ASSISTANT,
+            "tool": OpenAIBackendRole.TOOL,
+        }.get(role, OpenAIBackendRole.ASSISTANT)
+        role_type = {
+            "system": RoleType.SYSTEM,
+            "developer": RoleType.SYSTEM,
+            "user": RoleType.USER,
+        }.get(role, RoleType.ASSISTANT)
+        content = raw_message.get("content")
+        stored_message = BaseMessage(
+            role_name=role,
+            role_type=role_type,
+            meta_dict={_RAW_OPENAI_MESSAGE_KEY: raw_message},
+            content=content if isinstance(content, str) else "",
+            reasoning_content=raw_message.get("reasoning_content"),
+        )
+        self.memory.write_record(
+            MemoryRecord(
+                message=stored_message,
+                role_at_backend=backend_role,
+                timestamp=time.time_ns() / 1_000_000_000,
+                agent_id=self.agent_id,
+            )
+        )
+
+    @property
+    def tool_dict(self) -> Dict[str, FunctionTool]:
+        """Return registered internal tools by function name."""
+        return self._internal_tools
+
+    @staticmethod
+    def _new_meta_info() -> Dict[str, Any]:
+        """Create zeroed usage, tool, termination, and error metadata."""
+        return {
+            "iteration_count": 0,
+            "termination_reason": TerminationReason.NOT_TERMINATED,
+            "max_tool_calls_per_turn": 0,
+            "total_tool_calls": 0,
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "total_tokens": 0,
+            "error_type": None,
+            "error_message": None,
+        }
+
+    def _get_full_tool_schemas(self) -> List[Dict[str, Any]]:
+        """Return OpenAI schemas for every registered internal or MCP tool."""
+        return [
+            tool.get_openai_tool_schema()
+            for tool in self._internal_tools.values()
+        ]
+
+    @staticmethod
+    def _create_token_usage_tracker() -> Dict[str, int]:
+        """Create counters accumulated across all model calls in one step."""
+        return {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+
+    @staticmethod
+    def _update_token_usage_tracker(
+        tracker: Dict[str, int], usage: Dict[str, Any]
+    ) -> None:
+        """Add one completion's reported token usage into step totals."""
+        for key in ("prompt_tokens", "completion_tokens", "total_tokens"):
+            tracker[key] += int(usage.get(key) or 0)
+
+    def _set_termination(
+        self,
+        reason: TerminationReason,
+        error: Optional[BaseException] = None,
+    ) -> None:
+        """Record the final reason and optional exception in training state."""
+        self.termination_reason = reason
+        self.meta_info_record["termination_reason"] = reason
+        self.last_error = error
+        if error is not None:
+            self.meta_info_record["error_type"] = type(error).__name__
+            self.meta_info_record["error_message"] = str(error)
+
+    async def astep(
+        self,
+        input_message: Union[BaseMessage, str],
+        response_format: Optional[Type[BaseModel]] = None,
+    ) -> ChatAgentResponse:
+        """Append one user turn and run model/tool turns to termination.
+
+        ``step_timeout`` wraps the complete operation, including model retries
+        and sequential tool calls.
+        """
+        set_current_agent_id(self.agent_id)
+        self.meta_info_record = self._new_meta_info()
+        self.termination_reason = TerminationReason.NOT_TERMINATED
+        self.last_error = None
+        self.terminated = False
+
+        if isinstance(input_message, str):
+            input_message = BaseMessage.make_user_message(
+                role_name="User", content=input_message
+            )
+        self._write_openai_message(input_message.to_openai_user_message())
+
+        task = self._run_loop(response_format)
+        try:
+            if self.step_timeout is None:
+                return await task
+            return await asyncio.wait_for(task, timeout=self.step_timeout)
+        except BaseException as error:
+            if self.termination_reason is TerminationReason.NOT_TERMINATED:
+                self._set_termination(
+                    TerminationReason.from_error(error), error
+                )
+            raise
+
+    async def _run_loop(
+        self, response_format: Optional[Type[BaseModel]]
+    ) -> ChatAgentResponse:
+        """Run model and sequential tool turns until the step terminates.
+
+        Each raw assistant response is stored before its requested tools run;
+        every tool result is then appended in request order before the next
+        model call.
+        """
+        tool_call_records: List[ToolCallingRecord] = []
+        usage = self._create_token_usage_tracker()
+        response: Optional[ModelResponse] = None
+        last_prompt_tokens = 0
+
+        while True:
+            response = await self._aget_model_response(
+                self.message_list,
+                response_format=response_format,
+                tool_schemas=self._get_full_tool_schemas(),
+            )
+            self.meta_info_record["iteration_count"] += 1
+
+            raw_assistant = response.response.choices[0].message.model_dump(
+                exclude_none=True
+            )
+            raw_assistant["role"] = "assistant"
+            self._write_openai_message(raw_assistant)
+            self._update_token_usage_tracker(usage, response.usage_dict)
+            for key in usage:
+                self.meta_info_record[key] = usage[key]
+            last_prompt_tokens = int(
+                response.usage_dict.get("prompt_tokens") or 0
+            )
+
+            if (
+                self._token_limit is not None
+                and last_prompt_tokens > self._token_limit
+            ):
+                self.terminated = True
+                self._set_termination(
+                    TerminationReason.CONTEXT_WINDOW_OVERFLOW
+                )
+                break
+
+            requests = list(response.tool_call_requests or [])
+            if not requests:
+                if "length" in response.finish_reasons:
+                    self.terminated = True
+                    self._set_termination(TerminationReason.MAX_TOKENS_REACHED)
+                else:
+                    self._set_termination(TerminationReason.TASK_COMPLETE)
+                break
+
+            self.meta_info_record["max_tool_calls_per_turn"] = max(
+                self.meta_info_record["max_tool_calls_per_turn"], len(requests)
+            )
+            records = await self._aexecute_tools(requests)
+            for record in records:
+                tool_call_records.append(record)
+                self._write_openai_message(
+                    {
+                        "role": "tool",
+                        "tool_call_id": record.tool_call_id,
+                        "content": self._tool_result_content(record.result),
+                    }
+                )
+            self.meta_info_record["total_tool_calls"] = len(tool_call_records)
+
+            if (
+                self.max_iteration is not None
+                and self.meta_info_record["iteration_count"]
+                >= self.max_iteration
+            ):
+                self.terminated = True
+                self._set_termination(
+                    TerminationReason.MAX_TOOL_ITERATIONS_REACHED
+                )
+                break
+
+        assert response is not None
+        info = get_info_dict(
+            response.response_id,
+            usage,
+            response.finish_reasons,
+            last_prompt_tokens,
+            tool_call_records,
+        )
+        info["training"] = copy.deepcopy(self.meta_info_record)
+        return ChatAgentResponse(
+            msgs=response.output_messages,
+            terminated=self.terminated,
+            info=info,
+        )
+
+    async def _aget_model_response(
+        self,
+        messages: List[OpenAIMessage],
+        response_format: Optional[Type[BaseModel]],
+        tool_schemas: List[Dict[str, Any]],
+    ) -> ModelResponse:
+        """Call the backend with rate-limit retries and parse one response."""
+        last_error: Optional[BaseException] = None
+        for attempt in range(self.retry_attempts):
+            try:
+                raw = await self.model_backend.arun(
+                    messages, response_format, tool_schemas or None
+                )
+                if raw is not None:
+                    break
+            except RateLimitError as error:
+                last_error = error
+                if attempt == self.retry_attempts - 1:
+                    continue
+                delay = random.uniform(
+                    0, min(self.retry_delay * (2**attempt), 60.0)
+                )
+                await asyncio.sleep(delay)
+        else:
+            raise ModelProcessingError(
+                "Unable to process messages: "
+                f"{last_error or 'empty model response'}"
+            )
+
+        if not isinstance(raw, ChatCompletion):
+            raise TypeError(
+                f"Expected ChatCompletion, got {type(raw).__name__}"
+            )
+        return self._parse_model_response(raw)
+
+    def _parse_model_response(self, response: ChatCompletion) -> ModelResponse:
+        """Convert a completion into messages and ordered tool calls."""
+        output_messages: List[BaseMessage] = []
+        for choice in response.choices:
+            message = choice.message
+            if not (message.content or message.tool_calls):
+                continue
+            meta: Dict[str, Any] = {}
+            if logprobs := handle_logprobs(choice):
+                meta["logprobs_info"] = logprobs
+            output_messages.append(
+                BaseMessage(
+                    role_name=self.role_name,
+                    role_type=self.role_type,
+                    meta_dict=meta,
+                    content=message.content or "",
+                    parsed=getattr(message, "parsed", None),
+                    reasoning_content=getattr(
+                        message, "reasoning_content", None
+                    ),
+                )
+            )
+
+        requests: List[ToolCallRequest] = []
+        for tool_call in response.choices[0].message.tool_calls or []:
+            requests.append(
+                ToolCallRequest(
+                    tool_name=tool_call.function.name,
+                    args=json.loads(tool_call.function.arguments),
+                    tool_call_id=tool_call.id,
+                    extra_content=getattr(tool_call, "extra_content", None),
+                )
+            )
+        usage = safe_model_dump(response.usage) if response.usage else {}
+        return ModelResponse(
+            response=response,
+            tool_call_requests=requests or None,
+            output_messages=output_messages,
+            finish_reasons=[
+                str(choice.finish_reason) for choice in response.choices
+            ],
+            usage_dict=usage,
+            response_id=response.id or "",
+        )
+
+    async def _aexecute_tools(
+        self, requests: List[ToolCallRequest]
+    ) -> List[ToolCallingRecord]:
+        """Await each tool call in model-request order."""
+        return [await self._aexecute_tool(request) for request in requests]
+
+    async def _aexecute_tool(
+        self, request: ToolCallRequest
+    ) -> ToolCallingRecord:
+        """Execute CAMEL functions and MCP tools without memory writes."""
+        tool = self._internal_tools.get(request.tool_name)
+        if tool is None:
+            result: Any = (
+                "Tool execution failed: Tool "
+                f"'{request.tool_name}' not found in registered tools"
+            )
+        else:
+            try:
+                call = self._invoke_tool(tool, request.args)
+                result = (
+                    await asyncio.wait_for(
+                        call, timeout=self.tool_execution_timeout
+                    )
+                    if self.tool_execution_timeout is not None
+                    else await call
+                )
+            except Exception as error:
+                result = (
+                    f"Tool execution failed: Error executing async tool "
+                    f"'{request.tool_name}': {error}"
+                )
+                logger.warning(result)
+
+        images = result.images if isinstance(result, ToolResult) else None
+        return ToolCallingRecord(
+            tool_name=request.tool_name,
+            args=request.args,
+            result=result,
+            tool_call_id=request.tool_call_id,
+            images=images,
+        )
+
+    @staticmethod
+    async def _invoke_tool(tool: FunctionTool, args: Dict[str, Any]) -> Any:
+        """Invoke a tool without blocking the agent event loop.
+
+        MCP ``async_call`` is preferred, followed by coroutine functions;
+        ordinary synchronous tools run in the loop's executor.
+        """
+        if hasattr(tool, "func") and hasattr(tool.func, "async_call"):
+            return await tool.func.async_call(**args)
+        if hasattr(tool, "async_call") and callable(tool.async_call):
+            return await tool.async_call(**args)
+        if hasattr(tool, "func") and asyncio.iscoroutinefunction(tool.func):
+            return await tool.func(**args)
+        if asyncio.iscoroutinefunction(tool):
+            return await tool(**args)
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None, functools.partial(tool, **args)
+        )
+
+    @staticmethod
+    def _tool_result_content(result: Any) -> str:
+        """Serialize a tool result for the OpenAI ``tool`` memory message."""
+        return result.text if isinstance(result, ToolResult) else str(result)
+
+
+__all__ = ["BaseChatAgent", "TerminationReason"]

--- a/camel/agents/base_chat_agent.py
+++ b/camel/agents/base_chat_agent.py
@@ -135,6 +135,90 @@ class TerminationReason(StrEnum):
             yield current
             current = current.__cause__ or current.__context__
 
+    @staticmethod
+    def _error_payloads(error: BaseException) -> List[Dict[str, Any]]:
+        """Return OpenAI-style error payloads attached to an exception."""
+        payloads: List[Dict[str, Any]] = []
+        body = getattr(error, "body", None)
+        if isinstance(body, dict):
+            payloads.append(body)
+
+        response = getattr(error, "response", None)
+        json_fn = getattr(response, "json", None)
+        if callable(json_fn):
+            try:
+                body = json_fn()
+            except Exception:
+                body = None
+            if isinstance(body, dict):
+                payload = body.get("error", body)
+                if isinstance(payload, dict):
+                    payloads.append(payload)
+
+        return payloads
+
+    @staticmethod
+    def _error_status_code(error: BaseException) -> Optional[int]:
+        """Return an HTTP status code from SDK or raw HTTP exceptions."""
+        status_code = getattr(error, "status_code", None)
+        if status_code is None:
+            response = getattr(error, "response", None)
+            status_code = getattr(response, "status_code", None)
+        return int(status_code) if isinstance(status_code, int) else None
+
+    @classmethod
+    def _is_bad_request_error(
+        cls, error: BaseException, payloads: List[Dict[str, Any]]
+    ) -> bool:
+        """Return whether the exception represents a client request error."""
+        if cls._error_status_code(error) == 400:
+            return True
+        error_type = type(error).__name__.lower()
+        if error_type == "badrequesterror":
+            return True
+        return any(
+            str(payload.get("type", "")).lower()
+            in {"badrequesterror", "invalid_request_error"}
+            for payload in payloads
+        )
+
+    @staticmethod
+    def _error_message(
+        error: BaseException, payloads: List[Dict[str, Any]]
+    ) -> str:
+        """Return provider message text from structured fields."""
+        fragments = [str(error), str(getattr(error, "message", ""))]
+        fragments.extend(
+            str(payload.get("message", "")) for payload in payloads
+        )
+
+        response = getattr(error, "response", None)
+        text = getattr(response, "text", None)
+        if text is not None:
+            fragments.append(str(text))
+
+        return " ".join(fragment for fragment in fragments if fragment).lower()
+
+    @classmethod
+    def _is_context_overflow_error(cls, error: BaseException) -> bool:
+        """Detect prompt/context overflow from OpenAI-compatible errors.
+
+        OpenAI exposes a semantic ``context_length_exceeded`` code. vLLM and
+        SGLang expose HTTP 400/BadRequest errors whose message names the
+        model context length.
+        """
+        payloads = cls._error_payloads(error)
+        if any(
+            payload.get("code") == "context_length_exceeded"
+            for payload in payloads
+        ):
+            return True
+
+        message = cls._error_message(error, payloads)
+        return cls._is_bad_request_error(error, payloads) and (
+            "context length" in message or "context window" in message
+        )
+
     @classmethod
     def from_error(cls, error: Optional[BaseException]) -> "TerminationReason":
         """Classify an exception and its causes into a training termination."""
@@ -142,23 +226,32 @@ class TerminationReason(StrEnum):
             return cls.TASK_COMPLETE
 
         chain = list(cls._cause_chain(error))
-        names = " ".join(type(exc).__name__.lower() for exc in chain)
-        if "contextwindow" in names or "contextlength" in names:
+        if any(cls._is_context_overflow_error(exc) for exc in chain):
             return cls.CONTEXT_WINDOW_OVERFLOW
-        if "maxtoken" in names:
+        error_text = " ".join(
+            " ".join(
+                [
+                    type(exc).__name__.lower(),
+                    str(exc).lower(),
+                    str(getattr(exc, "message", "")).lower(),
+                ]
+            )
+            for exc in chain
+        )
+        if "maxtoken" in error_text or "max token" in error_text:
             return cls.MAX_TOKENS_REACHED
-        if "maxtooliteration" in names:
+        if "maxtooliteration" in error_text:
             return cls.MAX_TOOL_ITERATIONS_REACHED
-        if "maxtoolcall" in names:
+        if "maxtoolcall" in error_text:
             return cls.MAX_TOOL_CALLS_REACHED
-        if "maxmessage" in names:
+        if "maxmessage" in error_text:
             return cls.MAX_MESSAGES_REACHED
         if any(isinstance(exc, RecursionError) for exc in chain):
             return cls.RECURSION_DEPTH_EXCEEDED
-        if "timeout" in names:
+        if "timeout" in error_text:
             return cls.TIMEOUT
         if any(
-            marker in names
+            marker in error_text
             for marker in ("connection", "disconnected", "connecterror")
         ):
             return cls.CONNECTION_ERROR

--- a/camel/agents/base_chat_agent.py
+++ b/camel/agents/base_chat_agent.py
@@ -22,7 +22,7 @@ import json
 import random
 import time
 import uuid
-from enum import StrEnum
+from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
 from openai import RateLimitError
@@ -105,7 +105,7 @@ class _AppendOnlyContextCreator(BaseContextCreator):
         return messages, num_tokens
 
 
-class TerminationReason(StrEnum):
+class TerminationReason(str, Enum):
     """Why a training step ended.
 
     Values and cause-chain behaviour mirror

--- a/camel/agents/base_chat_agent.py
+++ b/camel/agents/base_chat_agent.py
@@ -23,7 +23,17 @@ import random
 import time
 import uuid
 from enum import Enum
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+    cast,
+)
 
 from openai import RateLimitError
 from pydantic import BaseModel
@@ -48,7 +58,12 @@ from camel.messages import BaseMessage, OpenAIMessage
 from camel.models import BaseModelBackend, ModelManager, ModelProcessingError
 from camel.responses import ChatAgentResponse
 from camel.toolkits import FunctionTool, RegisteredAgentToolkit
-from camel.types import ChatCompletion, OpenAIBackendRole, RoleType
+from camel.types import (
+    ChatCompletion,
+    ChatCompletionMessageFunctionToolCall,
+    OpenAIBackendRole,
+    RoleType,
+)
 from camel.types.agents import ToolCallingRecord
 from camel.utils import BaseTokenCounter
 from camel.utils.agent_context import set_current_agent_id
@@ -93,7 +108,9 @@ class _AppendOnlyContextCreator(BaseContextCreator):
             meta = memory_record.message.meta_dict or {}
             raw_message = meta.get(_RAW_OPENAI_MESSAGE_KEY)
             if isinstance(raw_message, dict):
-                messages.append(copy.deepcopy(raw_message))
+                messages.append(
+                    cast(OpenAIMessage, copy.deepcopy(raw_message))
+                )
             else:
                 messages.append(memory_record.to_openai_message())
 
@@ -324,7 +341,7 @@ class BaseChatAgent(BaseAgent):
             ]
         }
         for toolkit in toolkits_to_register_agent or []:
-            toolkit.register_agent(self)
+            toolkit.register_agent(cast(Any, self))
 
         self._token_limit = (
             token_limit
@@ -411,12 +428,17 @@ class BaseChatAgent(BaseAgent):
             "user": RoleType.USER,
         }.get(role, RoleType.ASSISTANT)
         content = raw_message.get("content")
+        reasoning_content = raw_message.get("reasoning_content")
         stored_message = BaseMessage(
             role_name=role,
             role_type=role_type,
             meta_dict={_RAW_OPENAI_MESSAGE_KEY: raw_message},
             content=content if isinstance(content, str) else "",
-            reasoning_content=raw_message.get("reasoning_content"),
+            reasoning_content=(
+                reasoning_content
+                if isinstance(reasoning_content, str)
+                else None
+            ),
         )
         self.memory.write_record(
             MemoryRecord(
@@ -536,11 +558,12 @@ class BaseChatAgent(BaseAgent):
             )
             self.meta_info_record["iteration_count"] += 1
 
-            raw_assistant = response.response.choices[0].message.model_dump(
+            completion = cast(ChatCompletion, response.response)
+            raw_assistant = completion.choices[0].message.model_dump(
                 exclude_none=True
             )
             raw_assistant["role"] = "assistant"
-            self._write_openai_message(raw_assistant)
+            self._write_openai_message(cast(OpenAIMessage, raw_assistant))
             self._update_token_usage_tracker(usage, response.usage_dict)
             for key in usage:
                 self.meta_info_record[key] = usage[key]
@@ -668,12 +691,17 @@ class BaseChatAgent(BaseAgent):
 
         requests: List[ToolCallRequest] = []
         for tool_call in response.choices[0].message.tool_calls or []:
+            function_tool_call = cast(
+                ChatCompletionMessageFunctionToolCall, tool_call
+            )
             requests.append(
                 ToolCallRequest(
-                    tool_name=tool_call.function.name,
-                    args=json.loads(tool_call.function.arguments),
-                    tool_call_id=tool_call.id,
-                    extra_content=getattr(tool_call, "extra_content", None),
+                    tool_name=function_tool_call.function.name,
+                    args=json.loads(function_tool_call.function.arguments),
+                    tool_call_id=function_tool_call.id,
+                    extra_content=getattr(
+                        function_tool_call, "extra_content", None
+                    ),
                 )
             )
         usage = safe_model_dump(response.usage) if response.usage else {}

--- a/camel/models/__init__.py
+++ b/camel/models/__init__.py
@@ -21,6 +21,7 @@ from .aws_bedrock_converse_model import AWSBedrockConverseModel
 from .aws_bedrock_model import AWSBedrockModel
 from .azure_openai_model import AzureOpenAIModel
 from .base_audio_model import BaseAudioModel
+from .base_chat_model import BaseChatModel
 from .base_model import BaseModelBackend
 from .cerebras_model import CerebrasModel
 from .cohere_model import CohereModel
@@ -78,6 +79,7 @@ __all__ = [
     'AvianModel',
     'AzureOpenAIModel',
     'BaseAudioModel',
+    'BaseChatModel',
     'BaseModelBackend',
     'CerebrasModel',
     'CohereModel',

--- a/camel/models/base_chat_model.py
+++ b/camel/models/base_chat_model.py
@@ -1,0 +1,393 @@
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+"""Faithful asynchronous OpenAI-compatible backend for TITO rollouts."""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, ClassVar, Dict, List, Mapping, Optional, Type, Union
+
+from openai import AsyncOpenAI, AsyncStream, Stream
+from openai.lib.streaming.chat import (
+    AsyncChatCompletionStreamManager,
+    ChatCompletionStreamManager,
+)
+from pydantic import BaseModel
+
+from camel.messages import OpenAIMessage
+from camel.models.base_model import BaseModelBackend
+from camel.types import ChatCompletion, ChatCompletionChunk, ModelType
+from camel.utils import BaseTokenCounter
+
+
+class BaseChatModel(BaseModelBackend):
+    """Call an OpenAI-compatible training endpoint without rewriting data.
+
+    Both injected clients and URL-created ``AsyncOpenAI`` clients use
+    ``client.chat.completions.create(...)``. The backend is async-only,
+    non-streaming, and leaves message history and response content unchanged.
+
+    Examples:
+        ``BaseChatModel(url="http://trainer:8000")`` creates ``AsyncOpenAI``;
+        ``BaseChatModel(client=test_client)`` injects a compatible client.
+    """
+
+    _OPENAI_CREATE_PARAMS: ClassVar[frozenset[str]] = frozenset(
+        {
+            "audio",
+            "frequency_penalty",
+            "function_call",
+            "functions",
+            "logit_bias",
+            "logprobs",
+            "max_completion_tokens",
+            "max_tokens",
+            "metadata",
+            "modalities",
+            "n",
+            "parallel_tool_calls",
+            "prediction",
+            "presence_penalty",
+            "prompt_cache_key",
+            "reasoning_effort",
+            "response_format",
+            "safety_identifier",
+            "seed",
+            "service_tier",
+            "stop",
+            "store",
+            "stream_options",
+            "temperature",
+            "tool_choice",
+            "top_logprobs",
+            "top_p",
+            "user",
+            "verbosity",
+            "web_search_options",
+            "extra_headers",
+            "extra_query",
+            "timeout",
+        }
+    )
+
+    def __init__(
+        self,
+        model_type: Union[ModelType, str] = "Qwen/Qwen3-0.6B",
+        model_config_dict: Optional[Dict[str, Any]] = None,
+        api_key: Optional[str] = None,
+        url: Optional[str] = None,
+        token_counter: Optional[BaseTokenCounter] = None,
+        timeout: Optional[float] = None,
+        max_retries: int = 3,
+        client: Optional[Any] = None,
+        async_client: Optional[Any] = None,
+        http_client: Optional[Any] = None,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize an injected or URL-backed async model client.
+
+        ``client``/``async_client`` must expose ``chat.completions.create``.
+        Otherwise ``url`` creates an owned ``AsyncOpenAI`` client. Client and
+        URL inputs are mutually exclusive.
+        """
+        super().__init__(
+            model_type=model_type,
+            model_config_dict=model_config_dict or {},
+            api_key=api_key,
+            url=url,
+            token_counter=token_counter,
+            timeout=timeout,
+            max_retries=max_retries,
+            # Preserve raw assistant text and response extensions for training.
+            extract_thinking_from_response=False,
+        )
+        if client is not None and async_client is not None:
+            raise ValueError("Pass only one of client or async_client")
+        if url is not None and (
+            client is not None or async_client is not None
+        ):
+            raise ValueError("Pass either a client or url, not both")
+        injected_client = async_client or client
+        if injected_client is not None and http_client is not None:
+            raise ValueError(
+                "http_client cannot be combined with an injected client"
+            )
+
+        self._owns_async_client = injected_client is None
+        if injected_client is not None:
+            self._async_client = injected_client
+        else:
+            if not url:
+                raise ValueError(
+                    "url is required when an AsyncOpenAI client is not "
+                    "provided"
+                )
+            client_kwargs = dict(kwargs)
+            if http_client is not None:
+                client_kwargs["http_client"] = http_client
+            self._async_client = AsyncOpenAI(
+                api_key=api_key or "Set-but-ignored",
+                base_url=self._openai_base_url(url),
+                timeout=float(timeout or 180),
+                max_retries=max_retries,
+                **client_kwargs,
+            )
+
+        self._last_prompt_token_ids: List[int] = []
+        self._last_output_token_ids: List[int] = []
+
+    @staticmethod
+    def _openai_base_url(url: str) -> str:
+        """Normalize a URL for use as an ``AsyncOpenAI`` base URL.
+
+        For example, ``http://host:8000`` becomes ``http://host:8000/v1``;
+        existing ``/v1`` bases are preserved.
+        """
+        url = url.rstrip("/")
+        if url.endswith("/v1/chat/completions"):
+            return url[: -len("/chat/completions")]
+        if url.endswith("/v1"):
+            return url
+        return f"{url}/v1"
+
+    @property
+    def token_counter(self) -> BaseTokenCounter:
+        """Return a local token counter when one is available.
+
+        The configured counter takes precedence over a client-provided one.
+        """
+        counter = self._token_counter
+        if counter is None:
+            counter = getattr(self._async_client, "token_counter", None)
+        if counter is None:
+            raise RuntimeError(
+                "BaseChatModel requires an explicit token_counter when local "
+                "token counting is needed"
+            )
+        return counter
+
+    @property
+    def token_limit(self) -> int:
+        """Return the context limit used by the append-only agent.
+
+        Resolution order is configured ``context_length``, client tokenizer
+        limit, then ``32768``.
+        """
+        configured = self.model_config_dict.get("context_length")
+        if configured is not None:
+            return int(configured)
+        tokenizer = getattr(self._async_client, "tokenizer", None)
+        value = int(getattr(tokenizer, "model_max_length", 32768))
+        return value if value < 10**9 else 32768
+
+    def preprocess_messages(
+        self, messages: List[OpenAIMessage]
+    ) -> List[OpenAIMessage]:
+        """Return messages unchanged, without rendering or role conversion."""
+        return messages
+
+    def postprocess_response(self, response: Any) -> Any:
+        """Preserve assistant content, tool calls, and response metadata."""
+        return response
+
+    def _request_config(
+        self,
+        tools: Optional[List[Dict[str, Any]]],
+        response_format: Optional[Type[BaseModel]],
+    ) -> Dict[str, Any]:
+        """Build one non-streaming OpenAI chat-completion configuration.
+
+        Standard parameters stay as client arguments; framework-specific ones
+        move to ``extra_body``. Training aliases are normalized and streaming
+        is rejected because the agent requires complete responses.
+        """
+        config = copy.deepcopy(self.model_config_dict)
+        config.pop("context_length", None)
+        config.pop("model", None)
+        config.pop("messages", None)
+        config.pop("tools", None)
+        if config.pop("stream", False):
+            raise NotImplementedError(
+                "BaseChatModel only supports non-streaming rollouts"
+            )
+
+        aliases = {
+            "max_new_tokens": "max_tokens",
+            "min_new_tokens": "min_tokens",
+            "sampling_seed": "seed",
+        }
+        for source, target in aliases.items():
+            if source in config:
+                config.setdefault(target, config.pop(source))
+
+        extra_body = dict(config.pop("extra_body", None) or {})
+        for key in list(config):
+            if key not in self._OPENAI_CREATE_PARAMS:
+                extra_body[key] = config.pop(key)
+        if extra_body:
+            config["extra_body"] = extra_body
+        config["stream"] = False
+        if tools is not None:
+            config["tools"] = tools
+        if response_format is not None:
+            config["response_format"] = {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": response_format.__name__,
+                    "schema": response_format.model_json_schema(),
+                    "strict": True,
+                },
+            }
+        return config
+
+    async def _arun(
+        self,
+        messages: List[OpenAIMessage],
+        response_format: Optional[Type[BaseModel]] = None,
+        tools: Optional[List[Dict[str, Any]]] = None,
+    ) -> Union[
+        ChatCompletion,
+        AsyncStream[ChatCompletionChunk],
+        AsyncChatCompletionStreamManager[BaseModel],
+    ]:
+        """Run one asynchronous call through the shared client interface.
+
+        The same path serves injected and URL-created clients; optional token
+        IDs are recorded without changing the returned completion.
+        """
+        response = await self._async_client.chat.completions.create(
+            messages=messages,
+            model=str(self.model_type),
+            **self._request_config(tools, response_format),
+        )
+        if not isinstance(response, ChatCompletion):
+            raise TypeError(
+                "BaseChatModel expected a non-streaming ChatCompletion"
+            )
+        self._record_token_ids(response)
+        return response
+
+    def _run(
+        self,
+        messages: List[OpenAIMessage],
+        response_format: Optional[Type[BaseModel]] = None,
+        tools: Optional[List[Dict[str, Any]]] = None,
+    ) -> Union[
+        ChatCompletion,
+        Stream[ChatCompletionChunk],
+        ChatCompletionStreamManager[BaseModel],
+    ]:
+        """Reject synchronous inference; callers must use :meth:`arun`."""
+        raise NotImplementedError("BaseChatModel is asynchronous; use arun()")
+
+    @staticmethod
+    def _first_choice(raw: Mapping[str, Any]) -> Mapping[str, Any]:
+        """Return the first mapping-shaped choice, or an empty mapping."""
+        choices = raw.get("choices")
+        if not isinstance(choices, list) or not choices:
+            return {}
+        choice = choices[0]
+        return choice if isinstance(choice, Mapping) else {}
+
+    def _record_token_ids(self, response: ChatCompletion) -> None:
+        """Retain optional token-ID extensions from a completion.
+
+        IDs may be top-level, choice-level, or contained in SGLang-compatible
+        ``meta_info.output_token_logprobs`` entries.
+        """
+        raw = response.model_dump()
+        choice = self._first_choice(raw)
+        prompt_ids = raw.get("prompt_token_ids")
+        if prompt_ids is None:
+            prompt_ids = choice.get("prompt_token_ids")
+        self._last_prompt_token_ids = (
+            [int(token_id) for token_id in prompt_ids]
+            if isinstance(prompt_ids, list)
+            else []
+        )
+
+        output_ids = raw.get("output_token_ids")
+        if output_ids is None:
+            output_ids = choice.get("output_token_ids")
+        self._last_output_token_ids = (
+            [int(token_id) for token_id in output_ids]
+            if isinstance(output_ids, list)
+            else []
+        )
+        if self._last_output_token_ids:
+            return
+
+        meta_info = choice.get("meta_info")
+        logprobs = (
+            meta_info.get("output_token_logprobs")
+            if isinstance(meta_info, Mapping)
+            else None
+        )
+        if isinstance(logprobs, list):
+            for item in logprobs:
+                if isinstance(item, (list, tuple)) and len(item) > 1:
+                    self._last_output_token_ids.append(int(item[1]))
+                elif isinstance(item, Mapping) and "token_id" in item:
+                    self._last_output_token_ids.append(int(item["token_id"]))
+
+    @property
+    def last_prompt_tokens(self) -> Optional[int]:
+        """Return the last exact prompt length, if the client exposed IDs.
+
+        Prefer the in-house client's trajectory, then cached response fields.
+        """
+        generation = getattr(self._async_client, "last_generation", None)
+        if generation is not None:
+            return len(generation.prompt_token_ids)
+        return (
+            len(self._last_prompt_token_ids)
+            if self._last_prompt_token_ids
+            else None
+        )
+
+    @property
+    def last_context_tokens(self) -> Optional[int]:
+        """Return exact prompt plus output length when token IDs are known."""
+        generation = getattr(self._async_client, "last_generation", None)
+        if generation is not None:
+            return len(generation.prompt_token_ids) + len(
+                generation.output_token_ids
+            )
+        if not self._last_prompt_token_ids:
+            return None
+        return len(self._last_prompt_token_ids) + len(
+            self._last_output_token_ids
+        )
+
+    @property
+    def last_output_token_ids(self) -> Optional[List[int]]:
+        """Return a defensive copy of the last output token IDs, if known."""
+        generation = getattr(self._async_client, "last_generation", None)
+        if generation is not None:
+            return list(generation.output_token_ids)
+        return (
+            list(self._last_output_token_ids)
+            if self._last_output_token_ids
+            else None
+        )
+
+    async def aclose(self) -> None:
+        """Close a URL-created client; injected clients remain caller-owned."""
+        if self._owns_async_client:
+            async_client = self._async_client
+            if async_client is not None:
+                await async_client.close()
+
+
+__all__ = ["BaseChatModel"]

--- a/camel/models/client/__init__.py
+++ b/camel/models/client/__init__.py
@@ -1,0 +1,31 @@
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+"""Native inference clients used by CAMEL model backends."""
+
+from .sglang_client import SGLangClient, SGLangGeneration
+
+__all__ = ["SGLangClient", "SGLangGeneration"]
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========

--- a/camel/models/client/sglang_client.py
+++ b/camel/models/client/sglang_client.py
@@ -1,0 +1,558 @@
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+"""SGLang client for native and OpenAI-compatible training rollouts."""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Literal, Mapping, Optional, Union
+
+import httpx
+
+from camel.messages import OpenAIMessage
+from camel.types import ChatCompletion
+from camel.utils import BaseTokenCounter
+
+_TOOL_CALL_RE = re.compile(
+    r"<tool_call>\s*(\{.*?\})\s*</tool_call>", re.DOTALL
+)
+
+
+@dataclass(frozen=True)
+class SGLangGeneration:
+    """The OpenAI-compatible response and exact token trajectory."""
+
+    completion: ChatCompletion
+    prompt_token_ids: List[int]
+    output_token_ids: List[int]
+    raw_response: Dict[str, Any]
+
+
+class HuggingFaceTokenCounter(BaseTokenCounter):
+    """CAMEL token counter backed by the client's Hugging Face tokenizer."""
+
+    def __init__(self, tokenizer: Any, chat_template: Optional[str] = None):
+        self.tokenizer = tokenizer
+        self.chat_template = chat_template
+
+    def count_tokens_from_messages(self, messages: List[OpenAIMessage]) -> int:
+        encoded = self.tokenizer.apply_chat_template(
+            messages,
+            tokenize=True,
+            add_generation_prompt=True,
+            chat_template=self.chat_template,
+        )
+        if isinstance(encoded, Mapping):
+            encoded = encoded["input_ids"]
+        if hasattr(encoded, "tolist"):
+            encoded = encoded.tolist()
+        if encoded and isinstance(encoded[0], list):
+            encoded = encoded[0]
+        return len(encoded)
+
+    def encode(self, text: str) -> List[int]:
+        return list(self.tokenizer.encode(text, add_special_tokens=False))
+
+    def decode(self, token_ids: List[int]) -> str:
+        return self.tokenizer.decode(token_ids)
+
+
+class _SGLangChatCompletions:
+    """OpenAI-compatible ``client.chat.completions`` namespace."""
+
+    def __init__(self, client: "SGLangClient") -> None:
+        self._client = client
+
+    async def create(
+        self,
+        *,
+        messages: List[OpenAIMessage],
+        model: str,
+        tools: Optional[List[Dict[str, Any]]] = None,
+        response_format: Any = None,
+        stream: bool = False,
+        extra_body: Optional[Mapping[str, Any]] = None,
+        **kwargs: Any,
+    ) -> ChatCompletion:
+        """Match the non-streaming ``AsyncOpenAI`` creation interface."""
+        model_config = dict(extra_body or {})
+        for transport_key in ("extra_headers", "extra_query", "timeout"):
+            kwargs.pop(transport_key, None)
+        model_config.update(kwargs)
+        model_config["stream"] = stream
+        return await self._client.create_chat_completion(
+            messages,
+            model=model,
+            tools=tools,
+            model_config=model_config,
+            response_format=response_format,
+        )
+
+
+class _SGLangChat:
+    """OpenAI-compatible ``client.chat`` namespace."""
+
+    def __init__(self, client: "SGLangClient") -> None:
+        self.completions = _SGLangChatCompletions(client)
+
+
+class SGLangClient:
+    """Send chat messages to native or OpenAI-compatible SGLang endpoints.
+
+    Args:
+        base_url: SGLang or OpenAI-compatible server base URL.
+        model: Model name recorded in the returned ChatCompletion.
+        tokenizer: Hugging Face tokenizer instance or repository/path. If it
+            is omitted, ``model`` is loaded with ``AutoTokenizer``.
+        chat_template: A Jinja template string or a path to one. If omitted,
+            the tokenizer's model-specific template is used.
+        chat_template_kwargs: Extra model-specific template options such as
+            ``enable_thinking=False``.
+        http_client: Injectable ``httpx.AsyncClient`` for tests/custom HTTP.
+        api_key: Optional bearer token for authenticated OpenAI-compatible
+            endpoints.
+        api_mode: ``native`` uses ``/generate`` and local tokenization;
+            ``openai`` uses the standard ``/v1/chat/completions`` interface.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        model: str,
+        tokenizer: Optional[Union[str, Any]] = None,
+        chat_template: Optional[str] = None,
+        chat_template_kwargs: Optional[Mapping[str, Any]] = None,
+        timeout: float = 180.0,
+        http_client: Optional[httpx.AsyncClient] = None,
+        tokenizer_kwargs: Optional[Mapping[str, Any]] = None,
+        api_mode: Literal["native", "openai"] = "native",
+        api_key: Optional[str] = None,
+    ) -> None:
+        self.api_mode = self._validate_api_mode(api_mode)
+        self.base_url = self._normalise_base_url(base_url, self.api_mode)
+        self.model = model
+        self.api_key = api_key
+        tokenizer_source = tokenizer
+        if tokenizer_source is None and self.api_mode == "native":
+            tokenizer_source = model
+        self.tokenizer = (
+            self._load_tokenizer(
+                tokenizer_source, dict(tokenizer_kwargs or {})
+            )
+            if tokenizer_source is not None
+            else None
+        )
+        self.chat_template = self._load_chat_template(chat_template)
+        self.chat_template_kwargs = dict(chat_template_kwargs or {})
+        self._owns_http_client = http_client is None
+        self.http_client = http_client or httpx.AsyncClient(timeout=timeout)
+        self.token_counter = (
+            HuggingFaceTokenCounter(self.tokenizer, self.chat_template)
+            if self.tokenizer is not None
+            else None
+        )
+        self.last_generation: Optional[SGLangGeneration] = None
+        self.chat = _SGLangChat(self)
+
+    @staticmethod
+    def _validate_api_mode(
+        api_mode: Literal["native", "openai"],
+    ) -> Literal["native", "openai"]:
+        if api_mode not in {"native", "openai"}:
+            raise ValueError("api_mode must be one of 'native' or 'openai'")
+        return api_mode
+
+    @staticmethod
+    def _normalise_base_url(
+        url: str, api_mode: Literal["native", "openai"]
+    ) -> str:
+        url = url.rstrip("/")
+        if api_mode == "native" and url.endswith("/v1"):
+            return url[:-3]
+        return url
+
+    @staticmethod
+    def _load_tokenizer(tokenizer: Union[str, Any], kwargs: Dict[str, Any]):
+        if not isinstance(tokenizer, str):
+            return tokenizer
+        from transformers import AutoTokenizer
+
+        return AutoTokenizer.from_pretrained(tokenizer, **kwargs)
+
+    @staticmethod
+    def _load_chat_template(chat_template: Optional[str]) -> Optional[str]:
+        if chat_template is None:
+            return None
+        candidate = Path(chat_template).expanduser()
+        if candidate.is_file():
+            return candidate.read_text(encoding="utf-8")
+        return chat_template
+
+    def render_messages(
+        self,
+        messages: List[OpenAIMessage],
+        tools: Optional[List[Dict[str, Any]]] = None,
+    ) -> List[int]:
+        """Apply the configured model template and return exact prompt IDs."""
+        if self.tokenizer is None:
+            raise RuntimeError(
+                "A tokenizer is required to render messages in native mode"
+            )
+        kwargs = dict(self.chat_template_kwargs)
+        if tools:
+            kwargs["tools"] = tools
+        token_ids = self.tokenizer.apply_chat_template(
+            messages,
+            tokenize=True,
+            add_generation_prompt=True,
+            chat_template=self.chat_template,
+            **kwargs,
+        )
+        if isinstance(token_ids, Mapping):
+            token_ids = token_ids["input_ids"]
+        if hasattr(token_ids, "tolist"):
+            token_ids = token_ids.tolist()
+        if token_ids and isinstance(token_ids[0], list):
+            token_ids = token_ids[0]
+        return [int(token_id) for token_id in token_ids]
+
+    async def create_chat_completion(
+        self,
+        messages: List[OpenAIMessage],
+        *,
+        model: Optional[str] = None,
+        tools: Optional[List[Dict[str, Any]]] = None,
+        model_config: Optional[Mapping[str, Any]] = None,
+        response_format: Any = None,
+    ) -> ChatCompletion:
+        """Generate and return a CAMEL/OpenAI ``ChatCompletion``."""
+        request_model = model or self.model
+        if self.api_mode == "openai":
+            return await self._create_openai_chat_completion(
+                messages,
+                model=request_model,
+                tools=tools,
+                model_config=model_config,
+                response_format=response_format,
+            )
+
+        if response_format is not None:
+            raise NotImplementedError(
+                "Native SGLang client does not support response_format"
+            )
+
+        prompt_token_ids = self.render_messages(messages, tools)
+        sampling_params = self._sampling_params(model_config or {})
+        payload = {
+            "input_ids": prompt_token_ids,
+            "sampling_params": sampling_params,
+            "return_prompt_token_ids": True,
+        }
+        response = await self.http_client.post(
+            f"{self.base_url}/generate",
+            json=payload,
+            headers=self._request_headers(),
+        )
+        response.raise_for_status()
+        raw = response.json()
+        if isinstance(raw, list):
+            if len(raw) != 1:
+                raise ValueError("Only one SGLang generation is supported")
+            raw = raw[0]
+        if not isinstance(raw, dict):
+            raise TypeError("SGLang /generate returned a non-object response")
+
+        completion = self._parse_response(
+            raw, prompt_token_ids, model=request_model
+        )
+        generation = SGLangGeneration(
+            completion=completion,
+            prompt_token_ids=prompt_token_ids,
+            output_token_ids=[int(x) for x in raw.get("output_ids", [])],
+            raw_response=raw,
+        )
+        self.last_generation = generation
+        return completion
+
+    async def _create_openai_chat_completion(
+        self,
+        messages: List[OpenAIMessage],
+        *,
+        model: str,
+        tools: Optional[List[Dict[str, Any]]],
+        model_config: Optional[Mapping[str, Any]],
+        response_format: Any,
+    ) -> ChatCompletion:
+        config = dict(model_config or {})
+        if config.get("stream"):
+            raise NotImplementedError(
+                "Streaming is not supported by the rollout client"
+            )
+
+        payload = self._openai_payload(
+            messages, model, tools, config, response_format
+        )
+        response = await self.http_client.post(
+            self._chat_completions_url(),
+            json=payload,
+            headers=self._request_headers(),
+        )
+        response.raise_for_status()
+        raw = response.json()
+        if not isinstance(raw, dict):
+            raise TypeError(
+                "SGLang /v1/chat/completions returned a non-object response"
+            )
+
+        prompt_token_ids = self._extract_prompt_token_ids(raw)
+        output_token_ids = self._extract_output_token_ids(raw)
+        body = dict(raw)
+        # OpenAI's Pydantic models preserve these rollout extensions.
+        body["prompt_token_ids"] = prompt_token_ids
+        body["output_token_ids"] = output_token_ids
+        body["raw_response"] = raw
+        completion = ChatCompletion.model_validate(body)
+        self.last_generation = SGLangGeneration(
+            completion=completion,
+            prompt_token_ids=prompt_token_ids,
+            output_token_ids=output_token_ids,
+            raw_response=raw,
+        )
+        return completion
+
+    def _request_headers(self) -> Optional[Dict[str, str]]:
+        if self.api_key is None:
+            return None
+        return {"Authorization": f"Bearer {self.api_key}"}
+
+    def _chat_completions_url(self) -> str:
+        if self.base_url.endswith("/v1/chat/completions"):
+            return self.base_url
+        if self.base_url.endswith("/v1"):
+            return f"{self.base_url}/chat/completions"
+        return f"{self.base_url}/v1/chat/completions"
+
+    def _openai_payload(
+        self,
+        messages: List[OpenAIMessage],
+        model: str,
+        tools: Optional[List[Dict[str, Any]]],
+        config: Dict[str, Any],
+        response_format: Any,
+    ) -> Dict[str, Any]:
+        config.pop("context_length", None)
+        config.pop("stream", None)
+        config.pop("model", None)
+        config.pop("messages", None)
+        config.pop("tools", None)
+        max_new_tokens = config.pop("max_new_tokens", None)
+        if max_new_tokens is not None and "max_tokens" not in config:
+            config["max_tokens"] = max_new_tokens
+
+        payload: Dict[str, Any] = {
+            "model": model,
+            "messages": messages,
+            **config,
+            "stream": False,
+            # SGLang returns the exact IDs used after server-side templating.
+            "return_prompt_token_ids": True,
+        }
+        if tools is not None:
+            payload["tools"] = tools
+        if response_format is not None:
+            if isinstance(response_format, type) and hasattr(
+                response_format, "model_json_schema"
+            ):
+                payload["response_format"] = {
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": response_format.__name__,
+                        "schema": response_format.model_json_schema(),
+                        "strict": True,
+                    },
+                }
+            else:
+                payload["response_format"] = response_format
+        return payload
+
+    @staticmethod
+    def _first_choice(raw: Mapping[str, Any]) -> Mapping[str, Any]:
+        choices = raw.get("choices")
+        if not isinstance(choices, list) or not choices:
+            return {}
+        choice = choices[0]
+        return choice if isinstance(choice, Mapping) else {}
+
+    @classmethod
+    def _extract_prompt_token_ids(cls, raw: Mapping[str, Any]) -> List[int]:
+        value = raw.get("prompt_token_ids")
+        if value is None:
+            value = cls._first_choice(raw).get("prompt_token_ids")
+        if not isinstance(value, list):
+            return []
+        return [int(token_id) for token_id in value]
+
+    @classmethod
+    def _extract_output_token_ids(cls, raw: Mapping[str, Any]) -> List[int]:
+        value = raw.get("output_token_ids")
+        if isinstance(value, list):
+            return [int(token_id) for token_id in value]
+
+        meta_info = cls._first_choice(raw).get("meta_info")
+        if not isinstance(meta_info, Mapping):
+            return []
+        logprobs = meta_info.get("output_token_logprobs")
+        if not isinstance(logprobs, list):
+            return []
+        token_ids: List[int] = []
+        for item in logprobs:
+            if isinstance(item, (list, tuple)) and len(item) > 1:
+                token_ids.append(int(item[1]))
+            elif isinstance(item, Mapping) and "token_id" in item:
+                token_ids.append(int(item["token_id"]))
+        return token_ids
+
+    @staticmethod
+    def _sampling_params(config: Mapping[str, Any]) -> Dict[str, Any]:
+        allowed = {
+            "temperature",
+            "top_p",
+            "top_k",
+            "min_p",
+            "frequency_penalty",
+            "presence_penalty",
+            "repetition_penalty",
+            "stop",
+            "stop_token_ids",
+            "ignore_eos",
+            "skip_special_tokens",
+            "spaces_between_special_tokens",
+            "n",
+            "seed",
+        }
+        result = {
+            key: value for key, value in config.items() if key in allowed
+        }
+        max_tokens = config.get("max_tokens", config.get("max_new_tokens"))
+        if max_tokens is not None:
+            result["max_new_tokens"] = max_tokens
+        return result
+
+    def _parse_response(
+        self,
+        raw: Dict[str, Any],
+        prompt_token_ids: List[int],
+        *,
+        model: str,
+    ) -> ChatCompletion:
+        text = raw.get("text") or ""
+        output_ids = [int(x) for x in raw.get("output_ids", [])]
+        tool_calls = self._parse_tool_calls(text)
+        content = _TOOL_CALL_RE.sub("", text).strip() if tool_calls else text
+        meta = raw.get("meta_info") or {}
+        finish = meta.get("finish_reason", "stop")
+        if isinstance(finish, dict):
+            finish = finish.get("type", "stop")
+        if tool_calls:
+            finish = "tool_calls"
+
+        prompt_count = int(meta.get("prompt_tokens") or len(prompt_token_ids))
+        completion_count = int(
+            meta.get("completion_tokens") or len(output_ids)
+        )
+        body: Dict[str, Any] = {
+            "id": str(
+                meta.get("id") or raw.get("id") or f"sglang-{uuid.uuid4()}"
+            ),
+            "model": model,
+            "object": "chat.completion",
+            "created": int(time.time()),
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": content or None,
+                        "tool_calls": tool_calls or None,
+                    },
+                    "finish_reason": finish,
+                    "logprobs": None,
+                }
+            ],
+            "usage": {
+                "prompt_tokens": prompt_count,
+                "completion_tokens": completion_count,
+                "total_tokens": prompt_count + completion_count,
+            },
+            # Pydantic's OpenAI models preserve these training extensions.
+            "prompt_token_ids": prompt_token_ids,
+            "output_token_ids": output_ids,
+            "raw_response": raw,
+        }
+        return ChatCompletion.model_validate(body)
+
+    @staticmethod
+    def _parse_tool_calls(text: str) -> List[Dict[str, Any]]:
+        calls: List[Dict[str, Any]] = []
+        for index, match in enumerate(_TOOL_CALL_RE.finditer(text)):
+            try:
+                value = json.loads(match.group(1))
+                name = value["name"]
+                arguments = value.get("arguments", {})
+                if not isinstance(arguments, str):
+                    arguments = json.dumps(arguments, ensure_ascii=False)
+                calls.append(
+                    {
+                        "id": f"call_{uuid.uuid4().hex}",
+                        "index": index,
+                        "type": "function",
+                        "function": {"name": name, "arguments": arguments},
+                    }
+                )
+            except (KeyError, TypeError, json.JSONDecodeError):
+                continue
+        return calls
+
+    async def aclose(self) -> None:
+        if self._owns_http_client:
+            await self.http_client.aclose()
+
+    async def close(self) -> None:
+        """Match ``AsyncOpenAI.close`` for interchangeable client cleanup."""
+        await self.aclose()
+
+
+__all__ = [
+    "HuggingFaceTokenCounter",
+    "SGLangClient",
+    "SGLangGeneration",
+]
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========

--- a/test/agents/test_base_chat_agent.py
+++ b/test/agents/test_base_chat_agent.py
@@ -13,7 +13,7 @@
 # ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
 import asyncio
 import time
-from typing import Any, Dict, List, Optional, Type
+from typing import Any, ClassVar, Dict, List, Optional, Type
 
 import pytest
 from openai.types.chat import ChatCompletionMessageFunctionToolCall
@@ -164,6 +164,71 @@ def test_error_reason_walks_wrapped_causes():
     assert (
         TerminationReason.from_error(ModelConnectionError())
         is TerminationReason.CONNECTION_ERROR
+    )
+
+
+def test_error_reason_detects_openai_context_overflow_payload():
+    class OpenAIStyleBadRequestError(Exception):
+        code = "context_length_exceeded"
+        type = "invalid_request_error"
+        body: ClassVar[Dict[str, str]] = {
+            "message": "This model's maximum context length is 32768 tokens.",
+            "code": "context_length_exceeded",
+        }
+
+    assert (
+        TerminationReason.from_error(OpenAIStyleBadRequestError())
+        is TerminationReason.CONTEXT_WINDOW_OVERFLOW
+    )
+
+
+def test_error_reason_detects_http_response_context_overflow():
+    class Response:
+        status_code = 400
+        text = "The input is longer than the model's context length."
+
+        def json(self):
+            return {
+                "error": {
+                    "message": (
+                        "Requested token count exceeds the model's maximum "
+                        "context length"
+                    )
+                }
+            }
+
+    class HTTPStatusError(Exception):
+        response = Response()
+
+    try:
+        raise RuntimeError("model request failed") from HTTPStatusError()
+    except RuntimeError as error:
+        assert (
+            TerminationReason.from_error(error)
+            is TerminationReason.CONTEXT_WINDOW_OVERFLOW
+        )
+
+
+def test_error_reason_does_not_treat_all_bad_requests_as_context_overflow():
+    class Response:
+        status_code = 400
+        text = "The input JSON is invalid."
+
+        def json(self):
+            return {
+                "error": {
+                    "message": "The input JSON is invalid.",
+                    "type": "BadRequestError",
+                    "code": 400,
+                }
+            }
+
+    class HTTPStatusError(Exception):
+        response = Response()
+
+    assert (
+        TerminationReason.from_error(HTTPStatusError())
+        is TerminationReason.UNCLASSIFIED_ERROR
     )
 
 

--- a/test/agents/test_base_chat_agent.py
+++ b/test/agents/test_base_chat_agent.py
@@ -1,0 +1,300 @@
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+import asyncio
+import time
+from typing import Any, Dict, List, Optional, Type
+
+import pytest
+from openai.types.chat import ChatCompletionMessageFunctionToolCall
+from openai.types.chat.chat_completion_message_function_tool_call import (
+    Function,
+)
+from pydantic import BaseModel
+
+from camel.agents.base import BaseAgent
+from camel.agents.base_chat_agent import BaseChatAgent, TerminationReason
+from camel.agents.chat_agent import ChatAgent
+from camel.memories import AgentMemory
+from camel.messages import OpenAIMessage
+from camel.models.stub_model import StubModel
+from camel.types import (
+    ChatCompletion,
+    ChatCompletionMessage,
+    Choice,
+    CompletionUsage,
+    ModelType,
+)
+
+
+class SequencedModel(StubModel):
+    def __init__(self, responses: List[ChatCompletion]):
+        super().__init__(ModelType.STUB)
+        self.responses = responses
+        self.received: List[List[OpenAIMessage]] = []
+
+    async def _arun(
+        self,
+        messages: List[OpenAIMessage],
+        response_format: Optional[Type[BaseModel]] = None,
+        tools: Optional[List[Dict[str, Any]]] = None,
+    ) -> ChatCompletion:
+        self.received.append([dict(message) for message in messages])
+        return self.responses.pop(0)
+
+
+def completion(content=None, tool_calls=None):
+    return ChatCompletion(
+        id="test-id",
+        model="test-model",
+        object="chat.completion",
+        created=int(time.time()),
+        choices=[
+            Choice(
+                index=0,
+                finish_reason="tool_calls" if tool_calls else "stop",
+                message=ChatCompletionMessage(
+                    role="assistant",
+                    content=content,
+                    tool_calls=tool_calls,
+                ),
+            )
+        ],
+        usage=CompletionUsage(
+            prompt_tokens=4, completion_tokens=2, total_tokens=6
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_append_only_agent_executes_tool_with_unprocessed_memory():
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    tool_call = ChatCompletionMessageFunctionToolCall(
+        id="call-1",
+        type="function",
+        function=Function(name="add", arguments='{"a": 2, "b": 3}'),
+    )
+    backend = SequencedModel(
+        [completion(tool_calls=[tool_call]), completion(content="five")]
+    )
+    agent = BaseChatAgent(
+        system_message="Be concise.",
+        model=backend,
+        tools=[add],
+        token_limit=100,
+        step_timeout=None,
+    )
+
+    response = await agent.astep("calculate")
+
+    assert isinstance(agent, BaseAgent)
+    assert not isinstance(agent, ChatAgent)
+    assert isinstance(agent.memory, AgentMemory)
+    assert response.msgs[0].content == "five"
+    assert [message["role"] for message in agent.message_list] == [
+        "system",
+        "user",
+        "assistant",
+        "tool",
+        "assistant",
+    ]
+    assert agent.message_list[3] == {
+        "role": "tool",
+        "tool_call_id": "call-1",
+        "content": "5",
+    }
+    assert [message["role"] for message in backend.received[1]] == [
+        "system",
+        "user",
+        "assistant",
+        "tool",
+    ]
+    memory_messages, _ = agent.memory.get_context()
+    assert memory_messages == agent.message_list
+    assert agent.termination_reason is TerminationReason.TASK_COMPLETE
+    assert response.info["training"]["total_tool_calls"] == 1
+
+
+@pytest.mark.asyncio
+async def test_user_turns_append_and_reset_clears_trajectory():
+    backend = SequencedModel(
+        [completion(content="one"), completion(content="two")]
+    )
+    agent = BaseChatAgent(model=backend, token_limit=100, step_timeout=None)
+
+    await agent.astep("first")
+    await agent.astep("second")
+    assert [message["role"] for message in agent.message_list] == [
+        "user",
+        "assistant",
+        "user",
+        "assistant",
+    ]
+
+    agent.reset()
+    assert agent.message_list == []
+    assert agent.memory.retrieve() == []
+    assert agent.termination_reason is TerminationReason.NOT_TERMINATED
+
+
+def test_error_reason_walks_wrapped_causes():
+    try:
+        try:
+            raise asyncio.TimeoutError("server stalled")
+        except asyncio.TimeoutError as cause:
+            raise RuntimeError("model failed") from cause
+    except RuntimeError as error:
+        assert TerminationReason.from_error(error) is TerminationReason.TIMEOUT
+
+    class ModelConnectionError(Exception):
+        pass
+
+    assert (
+        TerminationReason.from_error(ModelConnectionError())
+        is TerminationReason.CONNECTION_ERROR
+    )
+
+
+@pytest.mark.asyncio
+async def test_multiple_tool_calls_execute_sequentially_without_a_cap():
+    active = 0
+    max_active = 0
+    events = []
+
+    async def echo(value: int) -> int:
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        events.append(("start", value))
+        await asyncio.sleep(0)
+        events.append(("end", value))
+        active -= 1
+        return value
+
+    calls = [
+        ChatCompletionMessageFunctionToolCall(
+            id=f"call-{i}",
+            type="function",
+            function=Function(name="echo", arguments=f'{{"value": {i}}}'),
+        )
+        for i in range(2)
+    ]
+    backend = SequencedModel(
+        [completion(tool_calls=calls), completion(content="done")]
+    )
+    agent = BaseChatAgent(
+        model=backend,
+        tools=[echo],
+        token_limit=100,
+        step_timeout=None,
+    )
+
+    result = await agent.astep("call tools")
+
+    assert [record.result for record in result.info["tool_calls"]] == [0, 1]
+    assert max_active == 1
+    assert events == [("start", 0), ("end", 0), ("start", 1), ("end", 1)]
+    assert not hasattr(agent, "parallel_internal_tools")
+    assert agent.meta_info_record["max_tool_calls_per_turn"] == 2
+    assert agent.meta_info_record["total_tool_calls"] == 2
+    assert agent.termination_reason is TerminationReason.TASK_COMPLETE
+
+
+@pytest.mark.asyncio
+async def test_length_finish_reason_tracks_output_token_limit():
+    response = completion(content="truncated")
+    response.choices[0].finish_reason = "length"
+    agent = BaseChatAgent(
+        model=SequencedModel([response]),
+        token_limit=100,
+        step_timeout=None,
+    )
+
+    result = await agent.astep("write")
+
+    assert result.terminated
+    assert agent.termination_reason is TerminationReason.MAX_TOKENS_REACHED
+
+
+@pytest.mark.asyncio
+async def test_prompt_over_token_limit_tracks_context_overflow():
+    agent = BaseChatAgent(
+        model=SequencedModel([completion(content="answer")]),
+        token_limit=3,
+        step_timeout=None,
+    )
+
+    result = await agent.astep("write")
+
+    assert result.terminated
+    assert (
+        agent.termination_reason is TerminationReason.CONTEXT_WINDOW_OVERFLOW
+    )
+
+
+@pytest.mark.asyncio
+async def test_mcp_async_call_path_is_preserved():
+    class MCPCallable:
+        async def async_call(self, value: str):
+            return f"mcp:{value}"
+
+    class MCPFunctionTool:
+        func = MCPCallable()
+
+        def get_openai_tool_schema(self):
+            return {
+                "type": "function",
+                "function": {"name": "mcp_echo", "parameters": {}},
+            }
+
+    tool_call = ChatCompletionMessageFunctionToolCall(
+        id="mcp-call",
+        type="function",
+        function=Function(name="mcp_echo", arguments='{"value": "hello"}'),
+    )
+    backend = SequencedModel(
+        [completion(tool_calls=[tool_call]), completion(content="done")]
+    )
+    agent = BaseChatAgent(model=backend, token_limit=100, step_timeout=None)
+    agent._internal_tools["mcp_echo"] = MCPFunctionTool()
+
+    result = await agent.astep("use MCP")
+
+    assert result.info["tool_calls"][0].result == "mcp:hello"
+    assert agent.message_list[-2]["content"] == "mcp:hello"
+
+
+def test_sync_step_is_intentionally_unsupported():
+    agent = BaseChatAgent(
+        model=SequencedModel([completion(content="unused")]), token_limit=100
+    )
+
+    with pytest.raises(NotImplementedError, match="use astep"):
+        agent.step("hello")
+
+
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========

--- a/test/agents/test_base_chat_agent.py
+++ b/test/agents/test_base_chat_agent.py
@@ -13,7 +13,7 @@
 # ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
 import asyncio
 import time
-from typing import Any, ClassVar, Dict, List, Optional, Type
+from typing import Any, ClassVar, Dict, List, Optional, Type, cast
 
 import pytest
 from openai.types.chat import ChatCompletionMessageFunctionToolCall
@@ -49,7 +49,9 @@ class SequencedModel(StubModel):
         response_format: Optional[Type[BaseModel]] = None,
         tools: Optional[List[Dict[str, Any]]] = None,
     ) -> ChatCompletion:
-        self.received.append([dict(message) for message in messages])
+        self.received.append(
+            cast(List[OpenAIMessage], [dict(message) for message in messages])
+        )
         return self.responses.pop(0)
 
 

--- a/test/models/client/test_sglang_client.py
+++ b/test/models/client/test_sglang_client.py
@@ -1,0 +1,287 @@
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+import json
+import os
+
+import httpx
+import pytest
+
+from camel.models.client import SGLangClient
+
+
+class FakeTokenizer:
+    model_max_length = 4096
+
+    def __init__(self):
+        self.calls = []
+
+    def apply_chat_template(self, messages, **kwargs):
+        self.calls.append((messages, kwargs))
+        return [10, 20, 30]
+
+    def encode(self, text, add_special_tokens=False):
+        return [ord(char) for char in text]
+
+    def decode(self, token_ids):
+        return "".join(chr(token_id) for token_id in token_ids)
+
+
+@pytest.mark.asyncio
+async def test_native_client_sends_ids_and_parses_qwen_tool_call():
+    seen = {}
+
+    async def handler(request: httpx.Request):
+        seen["url"] = str(request.url)
+        seen["body"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "text": (
+                    "thinking\n<tool_call>\n"
+                    '{"name":"weather","arguments":{"city":"Paris"}}'
+                    "\n</tool_call>"
+                ),
+                "output_ids": [41, 42],
+                "meta_info": {
+                    "id": "request-1",
+                    "prompt_tokens": 3,
+                    "completion_tokens": 2,
+                    "finish_reason": {"type": "stop"},
+                },
+            },
+        )
+
+    http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    tokenizer = FakeTokenizer()
+    client = SGLangClient(
+        "http://sglang.test/v1",
+        model="Qwen/Qwen3-0.6B",
+        tokenizer=tokenizer,
+        chat_template="custom-template",
+        chat_template_kwargs={"enable_thinking": False},
+        http_client=http_client,
+    )
+    tools = [
+        {
+            "type": "function",
+            "function": {"name": "weather", "parameters": {}},
+        }
+    ]
+
+    response = await client.create_chat_completion(
+        [{"role": "user", "content": "weather?"}],
+        tools=tools,
+        model_config={"temperature": 0, "max_tokens": 7, "stream": False},
+    )
+
+    assert seen["url"] == "http://sglang.test/generate"
+    assert seen["body"] == {
+        "input_ids": [10, 20, 30],
+        "sampling_params": {"temperature": 0, "max_new_tokens": 7},
+        "return_prompt_token_ids": True,
+    }
+    assert tokenizer.calls[0][1] == {
+        "tokenize": True,
+        "add_generation_prompt": True,
+        "chat_template": "custom-template",
+        "enable_thinking": False,
+        "tools": tools,
+    }
+    message = response.choices[0].message
+    assert message.content == "thinking"
+    assert message.tool_calls[0].function.name == "weather"
+    assert json.loads(message.tool_calls[0].function.arguments) == {
+        "city": "Paris"
+    }
+    assert response.output_token_ids == [41, 42]
+    assert response.prompt_token_ids == [10, 20, 30]
+    assert client.last_generation.output_token_ids == [41, 42]
+    await http_client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_openai_mode_uses_chat_completions_contract():
+    seen = {}
+
+    async def handler(request: httpx.Request):
+        seen["url"] = str(request.url)
+        seen["body"] = json.loads(request.content)
+        seen["authorization"] = request.headers.get("authorization")
+        return httpx.Response(
+            200,
+            json={
+                "id": "chatcmpl-session-1",
+                "object": "chat.completion",
+                "created": 1,
+                "model": "Qwen/Qwen3-0.6B",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "",
+                            "tool_calls": [
+                                {
+                                    "id": "call_from_server",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "weather",
+                                        "arguments": '{"city":"Paris"}',
+                                    },
+                                }
+                            ],
+                        },
+                        "finish_reason": "tool_calls",
+                        "prompt_token_ids": [10, 20, 30],
+                        "meta_info": {
+                            "completion_tokens": 2,
+                            "output_token_logprobs": [
+                                [-0.1, 41],
+                                [-0.2, 42],
+                            ],
+                        },
+                    }
+                ],
+            },
+        )
+
+    http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    client = SGLangClient(
+        "http://miles.test/sessions/session-123",
+        model="Qwen/Qwen3-0.6B",
+        api_mode="openai",
+        api_key="session-key",
+        http_client=http_client,
+    )
+    messages = [{"role": "user", "content": "weather?"}]
+    tools = [
+        {
+            "type": "function",
+            "function": {"name": "weather", "parameters": {}},
+        }
+    ]
+
+    response = await client.create_chat_completion(
+        messages,
+        tools=tools,
+        model_config={
+            "temperature": 0,
+            "max_new_tokens": 7,
+            "context_length": 4096,
+            "stream": False,
+        },
+    )
+
+    assert client.api_mode == "openai"
+    assert client.tokenizer is None
+    assert seen["url"] == (
+        "http://miles.test/sessions/session-123/v1/chat/completions"
+    )
+    assert seen["authorization"] == "Bearer session-key"
+    assert seen["body"] == {
+        "model": "Qwen/Qwen3-0.6B",
+        "messages": messages,
+        "tools": tools,
+        "temperature": 0,
+        "max_tokens": 7,
+        "stream": False,
+        "return_prompt_token_ids": True,
+    }
+    assert response.choices[0].message.content == ""
+    assert response.choices[0].message.tool_calls[0].id == ("call_from_server")
+    assert response.choices[0].meta_info["completion_tokens"] == 2
+    assert response.prompt_token_ids == [10, 20, 30]
+    assert response.output_token_ids == [41, 42]
+    assert client.last_generation.prompt_token_ids == [10, 20, 30]
+    assert client.last_generation.output_token_ids == [41, 42]
+    await http_client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_explicit_openai_mode_accepts_v1_base_url():
+    seen = {}
+
+    async def handler(request: httpx.Request):
+        seen["url"] = str(request.url)
+        return httpx.Response(
+            200,
+            json={
+                "id": "chatcmpl-1",
+                "object": "chat.completion",
+                "created": 1,
+                "model": "model",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "ok",
+                        },
+                        "finish_reason": "stop",
+                    }
+                ],
+            },
+        )
+
+    http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    client = SGLangClient(
+        "http://sglang.test/v1",
+        model="model",
+        api_mode="openai",
+        http_client=http_client,
+    )
+
+    await client.create_chat_completion([{"role": "user", "content": "hello"}])
+
+    assert seen["url"] == "http://sglang.test/v1/chat/completions"
+    await http_client.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    not os.environ.get("SGLANG_QWEN3_URL"),
+    reason="set SGLANG_QWEN3_URL to a Qwen/Qwen3-0.6B SGLang server",
+)
+async def test_qwen3_06b_sglang_returns_token_ids():
+    client = SGLangClient(
+        os.environ["SGLANG_QWEN3_URL"],
+        model="Qwen/Qwen3-0.6B",
+        tokenizer="Qwen/Qwen3-0.6B",
+        chat_template_kwargs={"enable_thinking": False},
+    )
+    try:
+        response = await client.create_chat_completion(
+            [{"role": "user", "content": "Reply with only: OK"}],
+            model_config={"temperature": 0, "max_tokens": 8},
+        )
+        assert response.choices[0].message.content
+        assert response.prompt_token_ids
+        assert response.output_token_ids
+    finally:
+        await client.aclose()
+
+
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========

--- a/test/models/test_base_chat_model.py
+++ b/test/models/test_base_chat_model.py
@@ -1,0 +1,153 @@
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+import json
+
+import httpx
+import pytest
+from openai import AsyncOpenAI
+
+from camel.models.base_chat_model import BaseChatModel
+from camel.models.client import SGLangClient
+
+
+class FakeTokenizer:
+    model_max_length = 8192
+
+    def apply_chat_template(self, messages, **kwargs):
+        return [10, 20, 30]
+
+    def encode(self, text, add_special_tokens=False):
+        return [ord(char) for char in text]
+
+    def decode(self, token_ids):
+        return "".join(chr(token_id) for token_id in token_ids)
+
+
+@pytest.mark.asyncio
+async def test_tito_backend_uses_in_house_client_via_openai_interface():
+    seen = {}
+
+    async def handler(request: httpx.Request):
+        seen["url"] = str(request.url)
+        seen["body"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "text": "<think>raw</think>answer",
+                "output_ids": [41, 42],
+                "meta_info": {
+                    "prompt_tokens": 3,
+                    "completion_tokens": 2,
+                    "finish_reason": {"type": "stop"},
+                },
+            },
+        )
+
+    http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    client = SGLangClient(
+        base_url="http://sglang.test",
+        model="Qwen/Qwen3-0.6B",
+        tokenizer=FakeTokenizer(),
+        http_client=http_client,
+    )
+    model = BaseChatModel(
+        model_type="Qwen/Qwen3-0.6B",
+        model_config_dict={
+            "temperature": 0.2,
+            "context_length": 8192,
+            "top_k": 20,
+        },
+        client=client,
+    )
+    messages = [{"role": "user", "content": "hello"}]
+    tools = [{"type": "function", "function": {"name": "ping"}}]
+
+    actual = await model.arun(messages, tools=tools)
+
+    assert seen["url"] == "http://sglang.test/generate"
+    assert seen["body"] == {
+        "input_ids": [10, 20, 30],
+        "sampling_params": {"temperature": 0.2, "top_k": 20},
+        "return_prompt_token_ids": True,
+    }
+    assert actual.choices[0].message.content == "<think>raw</think>answer"
+    assert model.token_counter.count_tokens_from_messages(messages) == 3
+    assert model.token_limit == 8192
+    assert model.last_output_token_ids == [41, 42]
+    await http_client.aclose()
+
+
+def test_tito_backend_requires_url_without_injected_client():
+    with pytest.raises(ValueError, match="url is required"):
+        BaseChatModel(model_type="Qwen/Qwen3-0.6B")
+
+
+@pytest.mark.asyncio
+async def test_tito_backend_starts_async_openai_for_session_url():
+    seen = {}
+
+    async def handler(request: httpx.Request):
+        seen["url"] = str(request.url)
+        seen["body"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "id": "chatcmpl-session",
+                "object": "chat.completion",
+                "created": 1,
+                "model": "Qwen/Qwen3-0.6B",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "answer",
+                        },
+                        "finish_reason": "stop",
+                        "prompt_token_ids": [1, 2],
+                        "meta_info": {
+                            "completion_tokens": 1,
+                            "output_token_logprobs": [[-0.1, 3]],
+                        },
+                    }
+                ],
+            },
+        )
+
+    http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    model = BaseChatModel(
+        model_type="Qwen/Qwen3-0.6B",
+        model_config_dict={"temperature": 0, "top_k": 20},
+        url="http://miles.test/sessions/session-abc",
+        http_client=http_client,
+    )
+    messages = [{"role": "user", "content": "hello"}]
+
+    response = await model.arun(messages)
+
+    assert isinstance(model._async_client, AsyncOpenAI)
+    assert seen["url"] == (
+        "http://miles.test/sessions/session-abc/v1/chat/completions"
+    )
+    assert seen["body"] == {
+        "messages": messages,
+        "model": "Qwen/Qwen3-0.6B",
+        "stream": False,
+        "temperature": 0,
+        "top_k": 20,
+    }
+    assert response.choices[0].message.content == "answer"
+    assert model.last_prompt_tokens == 2
+    assert model.last_output_token_ids == [3]
+    await model.aclose()


### PR DESCRIPTION
## Summary

- Add `BaseChatAgent`, an async-only agent derived directly from `BaseAgent`, with canonical append-only `AgentMemory` and raw OpenAI-format trajectory preservation.
- Keep function and MCP tool execution asynchronous and sequential, preserving assistant tool calls and tool results in request order.
- Add `BaseChatModel`, supporting either an injected AsyncOpenAI-compatible client or an endpoint URL used to construct `AsyncOpenAI`.
- Add `SGLangClient` with native and OpenAI-compatible transports while retaining available prompt/output token metadata.
- Add focused agent, model, and client tests.

The base path performs no hidden pruning, summarization, message rewriting, or tool-output masking. Endpoint integration remains training-framework agnostic.

## Testing

```text
pytest -q test/models/test_base_chat_model.py test/models/client/test_sglang_client.py test/agents/test_base_chat_agent.py
14 passed, 1 skipped

ruff check <changed Python files>
All checks passed

ruff format --check <changed Python files>
7 files already formatted
```

Supersedes the earlier implementation draft in #4163.

Closes #4162