### PR TITLE
fix: ResponseWordsTerminator.reset() breaks subsequent is_terminated() calls

### DIFF
--- a/camel/terminators/response_terminator.py
+++ b/camel/terminators/response_terminator.py
@@ -125,4 +125,4 @@ class ResponseWordsTerminator(ResponseTerminator):
         r"""Reset the terminator."""
         self._terminated = False
         self._termination_reason = None
-        self._word_count_dict = defaultdict(int)
+        self._word_count_dict = []

--- a/test/terminators/test_response_terminator.py
+++ b/test/terminators/test_response_terminator.py
@@ -61,3 +61,32 @@ def test_response_words_termination(mode):
     termination.reset()
     assert not termination._terminated
     assert termination._termination_reason is None
+
+
+def test_response_words_termination_is_terminated_after_reset():
+    # Regression test for https://github.com/camel-ai/camel/issues/4181
+    # reset() must restore `_word_count_dict` to the same type/shape as
+    # __init__ (a list), not a bare `defaultdict`, or the next
+    # `is_terminated()` call raises AttributeError on `.append()`.
+    words_dict = {"stop": 5}
+    termination = ResponseWordsTerminator(words_dict=words_dict)
+    message = BaseMessage(
+        role_name="user",
+        role_type=RoleType.USER,
+        meta_dict={},
+        content="hello world",
+    )
+
+    terminated, reason = termination.is_terminated([message])
+    assert not terminated
+    assert reason is None
+
+    termination.reset()
+
+    # Must not raise, and must behave identically to a fresh instance.
+    terminated, reason = termination.is_terminated([message])
+    fresh = ResponseWordsTerminator(words_dict=words_dict)
+    fresh_terminated, fresh_reason = fresh.is_terminated([message])
+    assert terminated == fresh_terminated
+    assert reason == fresh_reason
+    assert termination._word_count_dict == fresh._word_count_dict


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Related Issue

Closes #4181

### Description

`ResponseWordsTerminator._word_count_dict` is declared and used as
`List[Dict[str, int]]` (`__init__` sets `[]`; `is_terminated()` calls
`.append()` on it), but `reset()` reassigned it to `defaultdict(int)`
instead. Any code path that calls `.reset()` and then `is_terminated()`
again crashes with `AttributeError: 'collections.defaultdict' object
has no attribute 'append'`.

This is reachable in real flows: `ChatAgent.reset()` calls `.reset()`
on every terminator, and `AgentPool` / `SingleAgentWorker` (workforce
agent pooling) call `agent.reset()` on checkout and checkin — any
pooled or reset agent configured with a `ResponseWordsTerminator`
crashes on its second use.

Fix: `reset()` now mirrors `__init__` and restores `_word_count_dict`
to `[]`, matching its declared type.

Added a regression test (`test_response_words_termination_is_terminated_after_reset`)
that reproduces the crash pre-fix and asserts post-reset behavior is
identical to a fresh instance.

Credit to @chuenchen309 for filing the issue with a clear repro and
one-line fix, and to @ebarkhordar for confirming reachability through
`ChatAgent.reset()` / pooled workforce agents.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Checklist

- [X] I have read and agree to the [AI-Generated Code Policy](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md#ai-generated-code-policy) (**required**)
- [X] I have linked this PR to an issue (**required**)
- [ ] I have checked if any dependencies need to be added or updated in `pyproject.toml` and run `uv lock` (not applicable — no dependency changes)
- [X] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed (not applicable — internal bugfix, no public API/behavior change beyond the crash)
- [ ] I have added examples if this is a new feature (not applicable)

### Test plan

```
pytest test/terminators/ -v
```

```
test/terminators/test_response_terminator.py::test_response_words_termination[TerminationMode.ANY] PASSED
test/terminators/test_response_terminator.py::test_response_words_termination[TerminationMode.ALL] PASSED
test/terminators/test_response_terminator.py::test_response_words_termination_is_terminated_after_reset PASSED
test/terminators/test_token_limit_terminator.py::test_token_limit_termination[5] PASSED
test/terminators/test_token_limit_terminator.py::test_token_limit_termination[10] PASSED

5 passed in 1.57s
```

Revert-proofed locally: reverting the one-line fix reproduces the
exact `AttributeError: 'collections.defaultdict' object has no
attribute 'append'` from the issue, at
`camel/terminators/response_terminator.py:79`, and the new regression
test fails; restoring the fix makes it pass again.

`ruff check` passes on both changed files. `ruff format --check`
flags a pre-existing formatting issue elsewhere in
`response_terminator.py` (lines 116-121, an unrelated multi-line
`raise ValueError(...)`) that also reproduces on `master` before this
change — left untouched to keep this PR minimal.

`test/agents/test_chat_agent.py::test_response_words_termination`
also exercises this terminator end-to-end via `ChatAgent`, but that
module requires `OPENAI_API_KEY` just to import (module-level
`ModelFactory.create` call), so it was not run locally (no API key
available in this environment) — flagging for CI / maintainer to
confirm.

NOTE: Per CONTRIBUTING's AI-Generated Code Policy, PRs must link a
*prior accepted* issue or discussion. As of this draft, issue #4181
has two contributor comments confirming/reproducing the bug but no
maintainer response yet. Please hold this PR until a maintainer has
accepted the issue.
