### PR TITLE
fix(models): map Reka finish_reason to the OpenAI vocabulary

### DIFF
--- a/camel/models/reka_model.py
+++ b/camel/models/reka_model.py
@@ -50,6 +50,15 @@ except (ImportError, AttributeError):
     LLMEvent = None
 
 
+_FINISH_REASON_MAP = {
+    "stop": "stop",
+    "length": "length",
+    # Reka's "context" means the context window was exhausted before a
+    # natural stop, the same class of event OpenAI reports as "length".
+    "context": "length",
+}
+
+
 class RekaModel(BaseModelBackend):
     r"""Reka API in a unified OpenAICompatibleModel interface.
 
@@ -119,6 +128,16 @@ class RekaModel(BaseModelBackend):
             **kwargs,
         )
 
+    @staticmethod
+    def _map_finish_reason(reka_reason: str) -> str:
+        r"""Map a Reka finish reason to its OpenAI equivalent."""
+        try:
+            return _FINISH_REASON_MAP[reka_reason]
+        except KeyError as exc:
+            raise ValueError(
+                f"Unknown Reka finish reason: {reka_reason!r}"
+            ) from exc
+
     def _convert_reka_to_openai_response(
         self, response: 'ChatResponse'
     ) -> ChatCompletion:
@@ -131,6 +150,7 @@ class RekaModel(BaseModelBackend):
         Returns:
             ChatCompletion: An OpenAI-compatible chat completion response.
         """
+        reka_finish_reason = response.responses[0].finish_reason
         openai_response = ChatCompletion.construct(
             id=response.id,
             choices=[
@@ -139,8 +159,8 @@ class RekaModel(BaseModelBackend):
                         "role": response.responses[0].message.role,
                         "content": response.responses[0].message.content,
                     },
-                    finish_reason=response.responses[0].finish_reason
-                    if response.responses[0].finish_reason
+                    finish_reason=self._map_finish_reason(reka_finish_reason)
+                    if reka_finish_reason
                     else None,
                 )
             ],

--- a/camel/models/reka_model.py
+++ b/camel/models/reka_model.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, Union
 from pydantic import BaseModel
 
 from camel.configs import RekaConfig
+from camel.logger import get_logger
 from camel.messages import OpenAIMessage
 from camel.models import BaseModelBackend
 from camel.types import ChatCompletion, ModelType
@@ -49,6 +50,7 @@ try:
 except (ImportError, AttributeError):
     LLMEvent = None
 
