### PR TITLE
fix(agents): isolate response terminators when cloning ChatAgent

### DIFF
--- a/camel/agents/chat_agent.py
+++ b/camel/agents/chat_agent.py
@@ -17,6 +17,7 @@ import asyncio
 import atexit
 import base64
 import concurrent.futures
+import copy
 import functools
 import hashlib
 import inspect
@@ -6229,7 +6230,7 @@ class ChatAgent(BaseAgent):
             external_tools=[
                 schema for schema in self._external_tool_schemas.values()
             ],
-            response_terminators=self.response_terminators,
+            response_terminators=copy.deepcopy(self.response_terminators),
             scheduling_strategy=(
                 self.model_backend.scheduling_strategy.__name__
             ),

--- a/test/agents/test_chat_agent_clone.py
+++ b/test/agents/test_chat_agent_clone.py
@@ -1,0 +1,80 @@
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+from camel.agents import ChatAgent
+from camel.messages import BaseMessage
+from camel.models import StubModel
+from camel.terminators import ResponseWordsTerminator
+from camel.types import ModelType
+
+
+def _make_agent() -> ChatAgent:
+    return ChatAgent(
+        model=StubModel(ModelType.STUB),
+        response_terminators=[ResponseWordsTerminator(words_dict={"stop": 2})],
+    )
+
+
+def _stop_response():
+    return [
+        BaseMessage.make_assistant_message(
+            role_name="assistant",
+            content="stop",
+        )
+    ]
+
+
+def test_clone_response_terminators_have_independent_identity():
+    source = _make_agent()
+    first = source.clone()
+    second = source.clone()
+
+    assert first.response_terminators is not source.response_terminators
+    assert second.response_terminators is not source.response_terminators
+    assert first.response_terminators is not second.response_terminators
+    assert first.response_terminators[0] is not source.response_terminators[0]
+    assert second.response_terminators[0] is not source.response_terminators[0]
+    assert first.response_terminators[0] is not second.response_terminators[0]
+
+
+def test_clone_response_terminator_counts_are_independent():
+    source = _make_agent()
+    first = source.clone()
+    second = source.clone()
+
+    assert first.response_terminators[0].is_terminated(_stop_response()) == (
+        False,
+        None,
+    )
+    assert second.response_terminators[0].is_terminated(_stop_response()) == (
+        False,
+        None,
+    )
+
+
+def test_resetting_clone_does_not_reset_another_clone_terminator():
+    source = _make_agent()
+    first = source.clone()
+    second = source.clone()
+
+    assert first.response_terminators[0].is_terminated(_stop_response()) == (
+        False,
+        None,
+    )
+    second.reset()
+
+    terminated, reason = first.response_terminators[0].is_terminated(
+        _stop_response()
+    )
+    assert terminated
+    assert reason is not None


### PR DESCRIPTION
### Related Issue

Fixes #4198.

Related to #3951 and #3950.

### Description

`ChatAgent.clone()` passed its `response_terminators` list directly to the
new agent. This caused the source agent and all clones, including pooled
workers, to share accumulated counts, termination state, and resets.

This change deep-copies the complete response terminator list at the clone
boundary so each agent owns independent mutable state. Copying the complete
list also preserves any alias relationships inside that list.

The fix is intentionally limited to `ChatAgent.clone()`:

- no `AgentPool` changes;
- no changes to terminator reset semantics;
- no unrelated clone, callback, or context changes.

The copied terminators retain their state at clone time; this PR only
enforces isolation after cloning. Custom response terminators containing
non-copyable resources can customize Python's standard `__deepcopy__`
protocol.

Regression tests verify that:

- cloned terminator lists and instances are independent;
- counts do not accumulate across clones;
- resetting one clone does not clear another clone's progress.

This extracts the response-terminator isolation portion of #3950 into a
focused bug fix.

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Checklist

- [x] I have read and agree to the
  [AI-Generated Code Policy](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md#ai-generated-code-policy).
- [x] I have linked this PR to an issue.
- [x] I checked dependency impact; no dependency or lockfile changes are
  required.
- [x] I have updated the tests accordingly.
- [x] Documentation changes are not required for this internal bug fix.
- [x] Examples are not required for this bug fix.

### Test plan

```text
$ python -m pytest test/agents/test_chat_agent_clone.py \
    test/terminators/test_response_terminator.py -q
......                                                                   [100%]
6 passed, 1 warning in 1.19s

$ ruff check camel/agents/chat_agent.py \
    test/agents/test_chat_agent_clone.py
All checks passed!

$ ruff format --check camel/agents/chat_agent.py \
    test/agents/test_chat_agent_clone.py
2 files already formatted
```

The remaining file-level pre-commit hooks also passed. The repository-wide
mypy hook could not be completed in the local isolated environment because
optional dependency modules and stubs were unavailable; GitHub CI remains
the authoritative full-environment check.
