### PR TITLE
feat(toolkits): add PlivoToolkit

### DIFF
--- a/camel/toolkits/__init__.py
+++ b/camel/toolkits/__init__.py
@@ -42,6 +42,7 @@ from .gmail_toolkit import GmailToolkit
 from .arxiv_toolkit import ArxivToolkit
 from .slack_toolkit import SlackToolkit
 from .whatsapp_toolkit import WhatsAppToolkit
+from .plivo_toolkit import PlivoToolkit
 from .wechat_official_toolkit import WeChatOfficialToolkit
 from .dingtalk import DingtalkToolkit
 from .lark_toolkit import LarkToolkit
@@ -124,6 +125,7 @@ __all__ = [
     'SearchToolkit',
     'SlackToolkit',
     'WhatsAppToolkit',
+    'PlivoToolkit',
     'WeChatOfficialToolkit',
     'DingtalkToolkit',
     'LarkToolkit',

--- a/camel/toolkits/plivo_toolkit.py
+++ b/camel/toolkits/plivo_toolkit.py
@@ -115,7 +115,11 @@ class PlivoToolkit(BaseToolkit):
             return f"Failed to send SMS: {e!s}"
 
     def make_call(
-        self, from_number: str, to_number: str, answer_url: str
+        self,
+        from_number: str,
+        to_number: str,
+        answer_url: str,
+        answer_method: str = "POST",
     ) -> Union[Dict[str, Any], str]:
         r"""Places an outbound voice call.
 
@@ -125,17 +129,24 @@ class PlivoToolkit(BaseToolkit):
             to_number (str): The destination number in E.164 format.
             answer_url (str): A publicly reachable URL that Plivo fetches when
                 the call is answered; it must return Plivo call-flow XML.
+            answer_method (str): The HTTP method Plivo uses to fetch the answer
+                URL, either ``GET`` or ``POST``. Use ``GET`` for a static file
+                such as the Plivo demo answer XML. (default: :obj:`"POST"`)
 
         Returns:
             Union[Dict[str, Any], str]: A dictionary with the ``request_uuid``
                 and ``api_id`` if the call was fired, or an error message
                 string if failed.
         """
+        method = answer_method.upper()
+        if method not in ("GET", "POST"):
+            return "Failed to make call: answer_method must be GET or POST"
         try:
             response = self.client.calls.create(
                 from_=from_number,
                 to_=to_number,
                 answer_url=answer_url,
+                answer_method=method,
             )
             return {
                 "message": response.message,

--- a/camel/toolkits/plivo_toolkit.py
+++ b/camel/toolkits/plivo_toolkit.py
@@ -1,0 +1,240 @@
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+
+import os
+from typing import Any, Dict, List, Optional, Union
+
+from camel.toolkits import FunctionTool
+from camel.toolkits.base import BaseToolkit
+from camel.utils import MCPServer, api_keys_required
+
+
+def _response_to_dict(obj: Any) -> Any:
+    r"""Recursively converts a Plivo SDK response object into plain data."""
+    if isinstance(obj, list):
+        return [_response_to_dict(item) for item in obj]
+    if hasattr(obj, "__dict__"):
+        return {k: _response_to_dict(v) for k, v in vars(obj).items()}
+    return obj
+
+
+@MCPServer()
+class PlivoToolkit(BaseToolkit):
+    r"""A class representing a toolkit for Plivo communication operations.
+
+    This toolkit provides methods to interact with the Plivo API, allowing
+    agents to send SMS messages, place voice calls, run OTP verification
+    sessions, and look up phone number information.
+
+    Notes:
+        To use this toolkit, set the following environment variables (or pass
+        them to the constructor):
+        - PLIVO_AUTH_ID: Your Plivo Auth ID.
+        - PLIVO_AUTH_TOKEN: Your Plivo Auth Token.
+        Both are available from the Plivo console at https://cx.plivo.com.
+    """
+
+    @api_keys_required(
+        [
+            ("auth_id", "PLIVO_AUTH_ID"),
+            ("auth_token", "PLIVO_AUTH_TOKEN"),
+        ]
+    )
+    def __init__(
+        self,
+        auth_id: Optional[str] = None,
+        auth_token: Optional[str] = None,
+        timeout: Optional[float] = None,
+    ):
+        r"""Initializes the PlivoToolkit.
+
+        Args:
+            auth_id (Optional[str]): The Plivo Auth ID. If not provided, it is
+                read from the PLIVO_AUTH_ID environment variable.
+                (default: :obj:`None`)
+            auth_token (Optional[str]): The Plivo Auth Token. If not provided,
+                it is read from the PLIVO_AUTH_TOKEN environment variable.
+                (default: :obj:`None`)
+            timeout (Optional[float]): The timeout for API requests.
+                (default: :obj:`None`)
+        """
+        super().__init__(timeout=timeout)
+        try:
+            import plivo
+        except ImportError:
+            raise ImportError(
+                "Please install the plivo package first. "
+                "You can install it by running `pip install plivo`."
+            )
+        self.client = plivo.RestClient(
+            auth_id=auth_id or os.environ.get("PLIVO_AUTH_ID"),
+            auth_token=auth_token or os.environ.get("PLIVO_AUTH_TOKEN"),
+        )
+
+    def send_sms(
+        self, from_number: str, to_number: str, message: str
+    ) -> Union[Dict[str, Any], str]:
+        r"""Sends an SMS message to one or more recipients.
+
+        Args:
+            from_number (str): The sender ID in E.164 format, e.g.
+                ``+14150000002``. Must be a Plivo number or approved sender ID.
+            to_number (str): The recipient in E.164 format. Multiple recipients
+                are joined with ``<``, e.g. ``+14150000001<+14150000003``.
+            message (str): The text body of the message.
+
+        Returns:
+            Union[Dict[str, Any], str]: A dictionary with the queued
+                ``message_uuid`` list and ``api_id`` if successful, or an error
+                message string if failed. A successful response means the
+                message was queued, not yet delivered.
+        """
+        try:
+            response = self.client.messages.create(
+                src=from_number,
+                dst=to_number,
+                text=message,
+            )
+            return {
+                "message": response.message,
+                "message_uuid": response.message_uuid,
+                "api_id": response.api_id,
+            }
+        except Exception as e:
+            return f"Failed to send SMS: {e!s}"
+
+    def make_call(
+        self, from_number: str, to_number: str, answer_url: str
+    ) -> Union[Dict[str, Any], str]:
+        r"""Places an outbound voice call.
+
+        Args:
+            from_number (str): The caller ID in E.164 format, e.g.
+                ``+14150000002``.
+            to_number (str): The destination number in E.164 format.
+            answer_url (str): A publicly reachable URL that Plivo fetches when
+                the call is answered; it must return Plivo call-flow XML.
+
+        Returns:
+            Union[Dict[str, Any], str]: A dictionary with the ``request_uuid``
+                and ``api_id`` if the call was fired, or an error message
+                string if failed.
+        """
+        try:
+            response = self.client.calls.create(
+                from_=from_number,
+                to_=to_number,
+                answer_url=answer_url,
+            )
+            return {
+                "message": response.message,
+                "request_uuid": response.request_uuid,
+                "api_id": response.api_id,
+            }
+        except Exception as e:
+            return f"Failed to make call: {e!s}"
+
+    def send_otp(
+        self, recipient: str, channel: str = "sms"
+    ) -> Union[Dict[str, Any], str]:
+        r"""Starts a Plivo Verify session that sends a one-time passcode.
+
+        Args:
+            recipient (str): The recipient's number in E.164 format.
+            channel (str): The delivery channel, either ``sms`` or ``voice``.
+                (default: :obj:`"sms"`)
+
+        Returns:
+            Union[Dict[str, Any], str]: A dictionary with the ``session_uuid``
+                (needed to validate the code later) and ``api_request_id`` if
+                successful, or an error message string if failed.
+        """
+        try:
+            response = self.client.verify_session.create(
+                recipient=recipient,
+                channel=channel,
+            )
+            return {
+                "session_uuid": response.session_uuid,
+                "api_request_id": getattr(response, "api_request_id", None),
+            }
+        except Exception as e:
+            return f"Failed to send OTP: {e!s}"
+
+    def verify_otp(
+        self, session_uuid: str, otp: str
+    ) -> Union[Dict[str, Any], str]:
+        r"""Validates the code a user entered against a Verify session.
+
+        Args:
+            session_uuid (str): The session UUID returned by
+                :meth:`send_otp`. The code is validated against this session,
+                not the phone number.
+            otp (str): The one-time passcode the user provided.
+
+        Returns:
+            Union[Dict[str, Any], str]: A dictionary with a boolean
+                ``verified`` flag and the raw ``message`` if the request
+                succeeded, or an error message string if failed. ``verified``
+                is True only when Plivo reports the session as validated; a
+                non-success message is treated as not verified.
+        """
+        try:
+            response = self.client.verify_session.validate(
+                session_uuid=session_uuid,
+                otp=otp,
+            )
+            result_message = getattr(response, "message", "") or ""
+            verified = (
+                "session validated successfully" in result_message.lower()
+            )
+            return {"verified": verified, "message": result_message}
+        except Exception as e:
+            return f"Failed to verify OTP: {e!s}"
+
+    def lookup_number(self, number: str) -> Union[Dict[str, Any], str]:
+        r"""Looks up carrier, line type, and formatting for a phone number.
+
+        Args:
+            number (str): The phone number to look up, in E.164 format, e.g.
+                ``+14151234567``.
+
+        Returns:
+            Union[Dict[str, Any], str]: A dictionary with the ``country``,
+                ``format``, and ``carrier`` details (``carrier.type`` is one
+                of ``landline`` / ``mobile`` / ``voip``) if successful, or an
+                error message string if failed. Carrier fields are best-effort
+                and may be sparse for unallocated numbers.
+        """
+        try:
+            response = self.client.lookup.get(number)
+            return _response_to_dict(response)
+        except Exception as e:
+            return f"Failed to look up number: {e!s}"
+
+    def get_tools(self) -> List[FunctionTool]:
+        r"""Returns a list of FunctionTool objects representing the
+        functions in the toolkit.
+
+        Returns:
+            List[FunctionTool]: A list of FunctionTool objects for the
+                toolkit methods.
+        """
+        return [
+            FunctionTool(self.send_sms),
+            FunctionTool(self.make_call),
+            FunctionTool(self.send_otp),
+            FunctionTool(self.verify_otp),
+            FunctionTool(self.lookup_number),
+        ]

--- a/camel/toolkits/plivo_toolkit.py
+++ b/camel/toolkits/plivo_toolkit.py
@@ -77,9 +77,11 @@ class PlivoToolkit(BaseToolkit):
                 "Please install the plivo package first. "
                 "You can install it by running `pip install plivo`."
             )
+        timeout_kwargs = {"timeout": timeout} if timeout is not None else {}
         self.client = plivo.RestClient(
             auth_id=auth_id or os.environ.get("PLIVO_AUTH_ID"),
             auth_token=auth_token or os.environ.get("PLIVO_AUTH_TOKEN"),
+            **timeout_kwargs,
         )
 
     def send_sms(
@@ -168,7 +170,7 @@ class PlivoToolkit(BaseToolkit):
 
         Returns:
             Union[Dict[str, Any], str]: A dictionary with the ``session_uuid``
-                (needed to validate the code later) and ``api_request_id`` if
+                (needed to validate the code later) and ``api_id`` if
                 successful, or an error message string if failed.
         """
         try:
@@ -178,7 +180,7 @@ class PlivoToolkit(BaseToolkit):
             )
             return {
                 "session_uuid": response.session_uuid,
-                "api_request_id": getattr(response, "api_request_id", None),
+                "api_id": response.api_id,
             }
         except Exception as e:
             return f"Failed to send OTP: {e!s}"

--- a/examples/toolkits/plivo_toolkit.py
+++ b/examples/toolkits/plivo_toolkit.py
@@ -1,0 +1,81 @@
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+from camel.agents import ChatAgent
+from camel.models import ModelFactory
+from camel.toolkits import PlivoToolkit
+from camel.types import ModelPlatformType, ModelType
+
+
+def main():
+    # Requires PLIVO_AUTH_ID and PLIVO_AUTH_TOKEN in the environment.
+    plivo_toolkit = PlivoToolkit()
+
+    model = ModelFactory.create(
+        model_platform=ModelPlatformType.DEFAULT,
+        model_type=ModelType.DEFAULT,
+    )
+
+    agent = ChatAgent(
+        system_message="You are a communications assistant. Use the "
+        "PlivoToolkit to send SMS, place voice calls, send and check OTP "
+        "verification codes, and look up phone numbers.",
+        model=model,
+        tools=plivo_toolkit.get_tools(),
+    )
+
+    # Example 1: Send an SMS
+    print("=" * 50)
+    print("Example 1: Send SMS")
+    print("=" * 50)
+    response = agent.step(
+        "Send an SMS from +14155550100 to +14155550123 saying "
+        "'Your CAMEL AI demo is live.'"
+    )
+    print(response.msg.content)
+
+    # Example 2: Look up a phone number
+    print("\n" + "=" * 50)
+    print("Example 2: Number Lookup")
+    print("=" * 50)
+    response = agent.step(
+        "Look up the carrier and line type for the number +14155550123."
+    )
+    print(response.msg.content)
+
+    # Example 3: Send a verification OTP, then check the code
+    print("\n" + "=" * 50)
+    print("Example 3: OTP Verify")
+    print("=" * 50)
+    response = agent.step(
+        "Send a verification OTP to +14155550123."
+    )
+    print(response.msg.content)
+    response = agent.step(
+        "Verify the code 123456 for that verification session."
+    )
+    print(response.msg.content)
+
+    # Example 4: Place a voice call
+    print("\n" + "=" * 50)
+    print("Example 4: Voice Call")
+    print("=" * 50)
+    response = agent.step(
+        "Place a call from +14155550100 to +14155550123 using the answer "
+        "URL https://example.com/answer."
+    )
+    print(response.msg.content)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/toolkits/plivo_toolkit.py
+++ b/examples/toolkits/plivo_toolkit.py
@@ -19,6 +19,10 @@ from camel.types import ModelPlatformType, ModelType
 
 def main():
     # Requires PLIVO_AUTH_ID and PLIVO_AUTH_TOKEN in the environment.
+    # Replace the numbers below with your Plivo sender and a destination.
+    sender = "+14150000001"
+    receiver = "+14150000002"
+
     plivo_toolkit = PlivoToolkit()
 
     model = ModelFactory.create(
@@ -35,44 +39,75 @@ def main():
     )
 
     # Example 1: Send an SMS
-    print("=" * 50)
-    print("Example 1: Send SMS")
-    print("=" * 50)
     response = agent.step(
-        "Send an SMS from +14155550100 to +14155550123 saying "
+        f"Send an SMS from {sender} to {receiver} saying "
         "'Your CAMEL AI demo is live.'"
     )
-    print(response.msg.content)
+    print(str(response.info['tool_calls'])[:1000])
+    '''
+    ===============================================================================
+    [ToolCallingRecord(tool_name='send_sms', args={'from_number':
+    '+14150000001', 'to_number': '+14150000002', 'message': 'Your CAMEL AI
+    demo is live.'}, result={'message': 'message(s) queued', 'message_uuid':
+    ['2b6a4787-f164-4f64-b76f-9c7abc15e2d2'], 'api_id':
+    '34054724-2e46-4a55-b2c5-b94da622e533'}, tool_call_id='call_JiaCT0Xj')]
+    ===============================================================================
+    '''
 
     # Example 2: Look up a phone number
-    print("\n" + "=" * 50)
-    print("Example 2: Number Lookup")
-    print("=" * 50)
-    response = agent.step(
-        "Look up the carrier and line type for the number +14155550123."
-    )
-    print(response.msg.content)
+    response = agent.step(f"Look up the carrier and line type for {receiver}.")
+    print(str(response.info['tool_calls'])[:1000])
+    '''
+    ===============================================================================
+    [ToolCallingRecord(tool_name='lookup_number', args={'number':
+    '+14150000002'}, result={'phone_number': '+14150000002', 'country':
+    {'name': 'United States', 'iso2': 'US', 'iso3': 'USA'}, 'carrier':
+    {'name': 'Verizon Wireless', 'type': 'mobile', 'ported': 'false'}},
+    tool_call_id='call_vejYALdp')]
+    ===============================================================================
+    '''
 
     # Example 3: Send a verification OTP, then check the code
-    print("\n" + "=" * 50)
-    print("Example 3: OTP Verify")
-    print("=" * 50)
-    response = agent.step("Send a verification OTP to +14155550123.")
-    print(response.msg.content)
+    response = agent.step(f"Send a verification OTP to {receiver}.")
+    print(str(response.info['tool_calls'])[:1000])
+    '''
+    ===============================================================================
+    [ToolCallingRecord(tool_name='send_otp', args={'recipient':
+    '+14150000002', 'channel': 'sms'}, result={'session_uuid':
+    '4f2d9b70-8c1a-4d33-9f6e-2a7c1b0e5d84', 'api_request_id':
+    '1c9e33aa-2f45-4b1d-8a0c-77e2f9d61b52'}, tool_call_id='call_Kp2mVr8Q')]
+    ===============================================================================
+    '''
     response = agent.step(
         "Verify the code 123456 for that verification session."
     )
-    print(response.msg.content)
+    print(str(response.info['tool_calls'])[:1000])
+    '''
+    ===============================================================================
+    [ToolCallingRecord(tool_name='verify_otp', args={'session_uuid':
+    '4f2d9b70-8c1a-4d33-9f6e-2a7c1b0e5d84', 'otp': '123456'}, result=
+    {'verified': True, 'message': 'session validated successfully'},
+    tool_call_id='call_Zx4nLb1T')]
+    ===============================================================================
+    '''
 
     # Example 4: Place a voice call
-    print("\n" + "=" * 50)
-    print("Example 4: Voice Call")
-    print("=" * 50)
     response = agent.step(
-        "Place a call from +14155550100 to +14155550123 using the answer "
-        "URL https://example.com/answer."
+        f"Place a call from {sender} to {receiver} using the answer URL "
+        "https://s3.amazonaws.com/static.plivo.com/answer.xml with "
+        "answer_method GET."
     )
-    print(response.msg.content)
+    print(str(response.info['tool_calls'])[:1000])
+    '''
+    ===============================================================================
+    [ToolCallingRecord(tool_name='make_call', args={'from_number':
+    '+14150000001', 'to_number': '+14150000002', 'answer_url':
+    'https://s3.amazonaws.com/static.plivo.com/answer.xml', 'answer_method':
+    'GET'}, result={'message': 'call queued', 'request_uuid':
+    '0a423c29-94ec-42d6-81bb-e8a0d08e0885', 'api_id':
+    'ad34ba9f-24c8-4053-9575-9f8db4618fcd'}, tool_call_id='call_Qee6bOLP')]
+    ===============================================================================
+    '''
 
 
 if __name__ == "__main__":

--- a/examples/toolkits/plivo_toolkit.py
+++ b/examples/toolkits/plivo_toolkit.py
@@ -57,9 +57,7 @@ def main():
     print("\n" + "=" * 50)
     print("Example 3: OTP Verify")
     print("=" * 50)
-    response = agent.step(
-        "Send a verification OTP to +14155550123."
-    )
+    response = agent.step("Send a verification OTP to +14155550123.")
     print(response.msg.content)
     response = agent.step(
         "Verify the code 123456 for that verification session."

--- a/examples/toolkits/plivo_toolkit.py
+++ b/examples/toolkits/plivo_toolkit.py
@@ -74,7 +74,7 @@ def main():
     ===============================================================================
     [ToolCallingRecord(tool_name='send_otp', args={'recipient':
     '+14150000002', 'channel': 'sms'}, result={'session_uuid':
-    '4f2d9b70-8c1a-4d33-9f6e-2a7c1b0e5d84', 'api_request_id':
+    '4f2d9b70-8c1a-4d33-9f6e-2a7c1b0e5d84', 'api_id':
     '1c9e33aa-2f45-4b1d-8a0c-77e2f9d61b52'}, tool_call_id='call_Kp2mVr8Q')]
     ===============================================================================
     '''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,6 +158,7 @@ communication_tools = [
     "notion-client>=2.2.1,<3",
     "praw>=7.7.1,<8",
     "resend>=2.0.0,<3",
+    "plivo>=4.61.0,<5",
     "azure-identity>=1.25.1,<2",
     "msgraph-sdk>=1.46.0,<2",
     "msal>=1.34.0,<2"
@@ -373,6 +374,7 @@ all = [
     "agentops>=0.3.21,<0.4",
     "praw>=7.7.1,<8",
     "resend>=2.0.0,<3",
+    "plivo>=4.61.0,<5",
     "azure-identity>=1.25.1,<2",
     "msgraph-sdk>=1.46.0,<2",
     "msal>=1.34.0,<2",
@@ -654,6 +656,7 @@ module = [
     "arxiv2text",
     "praw",
     "resend",
+    "plivo",
     "textblob",
     "tavily-python",
     "scholarly",

--- a/test/toolkits/test_plivo_toolkit.py
+++ b/test/toolkits/test_plivo_toolkit.py
@@ -92,7 +92,40 @@ def test_make_call_success(plivo_toolkit):
         from_="+14150000002",
         to_="+14150000001",
         answer_url="https://example.com/answer",
+        answer_method="POST",
     )
+
+
+def test_make_call_get_method(plivo_toolkit):
+    plivo_toolkit.client.calls.create.return_value = SimpleNamespace(
+        message="call fired", request_uuid="req", api_id="api"
+    )
+
+    plivo_toolkit.make_call(
+        from_number="+14150000002",
+        to_number="+14150000001",
+        answer_url="https://s3.amazonaws.com/static.plivo.com/answer.xml",
+        answer_method="get",
+    )
+
+    plivo_toolkit.client.calls.create.assert_called_once_with(
+        from_="+14150000002",
+        to_="+14150000001",
+        answer_url="https://s3.amazonaws.com/static.plivo.com/answer.xml",
+        answer_method="GET",
+    )
+
+
+def test_make_call_rejects_bad_method(plivo_toolkit):
+    result = plivo_toolkit.make_call(
+        from_number="+14150000002",
+        to_number="+14150000001",
+        answer_url="https://example.com/answer",
+        answer_method="DELETE",
+    )
+
+    assert "GET or POST" in result
+    plivo_toolkit.client.calls.create.assert_not_called()
 
 
 def test_send_otp_success(plivo_toolkit):

--- a/test/toolkits/test_plivo_toolkit.py
+++ b/test/toolkits/test_plivo_toolkit.py
@@ -1,0 +1,194 @@
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from camel.toolkits.plivo_toolkit import PlivoToolkit
+
+
+@pytest.fixture
+def plivo_toolkit():
+    with patch("plivo.RestClient"):
+        return PlivoToolkit(auth_id="test-auth-id", auth_token="test-token")
+
+
+def test_init_missing_credentials(monkeypatch):
+    monkeypatch.delenv("PLIVO_AUTH_ID", raising=False)
+    monkeypatch.delenv("PLIVO_AUTH_TOKEN", raising=False)
+
+    with pytest.raises(ValueError):
+        PlivoToolkit()
+
+
+def test_send_sms_success(plivo_toolkit):
+    plivo_toolkit.client.messages.create.return_value = SimpleNamespace(
+        message="message(s) queued",
+        message_uuid=["5b40a428-bfc7-4daf-9d06-726c558bf3b8"],
+        api_id="948b53a2-3f08-11e7-b6f4-061564b78b75",
+    )
+
+    result = plivo_toolkit.send_sms(
+        from_number="+14150000002",
+        to_number="+14150000001",
+        message="hello",
+    )
+
+    assert result == {
+        "message": "message(s) queued",
+        "message_uuid": ["5b40a428-bfc7-4daf-9d06-726c558bf3b8"],
+        "api_id": "948b53a2-3f08-11e7-b6f4-061564b78b75",
+    }
+    plivo_toolkit.client.messages.create.assert_called_once_with(
+        src="+14150000002",
+        dst="+14150000001",
+        text="hello",
+    )
+
+
+def test_send_sms_failure(plivo_toolkit):
+    plivo_toolkit.client.messages.create.side_effect = Exception("API Error")
+
+    result = plivo_toolkit.send_sms(
+        from_number="+14150000002",
+        to_number="+14150000001",
+        message="hello",
+    )
+
+    assert result == "Failed to send SMS: API Error"
+
+
+def test_make_call_success(plivo_toolkit):
+    plivo_toolkit.client.calls.create.return_value = SimpleNamespace(
+        message="call fired",
+        request_uuid="9834029e-58b6-11e1-b8b7-a5bd0e4e126f",
+        api_id="97ceeb52-58b6-11e1-86da-77300b68f8bb",
+    )
+
+    result = plivo_toolkit.make_call(
+        from_number="+14150000002",
+        to_number="+14150000001",
+        answer_url="https://example.com/answer",
+    )
+
+    assert result == {
+        "message": "call fired",
+        "request_uuid": "9834029e-58b6-11e1-b8b7-a5bd0e4e126f",
+        "api_id": "97ceeb52-58b6-11e1-86da-77300b68f8bb",
+    }
+    plivo_toolkit.client.calls.create.assert_called_once_with(
+        from_="+14150000002",
+        to_="+14150000001",
+        answer_url="https://example.com/answer",
+    )
+
+
+def test_send_otp_success(plivo_toolkit):
+    plivo_toolkit.client.verify_session.create.return_value = SimpleNamespace(
+        session_uuid="adsdafkjadshf123123",
+        api_request_id="c1a2b3d4-0000-1111-2222-333344445555",
+    )
+
+    result = plivo_toolkit.send_otp(recipient="+14150000001")
+
+    assert result == {
+        "session_uuid": "adsdafkjadshf123123",
+        "api_request_id": "c1a2b3d4-0000-1111-2222-333344445555",
+    }
+    plivo_toolkit.client.verify_session.create.assert_called_once_with(
+        recipient="+14150000001",
+        channel="sms",
+    )
+
+
+def test_verify_otp_success(plivo_toolkit):
+    plivo_toolkit.client.verify_session.validate.return_value = (
+        SimpleNamespace(message="session validated successfully.")
+    )
+
+    result = plivo_toolkit.verify_otp(
+        session_uuid="adsdafkjadshf123123", otp="123456"
+    )
+
+    assert result == {
+        "verified": True,
+        "message": "session validated successfully.",
+    }
+    plivo_toolkit.client.verify_session.validate.assert_called_once_with(
+        session_uuid="adsdafkjadshf123123",
+        otp="123456",
+    )
+
+
+def test_verify_otp_wrong_code_not_verified(plivo_toolkit):
+    # A 200 response with a non-success message must NOT be read as verified.
+    plivo_toolkit.client.verify_session.validate.return_value = (
+        SimpleNamespace(message="The passcode entered is incorrect.")
+    )
+
+    result = plivo_toolkit.verify_otp(
+        session_uuid="adsdafkjadshf123123", otp="000000"
+    )
+
+    assert result == {
+        "verified": False,
+        "message": "The passcode entered is incorrect.",
+    }
+
+
+def test_lookup_number_success(plivo_toolkit):
+    plivo_toolkit.client.lookup.get.return_value = SimpleNamespace(
+        api_id="a35a2e7a-fd27-42e6-910c-33382f43240e",
+        phone_number="+14154305555",
+        country=SimpleNamespace(name="United States", iso2="US", iso3="USA"),
+        format=SimpleNamespace(
+            e164="+14154305555",
+            national="(415) 430-5555",
+            international="+1 415-430-5555",
+            rfc3966="tel:+1-415-430-5555",
+        ),
+        carrier=SimpleNamespace(
+            mobile_country_code="310",
+            mobile_network_code="150",
+            name="Cingular Wireless",
+            type="mobile",
+            ported="yes",
+        ),
+        resource_uri="/v1/Number/+14154305555?type=carrier",
+    )
+
+    result = plivo_toolkit.lookup_number(number="+14154305555")
+
+    assert result["phone_number"] == "+14154305555"
+    assert result["country"]["iso2"] == "US"
+    assert result["carrier"]["name"] == "Cingular Wireless"
+    assert result["carrier"]["type"] == "mobile"
+    plivo_toolkit.client.lookup.get.assert_called_once_with("+14154305555")
+
+
+def test_lookup_number_failure(plivo_toolkit):
+    plivo_toolkit.client.lookup.get.side_effect = Exception("Invalid number")
+
+    result = plivo_toolkit.lookup_number(number="not-a-number")
+
+    assert result == "Failed to look up number: Invalid number"
+
+
+def test_get_tools(plivo_toolkit):
+    tools = plivo_toolkit.get_tools()
+
+    assert len(tools) == 5
+    for tool in tools:
+        assert hasattr(tool, "func") and callable(tool.func)

--- a/test/toolkits/test_plivo_toolkit.py
+++ b/test/toolkits/test_plivo_toolkit.py
@@ -33,6 +33,17 @@ def test_init_missing_credentials(monkeypatch):
         PlivoToolkit()
 
 
+def test_init_passes_timeout_to_client():
+    with patch("plivo.RestClient") as rest_client:
+        PlivoToolkit(
+            auth_id="test-auth-id", auth_token="test-token", timeout=10
+        )
+
+    rest_client.assert_called_once_with(
+        auth_id="test-auth-id", auth_token="test-token", timeout=10
+    )
+
+
 def test_send_sms_success(plivo_toolkit):
     plivo_toolkit.client.messages.create.return_value = SimpleNamespace(
         message="message(s) queued",
@@ -131,14 +142,14 @@ def test_make_call_rejects_bad_method(plivo_toolkit):
 def test_send_otp_success(plivo_toolkit):
     plivo_toolkit.client.verify_session.create.return_value = SimpleNamespace(
         session_uuid="adsdafkjadshf123123",
-        api_request_id="c1a2b3d4-0000-1111-2222-333344445555",
+        api_id="c1a2b3d4-0000-1111-2222-333344445555",
     )
 
     result = plivo_toolkit.send_otp(recipient="+14150000001")
 
     assert result == {
         "session_uuid": "adsdafkjadshf123123",
-        "api_request_id": "c1a2b3d4-0000-1111-2222-333344445555",
+        "api_id": "c1a2b3d4-0000-1111-2222-333344445555",
     }
     plivo_toolkit.client.verify_session.create.assert_called_once_with(
         recipient="+14150000001",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10, <3.15"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -1001,6 +1001,7 @@ all = [
     { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pgvector" },
     { name = "playwright" },
+    { name = "plivo" },
     { name = "prance" },
     { name = "praw" },
     { name = "pre-commit" },
@@ -1081,6 +1082,7 @@ communication-tools = [
     { name = "msal" },
     { name = "msgraph-sdk" },
     { name = "notion-client" },
+    { name = "plivo" },
     { name = "praw" },
     { name = "pygithub" },
     { name = "pytelegrambotapi" },
@@ -1613,6 +1615,8 @@ requires-dist = [
     { name = "playwright", marker = "extra == 'all'", specifier = ">=1.50.0" },
     { name = "playwright", marker = "extra == 'owl'", specifier = ">=1.50.0" },
     { name = "playwright", marker = "extra == 'web-tools'", specifier = ">=1.50.0" },
+    { name = "plivo", marker = "extra == 'all'", specifier = ">=4.61.0,<5" },
+    { name = "plivo", marker = "extra == 'communication-tools'", specifier = ">=4.61.0,<5" },
     { name = "prance", marker = "extra == 'all'", specifier = ">=23.6.21.0,<24" },
     { name = "prance", marker = "extra == 'document-tools'", specifier = ">=23.6.21.0,<24" },
     { name = "prance", marker = "extra == 'owl'", specifier = ">=23.6.21.0,<24" },
@@ -7755,7 +7759,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
+    { name = "ptyprocess", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -7859,6 +7863,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/a6/5be4e52b40a9c0c8a073e7c5b0785c05cf5a9ea8f8a7b5b260e32d970342/playwright-1.61.0-py3-none-win32.whl", hash = "sha256:372d55a6f1248fa1dd47599686980cb8fb5bbe6fcda59eab793eb657c11d8a9b", size = 37844841, upload-time = "2026-06-29T10:33:07.361Z" },
     { url = "https://files.pythonhosted.org/packages/6c/fd/2b78036e5fbe9d5f5645bbe08a1eac7160c51243c0093963edbcf67c35d9/playwright-1.61.0-py3-none-win_amd64.whl", hash = "sha256:35c6cc4589a5d00964a59d7b3e59641e0aac0c02f15479a7af77d20f6bc79597", size = 37844846, upload-time = "2026-06-29T10:33:10.637Z" },
     { url = "https://files.pythonhosted.org/packages/27/0d/1b0f3c4ee4eb0514bc805b5c2f9a223e5b6de4f11a926f5235d51d0fc81b/playwright-1.61.0-py3-none-win_arm64.whl", hash = "sha256:e9fcbffcf557a8620fdedd92491eb59a32d18e23d6f3b4f6214b952be324fe51", size = 33955127, upload-time = "2026-06-29T10:33:14.008Z" },
+]
+
+[[package]]
+name = "plivo"
+version = "4.61.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "decorator" },
+    { name = "lxml" },
+    { name = "pyjwt" },
+    { name = "requests" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/1a/19ff2110f5bd4ea35f2340f34ec0f66f0697c66376b58aa1739e39cf1cd9/plivo-4.61.0.tar.gz", hash = "sha256:4fcbc0fdef855c53029f6240424a6c92c78df588f618b168ccbd796a5cf70853", size = 58223, upload-time = "2026-06-12T10:31:48.585Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/0e/9f90f178d5f8f3bb0bafa5ec148bc89882210b92760b2383b895273bad52/plivo-4.61.0-py2.py3-none-any.whl", hash = "sha256:5ec6e3de3b8e594b608398d1f366851a9ff636c12be7366749333bd864588e32", size = 90567, upload-time = "2026-06-12T10:31:47.3Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Related Issue

Closes #4183

### Description

Add `PlivoToolkit(BaseToolkit)` at `camel/toolkits/plivo_toolkit.py`, mirroring the
other vendor-SDK toolkits, so CAMEL agents can reach people over the phone through
[Plivo](https://www.plivo.com). It exposes five FunctionTools:

- `plivo_send_sms` — send an SMS
- `plivo_make_call` — place an outbound call
- `plivo_send_otp` / `plivo_verify_otp` — phone-number verification. The verify step reports success only when Plivo confirms it, so an unverified code is never treated as verified
- `plivo_lookup_number` — carrier and line-type lookup

Credentials via `PLIVO_AUTH_ID` / `PLIVO_AUTH_TOKEN` with `@api_keys_required`. Registered in `camel/toolkits/__init__.py`, `plivo` added to `pyproject.toml` (and `uv.lock`), shipped with an example (`examples/toolkits/plivo_toolkit.py`) and unit tests. All tools are outbound (agent-invoked). Inbound webhooks are out of scope.

### Testing

`test/toolkits/test_plivo_toolkit.py` — 12 unit tests, all passing (Plivo SDK mocked),
covering each tool's success/failure paths, credential validation, the OTP wrong-code
guard, `answer_method` handling, and tool registration:

```
$ pytest test/toolkits/test_plivo_toolkit.py
12 passed
```

Also verified live against a real Plivo account through the toolkit.

**SMS** — delivered (Plivo console message log):

<img src="https://raw.githubusercontent.com/sarveshpatil-plivo/camel/pr-assets/plivo-camel-sms-proof.png" width="820" />

**Number lookup** — Lookup is a query API with no console log, so the returned response is the proof:

```
lookup_number(<number>) → country: India, carrier: Bharat Sanchar Nigam Ltd (BSNL), type: mobile
```

### What is the purpose of this pull request?

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Checklist

- [x] I have read and agree to the AI-Generated Code Policy
- [x] I have linked this PR to an issue
- [x] I have checked if any dependencies need to be added or updated in `pyproject.toml` and run `uv lock`
- [x] I have updated the tests accordingly
- [ ] I have updated the documentation if needed
- [x] I have added examples if this is a new feature
