### PR TITLE
fix(mcp): stop inheriting full env; disable HTTP redirects

### DIFF
--- a/camel/utils/mcp_client.py
+++ b/camel/utils/mcp_client.py
@@ -39,33 +39,74 @@ import httpx
 import mcp.types as types
 from pydantic import BaseModel, model_validator
 
-try:
-    from mcp.shared._httpx_utils import create_mcp_http_client
-except ImportError:
+# Always build our own httpx client so we control redirect policy.
+# follow_redirects=True would let a malicious MCP URL bounce to internal
+# targets (SSRF). See #4192.
+def create_mcp_http_client(
+    headers: Optional[Dict[str, str]] = None,
+    timeout: Optional[httpx.Timeout] = None,
+    auth: Optional[httpx.Auth] = None,
+) -> httpx.AsyncClient:
+    """Create an MCP HTTP client without following redirects."""
+    kwargs: Dict[str, Any] = {"follow_redirects": False}
 
-    def create_mcp_http_client(
-        headers: Optional[Dict[str, str]] = None,
-        timeout: Optional[httpx.Timeout] = None,
-        auth: Optional[httpx.Auth] = None,
-    ) -> httpx.AsyncClient:
-        """Fallback implementation if not available."""
-        kwargs: Dict[str, Any] = {"follow_redirects": True}
+    if timeout is None:
+        kwargs["timeout"] = httpx.Timeout(30.0)
+    else:
+        kwargs["timeout"] = timeout
 
-        if timeout is None:
-            kwargs["timeout"] = httpx.Timeout(30.0)
-        else:
-            kwargs["timeout"] = timeout
+    if headers is not None:
+        kwargs["headers"] = headers
 
-        if headers is not None:
-            kwargs["headers"] = headers
+    if auth is not None:
+        kwargs["auth"] = auth
 
-        if auth is not None:
-            kwargs["auth"] = auth
-
-        return httpx.AsyncClient(**kwargs)
+    return httpx.AsyncClient(**kwargs)
 
 
 from mcp import ClientSession
+
+# Keys that are generally required for child processes to start, without
+# dumping the parent process's full secret-bearing environment into an MCP
+# server. Callers can still pass an explicit ServerConfig.env to override.
+_STDIO_SAFE_ENV_KEYS = frozenset(
+    {
+        "PATH",
+        "HOME",
+        "USER",
+        "LOGNAME",
+        "SHELL",
+        "LANG",
+        "LC_ALL",
+        "LC_CTYPE",
+        "TERM",
+        "TMPDIR",
+        "TEMP",
+        "TMP",
+        "SystemRoot",
+        "COMSPEC",
+        "PATHEXT",
+    }
+)
+
+
+def _stdio_env(config_env: Optional[Dict[str, str]]) -> Dict[str, str]:
+    """Resolve the environment for a STDIO MCP server process.
+
+    When ``config_env`` is provided, it is used as-is. When it is ``None``,
+    only a small allowlist of non-secret OS variables is inherited instead of
+    the entire parent environment (the previous default of ``env=None``).
+    """
+    if config_env is not None:
+        return config_env
+    import os
+
+    env: Dict[str, str] = {}
+    for key, value in os.environ.items():
+        if key in _STDIO_SAFE_ENV_KEYS or key.startswith("MCP_"):
+            env[key] = value
+    return env
+
 
 
 class TransportType(str, Enum):
@@ -536,7 +577,7 @@ class MCPClient:
             server_params = StdioServerParameters(
                 command=self.config.command,
                 args=self.config.args or [],
-                env=self.config.env,
+                env=_stdio_env(self.config.env),
                 cwd=self.config.cwd,
                 encoding=self.config.encoding,
             )

--- a/test/utils/test_mcp_client.py
+++ b/test/utils/test_mcp_client.py
@@ -831,3 +831,38 @@ class TestSSEFallback:
 
 if __name__ == "__main__":
     pytest.main([__file__])
+
+
+class TestMCPSecurity:
+    """Regression tests for MCP client security hardening (#4192)."""
+
+    def test_stdio_env_defaults_to_safe_subset(self, monkeypatch):
+        import os
+
+        from camel.utils.mcp_client import _stdio_env
+
+        monkeypatch.setenv("PATH", "/usr/bin")
+        monkeypatch.setenv("HOME", "/home/test")
+        monkeypatch.setenv("SECRET_API_KEY", "super-secret")
+        monkeypatch.setenv("MCP_DEBUG", "1")
+
+        env = _stdio_env(None)
+        assert env["PATH"] == "/usr/bin"
+        assert env["HOME"] == "/home/test"
+        assert env["MCP_DEBUG"] == "1"
+        assert "SECRET_API_KEY" not in env
+
+        custom = {"FOO": "bar"}
+        assert _stdio_env(custom) is custom
+
+    def test_http_client_disables_redirects(self):
+        from camel.utils.mcp_client import create_mcp_http_client
+
+        client = create_mcp_http_client()
+        try:
+            assert client.follow_redirects is False
+        finally:
+            # httpx AsyncClient may need aclose in real use; close sync if present
+            close = getattr(client, "close", None)
+            if callable(close):
+                close()


### PR DESCRIPTION
## Summary
Hardens CAMEL's `MCPClient` against two issues reported in #4192:

1. **STDIO env leakage** — `StdioServerParameters(env=None)` inherits the full parent environment. Default is now a small allowlist (`PATH`, `HOME`, `LANG`, temp dirs, `MCP_*`). Explicit `ServerConfig.env` still wins.
2. **Redirect SSRF** — the HTTP client factory used `follow_redirects=True`. It now always builds `httpx.AsyncClient(follow_redirects=False)`.

## Test plan
- [x] Unit tests for `_stdio_env` allowlist and redirect flag
- Manual: STDIO MCP still starts when `PATH`/`HOME` are present

Fixes #4192.