+logger = get_logger(__name__)
 
 _FINISH_REASON_MAP = {
     "stop": "stop",
@@ -130,13 +132,23 @@ class RekaModel(BaseModelBackend):
 
     @staticmethod
     def _map_finish_reason(reka_reason: str) -> str:
-        r"""Map a Reka finish reason to its OpenAI equivalent."""
+        r"""Map a Reka finish reason to its OpenAI equivalent.
+
+        Reka's SDK types finish_reason as
+        ``Union[Literal["stop", "length", "context"], Any]``, so a future
+        provider value is a normal, successful response rather than a
+        malformed one. An unrecognized reason falls back to "stop" (the
+        OpenAI default for a completed response) instead of raising, and
+        the raw value is logged so the mapping can be extended.
+        """
         try:
             return _FINISH_REASON_MAP[reka_reason]
-        except KeyError as exc:
-            raise ValueError(
-                f"Unknown Reka finish reason: {reka_reason!r}"
-            ) from exc
+        except KeyError:
+            logger.warning(
+                f"Unknown Reka finish reason {reka_reason!r}, "
+                "falling back to 'stop'."
+            )
+            return "stop"
 
     def _convert_reka_to_openai_response(
         self, response: 'ChatResponse'

--- a/test/models/test_reka_model.py
+++ b/test/models/test_reka_model.py
@@ -12,6 +12,8 @@
 # limitations under the License.
 # ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
 
+from types import SimpleNamespace
+
 import pytest
 
 from camel.configs import RekaConfig
@@ -36,3 +38,48 @@ def test_reka_model(model_type: ModelType):
     assert isinstance(model.token_counter, OpenAITokenCounter)
     assert isinstance(model.model_type.value_for_tiktoken, str)
     assert isinstance(model.model_type.token_limit, int)
+
+
+def _mock_reka_response(finish_reason):
+    return SimpleNamespace(
+        id="resp-1",
+        model="reka-core",
+        usage=SimpleNamespace(input_tokens=5, output_tokens=3),
+        responses=[
+            SimpleNamespace(
+                message=SimpleNamespace(role="assistant", content="hi"),
+                finish_reason=finish_reason,
+            )
+        ],
+    )
+
+
+@pytest.mark.parametrize(
+    "reka_reason,expected",
+    [
+        ("stop", "stop"),
+        ("length", "length"),
+        ("context", "length"),
+        (None, None),
+    ],
+)
+def test_convert_reka_to_openai_response_maps_finish_reason(
+    reka_reason, expected
+):
+    r"""Reka's finish_reason values must land in the OpenAI contract.
+
+    Reka's own "context" (context window exhausted) is not a value OpenAI's
+    finish_reason accepts; it must be reported as "length", the closest
+    OpenAI analog for a token/context-budget stop.
+    """
+    model = object.__new__(RekaModel)
+    response = _mock_reka_response(reka_reason)
+
+    result = model._convert_reka_to_openai_response(response)
+
+    assert result.choices[0].finish_reason == expected
+
+
+def test_map_finish_reason_unknown_value_raises():
+    with pytest.raises(ValueError, match="Unknown Reka finish reason"):
+        RekaModel._map_finish_reason("some_new_reason")

--- a/test/models/test_reka_model.py
+++ b/test/models/test_reka_model.py
@@ -80,6 +80,13 @@ def test_convert_reka_to_openai_response_maps_finish_reason(
     assert result.choices[0].finish_reason == expected
 
 
-def test_map_finish_reason_unknown_value_raises():
-    with pytest.raises(ValueError, match="Unknown Reka finish reason"):
-        RekaModel._map_finish_reason("some_new_reason")
+def test_map_finish_reason_unknown_value_falls_back_to_stop(caplog):
+    r"""An unrecognized Reka finish reason is a forward-compat value, not
+    an error: it must not raise, and should fall back to "stop" with the
+    raw value logged.
+    """
+    with caplog.at_level("WARNING"):
+        result = RekaModel._map_finish_reason("some_new_reason")
+
+    assert result == "stop"
+    assert "some_new_reason" in caplog.text


### PR DESCRIPTION
### Related Issue

Closes #4213

### Description

`RekaModel._convert_reka_to_openai_response` assigned Reka's `finish_reason` straight to
the `ChatCompletion` choice. `reka-api` 3.2.0 types the field as
`Union[Literal['stop', 'length', 'context'], Any]`; OpenAI's `Choice.finish_reason` is
`Literal['stop', 'length', 'tool_calls', 'content_filter', 'function_call']`. `'stop'` and
`'length'` already match, but `'context'`, returned when the context window is exhausted,
is off-contract. `ChatCompletion.construct()` skips pydantic validation, so the value
landed silently, with no error and no log line.

**Fix.** A module-level `_FINISH_REASON_MAP` plus a `_map_finish_reason` static method,
mirroring `CohereModel._map_finish_reason` (#4202). `'context'` maps to `'length'`, the
closest OpenAI analog for a token/context-budget stop; `'stop'` and `'length'` map to
themselves. A `finish_reason` outside this set raises `ValueError` (matching the current
`CohereModel._map_finish_reason` behavior for an unrecognized reason) instead of passing
through silently. A response with no `finish_reason` still maps to `None`.

**Scope.** Parsing `reka_model.py` for every `finish_reason=` keyword shows
`_convert_reka_to_openai_response` is the only writer, and both `_run` and `_arun` route
their response through it; `RekaModel` has no separate streaming conversion path (`stream`
is a plain config-flag property, not a second code path that builds a `ChatCompletion`).

**Severity, stated plainly.** This is contract compliance, not a crash. Parsing the whole
`camel` package for every site that reads a `.finish_reason` attribute or does
`.get('finish_reason')` returns 23 hits; none of them branch on the specific string value
for a Reka response; `chat_agent.py`'s five sites either check truthiness (`if
choice.finish_reason:`) or stringify/collect the value for usage reporting
(`finish_reasons` lists). So no camel code path changes behavior today. The value is
still user visible through anything that logs or inspects `finish_reason` directly, and
camel's own config docstrings document the OpenAI vocabulary as the contract (e.g.
`minimax_config.py:50`, `samba_config.py:98`).

### Proof of testing

Clean `python:3.11-slim` container, camel installed from source at this branch,
`reka-api` 3.2.0. `RekaModel._convert_reka_to_openai_response` needs no live API key
since it is a pure response-conversion method, so I exercised it directly via
`object.__new__(RekaModel)`:

```
input='stop'    -> emitted='stop'    (expected 'stop')
input='length'  -> emitted='length'  (expected 'length')
input='context' -> emitted='length'  (expected 'length')
input=None      -> emitted=None      (expected None)
unknown reason raises ValueError as expected
```

Regression tests, `test/models/test_reka_model.py -m "not model_backend"`:

```
on master with the new tests applied: 2 failed, 3 passed
on this branch:                       5 passed
```

The 2 that fail on master are the parametrized `'context'` case and the unknown-value
`ValueError` test (the method does not exist yet on master). The 3 pre-existing
`model_backend` tests need a live `REKA_API_KEY`; I did not run them, matching the
`pytest_package_llm_test` job's own scope for fork PRs (no repository secrets).

Gates run locally on the changed files, all exit 0: `ruff`, `ruff-format`, `mypy
--namespace-packages -p camel.models.reka_model` (clean on the file I touched; the
package-wide run's remaining errors are pre-existing missing-stub issues in unrelated
toolkits, unchanged by this diff), `codespell`, the license header check, trailing
whitespace and end-of-file newline (via `pre-commit run --files`).

### What is the purpose of this pull request?

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Checklist

- [X] I have read and agree to the [AI-Generated Code Policy](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md#ai-generated-code-policy) (**required**)
- [X] I have linked this PR to an issue (**required**)
- [ ] I have checked if any dependencies need to be added or updated in `pyproject.toml` and run `uv lock`
- [X] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed
- [ ] I have added examples if this is a new feature
