### PR TITLE
fix: execute unsafe Python expressions only once

### DIFF
--- a/camel/interpreters/internal_python_interpreter.py
+++ b/camel/interpreters/internal_python_interpreter.py
@@ -188,20 +188,17 @@ class InternalPythonInterpreter(BaseInterpreter):
             import contextlib
             import io
 
-            # Try to execute first and capture stdout
             output_buffer = io.StringIO()
+            try:
+                compiled_code = compile(code, "<string>", "eval")
+            except SyntaxError:
+                with contextlib.redirect_stdout(output_buffer):
+                    exec(code, self.action_space)
+                return output_buffer.getvalue()
+
             with contextlib.redirect_stdout(output_buffer):
-                exec(code, self.action_space)
-            result = output_buffer.getvalue()
-
-            # If no output was captured, try to evaluate the code
-            if not result:
-                try:
-                    result = str(eval(code, self.action_space))
-                except (SyntaxError, NameError):
-                    result = ""  # If eval fails, return empty string
-
-            return result
+                result = eval(compiled_code, self.action_space)
+            return output_buffer.getvalue() or str(result)
         else:
             return str(self.execute(code))
 

--- a/test/interpreters/test_python_interpreter.py
+++ b/test/interpreters/test_python_interpreter.py
@@ -362,6 +362,16 @@ def test_unsafe_mode_eval(unsafe_interpreter):
     assert result == "3"
 
 
+def test_unsafe_mode_eval_executes_once(unsafe_interpreter):
+    values = []
+    unsafe_interpreter.update_action_space({"values": values})
+
+    result = unsafe_interpreter.run("values.append(1)", code_type="python")
+
+    assert result == "None"
+    assert values == [1]
+
+
 def test_unsafe_mode_exec(unsafe_interpreter):
     # Test print statement
     result = unsafe_interpreter.run("print('hello world')", code_type="python")


### PR DESCRIPTION
### Related Issue

Closes #4180

### Description

`InternalPythonInterpreter` currently executes non-printing expressions
once with `exec()` and again with `eval()` in unsafe mode, duplicating
their side effects.

This change determines whether the input is an expression before executing
it, so each input runs exactly once. It also adds a regression test for a
side-effecting expression.

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Checklist

- [ ] I have read and agree to the [AI-Generated Code Policy](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md#ai-generated-code-policy) (**required**)
- [x] I have linked this PR to an issue (**required**)
- [x] I have checked if any dependencies need to be added or updated in `pyproject.toml` and run `uv lock`
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [x] I have updated the documentation if needed
- [ ] I have added examples if this is a new feature

### Test evidence

```text
.venv/bin/python -m pytest -q test/interpreters/test_python_interpreter.py
31 passed

PATH="$PWD/.venv/bin:$PATH" .venv/bin/pre-commit run --files \
  camel/interpreters/internal_python_interpreter.py \
  test/interpreters/test_python_interpreter.py
All hooks passed
```
