### PR TITLE
fix(models): map Anthropic refusal stop_reason to content_filter

### DIFF
--- a/camel/models/anthropic_model.py
+++ b/camel/models/anthropic_model.py
@@ -705,6 +705,10 @@ class AnthropicModel(BaseModelBackend):
                 finish_reason = "stop"
             elif stop_reason == "tool_use":
                 finish_reason = "tool_calls"
+            elif stop_reason == "refusal":
+                # Anthropic's safety refusal; the OpenAI vocabulary term for
+                # a generation the provider declined on safety grounds.
+                finish_reason = "content_filter"
             else:
                 finish_reason = stop_reason
 
@@ -937,6 +941,11 @@ class AnthropicModel(BaseModelBackend):
                         finish_reason = "stop"
                     elif stop_reason == "tool_use":
                         finish_reason = "tool_calls"
+                    elif stop_reason == "refusal":
+                        # Anthropic's safety refusal; without this branch the
+                        # chunk carries finish_reason=None and message_stop
+                        # coerces it to "stop", hiding the refusal.
+                        finish_reason = "content_filter"
                 # Extract usage info from message_delta
                 if hasattr(chunk, "usage") and chunk.usage:
                     usage = self._extract_usage(chunk.usage)

--- a/test/models/test_anthropic_model.py
+++ b/test/models/test_anthropic_model.py
@@ -561,6 +561,8 @@ def test_convert_anthropic_response_stop_reasons():
         "max_tokens": "length",
         "stop_sequence": "stop",
         "tool_use": "tool_calls",
+        # A safety refusal must map to the OpenAI vocabulary, not leak raw.
+        "refusal": "content_filter",
     }
 
     for anthropic_reason, openai_reason in stop_reason_mapping.items():
@@ -993,6 +995,31 @@ def test_convert_stream_chunk_message_delta_stop():
     )
 
     assert result.choices[0].finish_reason == "stop"
+
+
+def test_convert_stream_chunk_message_delta_refusal():
+    """A streaming safety refusal must surface as content_filter.
+
+    Without the mapping the message_delta chunk carries finish_reason=None
+    and message_stop coerces it to "stop", so the refusal reads as a normal
+    completion.
+    """
+    model = AnthropicModel(
+        ModelType.CLAUDE_HAIKU_4_5,
+        api_key="dummy_api_key",
+    )
+
+    mock_chunk = MagicMock()
+    mock_chunk.type = "message_delta"
+    mock_chunk.delta = MagicMock()
+    mock_chunk.delta.stop_reason = "refusal"
+
+    tool_call_index = {}
+    result = model._convert_anthropic_stream_to_openai_chunk(
+        mock_chunk, "claude-haiku-4-5", tool_call_index
+    )
+
+    assert result.choices[0].finish_reason == "content_filter"
 
 
 def test_convert_stream_chunk_message_stop():


### PR DESCRIPTION
### Related Issue

Closes #4209

### Description

`AnthropicModel` normalizes Anthropic's `stop_reason` to the OpenAI `finish_reason` vocabulary in two hand-written mappings, and neither handled `refusal`. Anthropic 0.89.0 defines:

```python
StopReason = Literal['end_turn', 'max_tokens', 'stop_sequence', 'tool_use', 'pause_turn', 'refusal']
```

`refusal` is the safety-decline reason. Two paths were affected:

- Non-streaming (`_convert_anthropic_to_openai_response`): the `else` branch passed the raw string through, so callers saw `finish_reason='refusal'`, a value outside the OpenAI contract.
- Streaming (`_convert_anthropic_stream_to_openai_chunk`): the `message_delta` branch had no `refusal` case, so `finish_reason` stayed `None` and `message_stop` coerced it to `"stop"`, reporting a safety refusal as a normal completion.

**Fix.** Map `refusal` to `content_filter`, the OpenAI-vocabulary term for a provider-declined generation, in both paths. This follows the same disjoint-vocabulary fix already merged for Cohere (#4202) and the precedent in `aws_bedrock_converse_model._map_stop_reason` / `cohere_model._map_finish_reason`.

**Scope.** `finish_reason` for Anthropic responses is computed only in these two mappings (confirmed by reading both conversion methods); both are updated. `pause_turn`, the other non-OpenAI value in this enum, signals a paused rather than terminal turn and has no direct OpenAI equivalent, so it is left out of scope.

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Proof of testing

Clean `python:3.11-slim` container, camel installed from source at this branch, `anthropic` 0.89.0. `import camel.models.anthropic_model` resolves to the in-tree edited file.

Through the real conversion methods, with `stop_reason='refusal'`:

```
                       before          after
non-streaming          'refusal'       'content_filter'
streaming (delta+stop) 'stop'          'content_filter'
```

Tests (in `test/models/test_anthropic_model.py`):

- `test_convert_anthropic_response_stop_reasons` extended with `refusal -> content_filter` (non-streaming).
- `test_convert_stream_chunk_message_delta_refusal` added (streaming).

Both fail on `master` and pass on this branch. The rest of the file is unchanged: `53 passed` on the branch, with one unrelated pre-existing failure (`test_arun_passes_output_config_tool_choice_and_extra_fields`, which also fails on a pristine `master` checkout, independent of this change). Ruff (`0.7.4`) check and format, and codespell (`2.4.1`), are clean on the two changed files.

### Checklist

- [x] I have read and agree to the [AI-Generated Code Policy](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md#ai-generated-code-policy) (**required**)
- [x] I have linked this PR to an issue (**required**)
- [x] I have checked if any dependencies need to be added or updated in `pyproject.toml` and run `uv lock` (none needed)
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed
- [ ] I have added examples if this is a new feature
