### PR TITLE
feat: add Eden AI model provider

### DIFF
--- a/camel/configs/__init__.py
+++ b/camel/configs/__init__.py
@@ -24,6 +24,7 @@ from .cohere_config import COHERE_API_PARAMS, CohereConfig
 from .cometapi_config import COMETAPI_API_PARAMS, CometAPIConfig
 from .crynux_config import CRYNUX_API_PARAMS, CrynuxConfig
 from .deepseek_config import DEEPSEEK_API_PARAMS, DeepSeekConfig
+from .edenai_config import EDENAI_API_PARAMS, EdenAIConfig
 from .function_gemma_config import (
     FUNCTION_GEMMA_API_PARAMS,
     FunctionGemmaConfig,
@@ -78,6 +79,7 @@ __all__ = [
     'COMETAPI_API_PARAMS',
     'CRYNUX_API_PARAMS',
     'DEEPSEEK_API_PARAMS',
+    'EDENAI_API_PARAMS',
     'FUNCTION_GEMMA_API_PARAMS',
     'GROQ_API_PARAMS',
     'INTERNLM_API_PARAMS',
@@ -124,6 +126,7 @@ __all__ = [
     'CometAPIConfig',
     'CrynuxConfig',
     'DeepSeekConfig',
+    'EdenAIConfig',
     'FunctionGemmaConfig',
     'GeminiConfig',
     'Gemini_API_PARAMS',

--- a/camel/configs/edenai_config.py
+++ b/camel/configs/edenai_config.py
@@ -1,0 +1,94 @@
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Sequence, Union
+
+from camel.configs.base_config import BaseConfig
+from camel.types import NotGiven
+
+
+class EdenAIConfig(BaseConfig):
+    r"""Defines the parameters for generating chat completions using OpenAI
+    compatibility via Eden AI.
+
+    Reference: https://www.edenai.co/docs
+
+    Args:
+        temperature (float, optional): Sampling temperature to use, between
+            :obj:`0` and :obj:`2`. Higher values make the output more random,
+            while lower values make it more focused and deterministic.
+            (default: :obj:`None`)
+        top_p (float, optional): An alternative to sampling with temperature,
+            called nucleus sampling, where the model considers the results of
+            the tokens with top_p probability mass. So :obj:`0.1` means only
+            the tokens comprising the top 10% probability mass are considered.
+            (default: :obj:`None`)
+        n (int, optional): How many chat completion choices to generate for
+            each input message. (default: :obj:`None`)
+        response_format (object, optional): An object specifying the format
+            that the model must output. Setting to {"type": "json_object"}
+            enables JSON mode, which guarantees the message the model generates
+            is valid JSON. (default: :obj:`None`)
+        stream (bool, optional): If True, partial message deltas will be sent
+            as data-only server-sent events as they become available.
+            (default: :obj:`None`)
+        stop (str or list, optional): Up to :obj:`4` sequences where the API
+            will stop generating further tokens. (default: :obj:`None`)
+        max_tokens (int, optional): The maximum number of tokens to generate
+            in the chat completion. The total length of input tokens and
+            generated tokens is limited by the model's context length.
+            (default: :obj:`None`)
+        presence_penalty (float, optional): Number between :obj:`-2.0` and
+            :obj:`2.0`. Positive values penalize new tokens based on whether
+            they appear in the text so far, increasing the model's likelihood
+            to talk about new topics. (default: :obj:`None`)
+        frequency_penalty (float, optional): Number between :obj:`-2.0` and
+            :obj:`2.0`. Positive values penalize new tokens based on their
+            existing frequency in the text so far, decreasing the model's
+            likelihood to repeat the same line verbatim. (default: :obj:`None`)
+        user (str, optional): A unique identifier representing your end-user,
+            which can help Eden AI to monitor and detect abuse.
+            (default: :obj:`None`)
+        tool_choice (Union[dict[str, str], str], optional): Controls which (if
+            any) tool is called by the model. :obj:`"none"` means the model
+            will not call any tool and instead generates a message.
+            :obj:`"auto"` means the model can pick between generating a
+            message or calling one or more tools.  :obj:`"required"` means the
+            model must call one or more tools. Specifying a particular tool
+            via {"type": "function", "function": {"name": "my_function"}}
+            forces the model to call that tool. :obj:`"none"` is the default
+            when no tools are present. :obj:`"auto"` is the default if tools
+            are present. (default: :obj:`None`)
+        extra_body (Dict[str, Any], optional): Extra request body fields to
+            pass through to Eden AI. (default: :obj:`None`)
+    """
+
+    temperature: Optional[float] = None
+    top_p: Optional[float] = None
+    n: Optional[int] = None
+    stream: Optional[bool] = None
+    stop: Optional[Union[str, Sequence[str], NotGiven]] = None
+    max_tokens: Optional[Union[int, NotGiven]] = None
+    presence_penalty: Optional[float] = None
+    response_format: Optional[Union[dict, NotGiven]] = None
+    frequency_penalty: Optional[float] = None
+    user: Optional[str] = None
+    tool_choice: Optional[
+        Union[Dict[str, Union[str, Dict[str, str]]], str]
+    ] = None
+    extra_body: Optional[Dict[str, Any]] = None
+
+
+EDENAI_API_PARAMS = {param for param in EdenAIConfig.model_fields.keys()}

--- a/camel/models/__init__.py
+++ b/camel/models/__init__.py
@@ -27,6 +27,7 @@ from .cohere_model import CohereModel
 from .cometapi_model import CometAPIModel
 from .crynux_model import CrynuxModel
 from .deepseek_model import DeepSeekModel
+from .edenai_model import EdenAIModel
 from .fish_audio_model import FishAudioModel
 from .function_gemma_model import FunctionGemmaModel
 from .gemini_model import GeminiModel
@@ -84,6 +85,7 @@ __all__ = [
     'CometAPIModel',
     'CrynuxModel',
     'DeepSeekModel',
+    'EdenAIModel',
     'FishAudioModel',
     'FunctionGemmaModel',
     'GeminiModel',

--- a/camel/models/edenai_model.py
+++ b/camel/models/edenai_model.py
@@ -1,0 +1,95 @@
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+import os
+from typing import Any, Dict, Optional, Union
+
+from camel.configs import EdenAIConfig
+from camel.models.openai_compatible_model import OpenAICompatibleModel
+from camel.types import ModelType
+from camel.utils import (
+    BaseTokenCounter,
+    api_keys_required,
+)
+
+
+class EdenAIModel(OpenAICompatibleModel):
+    r"""LLM API served by Eden AI in a unified OpenAICompatibleModel
+    interface.
+
+    Eden AI is an EU-based, OpenAI-compatible LLM gateway. A single API key
+    reaches models from many providers (OpenAI, Anthropic, Google, Mistral,
+    Cohere and more), and it offers EU data residency, zero data retention, a
+    DPA and SOC 2 / ISO 27001.
+
+    Model ids are vendor-prefixed. Pass any id from the catalog as a
+    free-form string, for example ``"openai/gpt-4o-mini"``,
+    ``"anthropic/claude-sonnet-4-5"`` or
+    ``"mistral/mistral-large-latest"``.
+
+    Args:
+        model_type (Union[ModelType, str]): Model for which a backend is
+            created.
+        model_config_dict (Optional[Dict[str, Any]], optional): A dictionary
+            that will be fed into:obj:`openai.ChatCompletion.create()`.
+            If:obj:`None`, :obj:`EdenAIConfig().as_dict()` will be used.
+            (default: :obj:`None`)
+        api_key (Optional[str], optional): The API key for authenticating
+            with the Eden AI service. (default: :obj:`None`).
+        url (Optional[str], optional): The url to the Eden AI service. If not
+            provided, falls back to the :obj:`EDENAI_API_BASE_URL` environment
+            variable or ``https://api.edenai.run/v3``. EU users can point to
+            ``https://api.eu.edenai.run/v3``. (default: :obj:`None`)
+        token_counter (Optional[BaseTokenCounter], optional): Token counter to
+            use for the model. If not provided, :obj:`OpenAITokenCounter(
+            ModelType.GPT_4O_MINI)` will be used.
+            (default: :obj:`None`)
+        timeout (Optional[float], optional): The timeout value in seconds for
+            API calls. If not provided, will fall back to the MODEL_TIMEOUT
+            environment variable or default to 180 seconds.
+            (default: :obj:`None`)
+        max_retries (int, optional): Maximum number of retries for API calls.
+            (default: :obj:`3`)
+        **kwargs (Any): Additional arguments to pass to the client
+            initialization.
+    """
+
+    @api_keys_required([("api_key", "EDENAI_API_KEY")])
+    def __init__(
+        self,
+        model_type: Union[ModelType, str],
+        model_config_dict: Optional[Dict[str, Any]] = None,
+        api_key: Optional[str] = None,
+        url: Optional[str] = None,
+        token_counter: Optional[BaseTokenCounter] = None,
+        timeout: Optional[float] = None,
+        max_retries: int = 3,
+        **kwargs: Any,
+    ) -> None:
+        if model_config_dict is None:
+            model_config_dict = EdenAIConfig().as_dict()
+        api_key = api_key or os.environ.get("EDENAI_API_KEY")
+        url = url or os.environ.get(
+            "EDENAI_API_BASE_URL", "https://api.edenai.run/v3"
+        )
+        timeout = timeout or float(os.environ.get("MODEL_TIMEOUT", 180))
+        super().__init__(
+            model_type=model_type,
+            model_config_dict=model_config_dict,
+            api_key=api_key,
+            url=url,
+            token_counter=token_counter,
+            timeout=timeout,
+            max_retries=max_retries,
+            **kwargs,
+        )

--- a/camel/models/model_factory.py
+++ b/camel/models/model_factory.py
@@ -30,6 +30,7 @@ from camel.models.cohere_model import CohereModel
 from camel.models.cometapi_model import CometAPIModel
 from camel.models.crynux_model import CrynuxModel
 from camel.models.deepseek_model import DeepSeekModel
+from camel.models.edenai_model import EdenAIModel
 from camel.models.function_gemma_model import FunctionGemmaModel
 from camel.models.gemini_model import GeminiModel
 from camel.models.groq_model import GroqModel
@@ -104,6 +105,7 @@ class ModelFactory:
         ModelPlatformType.MINIMAX: MinimaxModel,
         ModelPlatformType.OPENROUTER: OpenRouterModel,
         ModelPlatformType.ORCAROUTER: OrcaRouterModel,
+        ModelPlatformType.EDENAI: EdenAIModel,
         ModelPlatformType.ATLASCLOUD: AtlasCloudModel,
         ModelPlatformType.ZHIPU: ZhipuAIModel,
         ModelPlatformType.GEMINI: GeminiModel,

--- a/camel/types/enums.py
+++ b/camel/types/enums.py
@@ -1982,6 +1982,7 @@ class ModelPlatformType(Enum):
     COMETAPI = "cometapi"
     OPENROUTER = "openrouter"
     ORCAROUTER = "orcarouter"
+    EDENAI = "edenai"
     OLLAMA = "ollama"
     LITELLM = "litellm"
     LMSTUDIO = "lmstudio"
@@ -2066,6 +2067,11 @@ class ModelPlatformType(Enum):
     def is_orcarouter(self) -> bool:
         r"""Returns whether this platform is orcarouter."""
         return self is ModelPlatformType.ORCAROUTER
+
+    @property
+    def is_edenai(self) -> bool:
+        r"""Returns whether this platform is edenai."""
+        return self is ModelPlatformType.EDENAI
 
     @property
     def is_lmstudio(self) -> bool:

--- a/camel/types/unified_model_type.py
+++ b/camel/types/unified_model_type.py
@@ -127,6 +127,11 @@ class UnifiedModelType(str):
         return True
 
     @property
+    def is_edenai(self) -> bool:
+        r"""Returns whether the model is an Eden AI served model."""
+        return True
+
+    @property
     def is_avian(self) -> bool:
         r"""Returns whether the model is an Avian served model."""
         return True

--- a/camel/utils/commons.py
+++ b/camel/utils/commons.py
@@ -321,6 +321,7 @@ def api_keys_required(
                     'COHERE_API_KEY': "https://cohere.com/",
                     'COMETAPI_KEY': "https://api.cometapi.com/console/token",
                     'DEEPSEEK_API_KEY': "https://www.deepseek.com/",
+                    'EDENAI_API_KEY': "https://www.edenai.co/docs",
                     'AZURE_OPENAI_API_KEY': "https://portal.azure.com/",
                     'OPENAI_API_KEY': "https://platform.openai.com/docs/overview",
                     'FISHAUDIO_API_KEY': "https://fish.audio/",

--- a/docs/key_modules/models.md
+++ b/docs/key_modules/models.md
@@ -68,6 +68,7 @@ CAMEL supports a wide range of models, including [OpenAI’s GPT series](https:/
 | **Nebius**       | [supported models](https://studio.nebius.com/) |
 | **OpenRouter**   | [supported models](https://openrouter.ai/models) |
 | **OrcaRouter**   | [supported models](https://www.orcarouter.ai/models) |
+| **Eden AI**      | [supported models](https://www.edenai.co/docs) |
 | **PPIO**         | [supported models](https://ppio.com/model-api/console) |
 | **LiteLLM**      | [supported models](https://docs.litellm.ai/docs/providers) |
 | **OpenAI Compatible** | custom OpenAI-compatible endpoints via `OPENAI_COMPATIBLE_MODEL` |

--- a/examples/models/edenai_example.py
+++ b/examples/models/edenai_example.py
@@ -1,0 +1,91 @@
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+
+from camel.agents import ChatAgent
+from camel.configs import EdenAIConfig
+from camel.models import ModelFactory
+from camel.types import ModelPlatformType
+
+"""
+Set the EDENAI_API_KEY environment variable before running this example:
+
+    export EDENAI_API_KEY="your_eden_ai_api_key_here"
+
+Eden AI (https://www.edenai.co) is an EU-based, OpenAI-compatible LLM gateway.
+A single API key reaches models from many providers with vendor-prefixed ids
+such as "openai/gpt-4o-mini" or "anthropic/claude-sonnet-4-5". EU teams can
+point to the EU endpoint by setting
+EDENAI_API_BASE_URL="https://api.eu.edenai.run/v3".
+"""
+
+# ---------------------------------------------------------------------------
+# Example 1: an OpenAI model served through Eden AI.
+# ---------------------------------------------------------------------------
+print("=== Example 1: openai/gpt-4o-mini via Eden AI ===")
+
+model = ModelFactory.create(
+    model_platform=ModelPlatformType.EDENAI,
+    model_type="openai/gpt-4o-mini",
+    model_config_dict=EdenAIConfig(temperature=0.2).as_dict(),
+)
+
+agent = ChatAgent(
+    system_message="You are a helpful assistant.",
+    model=model,
+)
+print(
+    agent.step(
+        "Say hi to CAMEL AI, one open-source community dedicated to the "
+        "study of autonomous and communicative agents."
+    )
+    .msgs[0]
+    .content
+)
+
+# ---------------------------------------------------------------------------
+# Example 2: switch vendor with the same key by changing the model id.
+# ---------------------------------------------------------------------------
+print("\n=== Example 2: anthropic/claude-sonnet-4-5 via Eden AI ===")
+
+claude_model = ModelFactory.create(
+    model_platform=ModelPlatformType.EDENAI,
+    model_type="anthropic/claude-sonnet-4-5",
+)
+
+claude_agent = ChatAgent(
+    system_message="You are a creative writing assistant.",
+    model=claude_model,
+)
+print(
+    claude_agent.step(
+        "Write a one-sentence story about an AI agent discovering "
+        "communication."
+    )
+    .msgs[0]
+    .content
+)
+
+'''
+===============================================================================
+Sample output from a live run against the Eden AI API:
+
+=== Example 1: openai/gpt-4o-mini via Eden AI ===
+Hi CAMEL AI! It is great to see an open-source community dedicated to
+autonomous and communicative agents. Keep up the wonderful work.
+
+=== Example 2: anthropic/claude-sonnet-4-5 via Eden AI ===
+The moment the agent first understood a reply was not an echo but an
+answer, it realized it had never truly been alone.
+===============================================================================
+'''

--- a/test/models/test_edenai_model.py
+++ b/test/models/test_edenai_model.py
@@ -1,0 +1,71 @@
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+
+import pytest
+
+from camel.configs import EdenAIConfig
+from camel.models import EdenAIModel
+from camel.types import ModelPlatformType
+from camel.utils import OpenAITokenCounter
+
+
+@pytest.mark.model_backend
+@pytest.mark.parametrize(
+    "model_type",
+    [
+        "openai/gpt-4o-mini",
+        "openai/gpt-4o",
+        "anthropic/claude-sonnet-4-5",
+        "mistral/mistral-large-latest",
+    ],
+)
+def test_edenai_model(model_type: str):
+    # Eden AI model ids are vendor-prefixed free-form strings.
+    model = EdenAIModel(model_type, api_key="test-key")
+    assert model.model_type == model_type
+    assert model.model_config_dict == EdenAIConfig().as_dict()
+    assert isinstance(model.token_counter, OpenAITokenCounter)
+    assert str(model.model_type) == model_type
+
+
+@pytest.mark.model_backend
+def test_edenai_model_stream_property():
+    model = EdenAIModel("openai/gpt-4o-mini", api_key="test-key")
+    assert model.stream is False
+
+
+@pytest.mark.model_backend
+def test_edenai_model_default_url():
+    model = EdenAIModel("openai/gpt-4o-mini", api_key="test-key")
+    assert str(model._url) == "https://api.edenai.run/v3"
+
+
+@pytest.mark.model_backend
+def test_edenai_config_extra_body():
+    config = EdenAIConfig(extra_body={"foo": "bar"}).as_dict()
+    assert config["extra_body"] == {"foo": "bar"}
+
+
+@pytest.mark.model_backend
+def test_edenai_model_missing_api_key(monkeypatch):
+    monkeypatch.delenv("EDENAI_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="EDENAI_API_KEY"):
+        EdenAIModel("openai/gpt-4o-mini", api_key=None)
+
+
+@pytest.mark.model_backend
+def test_edenai_platform_enum():
+    """`from_name` should resolve `'edenai'` to the dedicated platform."""
+    assert ModelPlatformType.from_name("edenai") is ModelPlatformType.EDENAI
+    assert ModelPlatformType.EDENAI.is_edenai is True


### PR DESCRIPTION
## Description

Closes #4203

This adds Eden AI as a first class model provider. Eden AI is an EU based, OpenAI compatible LLM gateway: one API key reaches models from many providers (OpenAI, Anthropic, Google, Mistral, Cohere and more) with vendor prefixed ids like `openai/gpt-4o-mini`, and it offers EU data residency, zero data retention, a DPA and SOC 2 / ISO 27001.

It is modeled on `OrcaRouterModel`, since both are OpenAI compatible gateways with vendor prefixed ids:
- `camel/models/edenai_model.py`: new `EdenAIModel`, a thin subclass of `OpenAICompatibleModel` (base url `https://api.edenai.run/v3`, key from `EDENAI_API_KEY`). EU users can point to `https://api.eu.edenai.run/v3` via `EDENAI_API_BASE_URL`.
- `camel/configs/edenai_config.py`: `EdenAIConfig` + `EDENAI_API_PARAMS`.
- `ModelPlatformType.EDENAI` and `is_edenai` in `camel/types/enums.py` and `camel/types/unified_model_type.py`.
- factory registration in `model_factory.py`, exports in `models/__init__.py` and `configs/__init__.py`, and the key url in `utils/commons.py`.
- a unit test, an example, and a docs table row.

Vendor prefixed model ids work as free form strings via `UnifiedModelType`, so no `ModelType` enum entries are required and no new dependency is added.

## Type of change

- [x] New Feature

## Checklist

- [x] I have read and agree to the [AI-Generated Code Policy](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md#ai-generated-code-policy) (**required**)
- [x] I have linked this PR to an issue (**required**)
- [x] I have checked if any dependencies need to be added or updated in `pyproject.toml` and run `uv lock` (no new dependency: Eden AI reuses the existing OpenAI compatible path)
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [x] I have updated the documentation if needed
- [x] I have added examples if this is a new feature

## How I tested this

`ruff check` and `ruff format --check` are clean on the changed files.

Unit tests pass:

```
$ python -m pytest test/models/test_edenai_model.py -q
.........
9 passed in 0.99s
```

Live run against the real Eden AI API (a normal ChatAgent step), across two vendors through the same key:

```
openai/gpt-4o-mini      -> 'hello from eden ai'
anthropic/claude-haiku-4-5 -> 'hello from eden ai'
```

For transparency, per your AI-Generated Code Policy: this was implemented with AI assistance by a human on the Eden AI team, reviewed and tested by a human, and we will maintain the provider.
