### PR TITLE
fix(utils): bind async wrappers to the correct sync functions

### DIFF
--- a/camel/utils/async_func.py
+++ b/camel/utils/async_func.py
@@ -29,14 +29,19 @@ def sync_funcs_to_async(funcs: list[FunctionTool]) -> list[FunctionTool]:
         list[FunctionTool]: List of Python asynchronous functions
             in the :obj:`FunctionTool` format.
     """
+
+    def _create_async_callable(sync_func):
+        async def async_callable(*args, **kwargs):
+            return await asyncio.to_thread(sync_func, *args, **kwargs)
+
+        return async_callable
+
     async_funcs = []
     for func in funcs:
-        sync_func = func.func
-
-        async def async_callable(*args, **kwargs):
-            return await asyncio.to_thread(sync_func, *args, **kwargs)  # noqa: B023
-
         async_funcs.append(
-            FunctionTool(async_callable, deepcopy(func.openai_tool_schema))
+            FunctionTool(
+                _create_async_callable(func.func),
+                deepcopy(func.openai_tool_schema),
+            )
         )
     return async_funcs

--- a/test/utils/test_async_func.py
+++ b/test/utils/test_async_func.py
@@ -1,0 +1,37 @@
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+import pytest
+
+from camel.toolkits import FunctionTool
+from camel.utils.async_func import sync_funcs_to_async
+
+
+@pytest.mark.asyncio
+async def test_sync_funcs_to_async_binds_each_function():
+    def add(a: int, b: int) -> int:
+        r"""Add two integers."""
+        return a + b
+
+    def multiply(a: int, b: int) -> int:
+        r"""Multiply two integers."""
+        return a * b
+
+    add_tool, multiply_tool = sync_funcs_to_async(
+        [FunctionTool(add), FunctionTool(multiply)]
+    )
+
+    assert await add_tool.func(3, 4) == 7
+    assert await multiply_tool.func(3, 4) == 12
+    assert add_tool.get_function_name() == "add"
+    assert multiply_tool.get_function_name() == "multiply"


### PR DESCRIPTION
### Related Issue

Closes #4182

### Description

`sync_funcs_to_async()` currently creates wrappers that share the loop's
late-bound `sync_func`. When multiple functions are converted, every wrapper
therefore calls the final function in the list even though its tool schema
still identifies the original function.

This change creates each wrapper through a small factory so it receives an
independent binding to the correct synchronous function. It also adds a
network-free regression test with two functions that runs in the fast test
suite.

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Checklist

- [ ] I have read and agree to the [AI-Generated Code Policy](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md#ai-generated-code-policy) (**required**)
- [x] I have linked this PR to an issue (**required**)
- [x] I have checked if any dependencies need to be added or updated in `pyproject.toml` and run `uv lock`
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [x] I have updated the documentation if needed
- [ ] I have added examples if this is a new feature

### Test evidence

```text
.venv/bin/python -m pytest -q test/utils/test_async_func.py
1 passed

.venv/bin/python -m pytest -q --fast-test-mode test/utils/test_async_func.py
1 passed

PATH="$PWD/.venv/bin:$PATH" .venv/bin/pre-commit run --files \
  camel/utils/async_func.py \
  test/utils/test_async_func.py
All hooks passed
```

Manual verification with `add`, `multiply`, and `subtract` produced:

```text
direct_results: [7, 12, -1]
async_call_results: [7, 12, -1]
schema_names: ['add', 'multiply', 'subtract']
```
