### PR TITLE
fix(agents): snapshot streamed usage instead of accumulating it

### DIFF
--- a/camel/agents/chat_agent.py
+++ b/camel/agents/chat_agent.py
@@ -3515,6 +3515,41 @@ class ChatAgent(BaseAgent):
         )
         tracker["total_tokens"] += usage_dict.get("total_tokens") or 0
 
+    def _apply_stream_usage_snapshot(
+        self,
+        request_token_usage: Dict[str, int],
+        step_token_usage: Dict[str, int],
+        usage_dict: Dict[str, Any],
+    ) -> None:
+        r"""Applies a streamed chunk's usage as the request's running
+        total, not an additional delta.
+
+        A `usage` field on a `ChatCompletionChunk` reports the cumulative
+        total for the whole request so far, the same as the `usage` on a
+        non-streamed completion. Most backends attach it once, on the
+        final chunk, so accumulating it works by accident. Some
+        OpenAI-compatible backends attach it to more than one chunk in the
+        same stream (running estimates, heartbeats); accumulating each of
+        those into the tracker sums the same cumulative total several
+        times over. This replaces request_token_usage with the latest
+        snapshot and folds only the resulting delta into step_token_usage,
+        so a request contributes its usage exactly once regardless of how
+        many usage-bearing chunks it emits.
+
+        Args:
+            request_token_usage (Dict[str, int]): The tracker for the
+                current streamed request; reset to the latest snapshot.
+            step_token_usage (Dict[str, int]): The tracker for the whole
+                step, accumulated across requests; advanced by the delta.
+            usage_dict (Dict[str, Any]): The usage dict from the chunk
+                that triggered this update.
+        """
+        for key in ("prompt_tokens", "completion_tokens", "total_tokens"):
+            new_value = usage_dict.get(key) or 0
+            delta = new_value - request_token_usage[key]
+            request_token_usage[key] = new_value
+            step_token_usage[key] += delta
+
     def _emit_request_usage(
         self,
         usage_dict: Dict[str, Any],
@@ -4803,13 +4838,15 @@ class ChatAgent(BaseAgent):
                         self.record_message(final_message)
             if chunk.usage:
                 # Handle final usage chunk, whether or not choices are present.
-                # This happens when stream_options={"include_usage": True}
-                # Update the final usage from this chunk
-                self._update_token_usage_tracker(
-                    request_token_usage, safe_model_dump(chunk.usage)
-                )
-                self._update_token_usage_tracker(
-                    step_token_usage, safe_model_dump(chunk.usage)
+                # This happens when stream_options={"include_usage": True}.
+                # chunk.usage is the request's running total, not a delta:
+                # snapshot it instead of accumulating, so a stream that
+                # attaches usage to more than one chunk does not count the
+                # same total several times over.
+                self._apply_stream_usage_snapshot(
+                    request_token_usage,
+                    step_token_usage,
+                    safe_model_dump(chunk.usage),
                 )
 
                 # Create final response with final usage
@@ -5933,13 +5970,15 @@ class ChatAgent(BaseAgent):
                         self.record_message(final_message)
             if chunk.usage:
                 # Handle final usage chunk, whether or not choices are present.
-                # This happens when stream_options={"include_usage": True}
-                # Update the final usage from this chunk
-                self._update_token_usage_tracker(
-                    request_token_usage, safe_model_dump(chunk.usage)
-                )
-                self._update_token_usage_tracker(
-                    step_token_usage, safe_model_dump(chunk.usage)
+                # This happens when stream_options={"include_usage": True}.
+                # chunk.usage is the request's running total, not a delta:
+                # snapshot it instead of accumulating, so a stream that
+                # attaches usage to more than one chunk does not count the
+                # same total several times over.
+                self._apply_stream_usage_snapshot(
+                    request_token_usage,
+                    step_token_usage,
+                    safe_model_dump(chunk.usage),
                 )
 
                 # Create final response with final usage

--- a/test/agents/test_chat_agent.py
+++ b/test/agents/test_chat_agent.py
@@ -1012,6 +1012,168 @@ async def test_chat_agent_async_stream_on_request_usage_callback():
 
 
 @pytest.mark.model_backend
+def test_chat_agent_stream_usage_not_double_counted_across_usage_chunks():
+    r"""A running usage estimate attached to a mid-stream chunk (no
+    finish_reason yet) followed by the true final usage chunk must not
+    have both counted into the tracked totals: the tracker should reflect
+    the last chunk's usage, not the sum of every usage-bearing chunk."""
+    from openai.types.chat.chat_completion_chunk import (
+        ChatCompletionChunk,
+        ChoiceDelta,
+    )
+    from openai.types.chat.chat_completion_chunk import (
+        Choice as ChunkChoice,
+    )
+
+    model = ModelFactory.create(
+        model_platform=ModelPlatformType.OPENAI,
+        model_type=ModelType.GPT_5_MINI,
+        model_config_dict={"stream": True},
+    )
+
+    chunks = [
+        ChatCompletionChunk(
+            id="mock_stream_running_usage_1",
+            choices=[
+                ChunkChoice(
+                    delta=ChoiceDelta(content="Hello", role="assistant"),
+                    index=0,
+                    finish_reason=None,
+                )
+            ],
+            created=1234567890,
+            model="gpt-5-mini",
+            object="chat.completion.chunk",
+            # Running/partial usage estimate on a non-final chunk, as
+            # some OpenAI-compatible backends emit.
+            usage={
+                "prompt_tokens": 10,
+                "completion_tokens": 1,
+                "total_tokens": 11,
+            },
+        ),
+        ChatCompletionChunk(
+            id="mock_stream_running_usage_1",
+            choices=[
+                ChunkChoice(
+                    delta=ChoiceDelta(content=" world"),
+                    index=0,
+                    finish_reason="stop",
+                )
+            ],
+            created=1234567890,
+            model="gpt-5-mini",
+            object="chat.completion.chunk",
+            usage={
+                "prompt_tokens": 10,
+                "completion_tokens": 3,
+                "total_tokens": 13,
+            },
+        ),
+    ]
+
+    def mock_stream():
+        for chunk in chunks:
+            yield chunk
+
+    model.run = MagicMock(return_value=mock_stream())
+
+    agent = ChatAgent(
+        system_message="You are a helpful assistant.",
+        model=model,
+    )
+
+    responses = list(agent.step("Say hello"))
+    assert len(responses) > 0
+    final_usage = responses[-1].info["usage"]
+    assert final_usage["total_tokens"] == 13
+    assert final_usage["prompt_tokens"] == 10
+    assert final_usage["completion_tokens"] == 3
+
+
+@pytest.mark.model_backend
+@pytest.mark.asyncio
+async def test_chat_agent_async_stream_usage_not_double_counted_across_usage_chunks():  # noqa: E501
+    r"""Async twin of the sync running-usage-chunk regression above."""
+    from typing import AsyncGenerator
+
+    from openai.types.chat.chat_completion_chunk import (
+        ChatCompletionChunk,
+        ChoiceDelta,
+    )
+    from openai.types.chat.chat_completion_chunk import (
+        Choice as ChunkChoice,
+    )
+
+    model = ModelFactory.create(
+        model_platform=ModelPlatformType.OPENAI,
+        model_type=ModelType.GPT_5_MINI,
+        model_config_dict={"stream": True},
+    )
+
+    chunks = [
+        ChatCompletionChunk(
+            id="mock_async_stream_running_usage_1",
+            choices=[
+                ChunkChoice(
+                    delta=ChoiceDelta(content="Hello", role="assistant"),
+                    index=0,
+                    finish_reason=None,
+                )
+            ],
+            created=1234567890,
+            model="gpt-5-mini",
+            object="chat.completion.chunk",
+            usage={
+                "prompt_tokens": 11,
+                "completion_tokens": 1,
+                "total_tokens": 12,
+            },
+        ),
+        ChatCompletionChunk(
+            id="mock_async_stream_running_usage_1",
+            choices=[
+                ChunkChoice(
+                    delta=ChoiceDelta(content=" world"),
+                    index=0,
+                    finish_reason="stop",
+                )
+            ],
+            created=1234567890,
+            model="gpt-5-mini",
+            object="chat.completion.chunk",
+            usage={
+                "prompt_tokens": 11,
+                "completion_tokens": 4,
+                "total_tokens": 15,
+            },
+        ),
+    ]
+
+    async def mock_async_stream() -> AsyncGenerator[ChatCompletionChunk, None]:
+        for chunk in chunks:
+            yield chunk
+
+    model.arun = AsyncMock(return_value=mock_async_stream())
+
+    agent = ChatAgent(
+        system_message="You are a helpful assistant.",
+        model=model,
+    )
+
+    responses = []
+    streaming_response = await agent.astep("Say hello")
+    async for response in streaming_response:
+        responses.append(response)
+
+    assert len(responses) > 0
+    final_usage = responses[-1].info["usage"]
+    assert final_usage["total_tokens"] == 15
+    assert final_usage["prompt_tokens"] == 11
+    assert final_usage["completion_tokens"] == 4
+
+
+@pytest.mark.model_backend
 def test_chat_agent_messages_window():
     system_msg = BaseMessage(
         role_name="assistant",


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Related Issue

Fixes #4217

### Description

`_process_stream_chunks_with_accumulator` (sync) and its async twin
`_aprocess_stream_chunks_with_accumulator` add every `chunk.usage` they see onto
`request_token_usage`/`step_token_usage` with a plain `+=`. That is correct only if `usage`
appears on exactly one chunk per request, which is what OpenAI itself does with
`stream_options={"include_usage": True}`. Several OpenAI-compatible backends camel routes
through this same code path (togetherai, groq, deepseek, siliconflow, and others) attach
`usage` to more than one chunk in the same stream, for example a running estimate mid-stream
plus the real total on the final chunk. Each `usage` value is already the cumulative total
for the whole request, not a delta, so summing two of them silently doubles
`prompt_tokens`/`completion_tokens`/`total_tokens` with no error or log line (issue #4217 has
a minimal repro and a run against `master` showing 20/4/24 instead of 10/3/13).

The fix, `_apply_stream_usage_snapshot`, replaces `request_token_usage` with the latest
`chunk.usage` snapshot instead of adding to it, and folds only the resulting delta into
`step_token_usage`. `step_token_usage` still needs to accumulate correctly across the
tool-calling loop's separate streamed requests within one step, this only removes the
double-count within a single request's own usage chunks.

### What is the purpose of this pull request?

- [x] Bug fix

### How I verified this

Root cause and fix confirmed by execution, in a clean `python:3.11-slim` Docker container
(`pip install -e .` only, no other camel install on the image), against a real
`ChatCompletionChunk`/`ChoiceDelta` stream (not mocks of camel's own code):

- On `master` (`ec48f99`), a two-chunk stream where the first chunk (no `finish_reason` yet)
  and the final chunk both carry `usage` fails the new regression tests:
  `total_tokens` comes back `27`/`24` instead of `15`/`13`.
- On this branch, the same two tests pass: `total_tokens` matches the final chunk's usage.
- `python -m pytest --full-test-mode test/agents/test_chat_agent.py`: same 4 pre-existing
  failures on both `master` and this branch (all live-API calls that 401 without a real
  `OPENAI_API_KEY`, e.g. `test_chat_agent_stream_with_structured_output`), no new failures.
- `ruff check`, `ruff format --check`, `codespell` on the two changed files: clean.
- `mypy --namespace-packages --ignore-missing-imports camel/agents/chat_agent.py`: clean.

I did not run the full `pytest_package` matrix (it needs live provider credentials this
environment does not have), and I have not reproduced the bug against a real
togetherai/groq/deepseek response, only against a synthetic stream shaped the way issue #4217
describes those backends behaving.

### Checklist

- [x] I have read and agree to the AI-Generated Code Policy (required)
- [x] I have linked this PR to an issue (required)
- [ ] I have checked if any dependencies need to be added or updated in `pyproject.toml` and run `uv lock`
- [x] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] I have updated the documentation if needed
- [ ] I have added examples if this is a new feature
