### PR TITLE
fix: block unsafe dunder attribute access in InternalPythonInterpreter

### DIFF
--- a/camel/interpreters/internal_python_interpreter.py
+++ b/camel/interpreters/internal_python_interpreter.py
@@ -474,7 +474,36 @@ class InternalPythonInterpreter(BaseInterpreter):
             keyword.arg: self._execute_ast(keyword.value)
             for keyword in call.keywords
         }
+
+        # Block dunder access laundered through getattr/setattr/vars, which
+        # would otherwise reach the same attributes the ast.Attribute gate
+        # rejects (e.g. getattr(x, "__class__")).
+        self._check_unsafe_reflection(callable_func, args, kwargs)
+
         return callable_func(*args, **kwargs)  # type: ignore[arg-type]
+
+    def _check_unsafe_reflection(
+        self,
+        callable_func: Any,
+        args: List[Any],
+        kwargs: Dict[str, Any],
+    ) -> None:
+        r"""Reject reflective builtins that resolve a blocked dunder
+        attribute at runtime, closing the escape the ``ast.Attribute``
+        gate leaves open.
+        """
+        if callable_func is getattr or callable_func is setattr:
+            # getattr(obj, name[, default]) / setattr(obj, name, value)
+            name = args[1] if len(args) > 1 else kwargs.get("name")
+            if isinstance(name, str) and name in _UNSAFE_ATTRIBUTES:
+                raise InterpreterError(
+                    f"Access to '{name}' is not allowed."
+                )
+        elif callable_func is vars and (args or kwargs):
+            # vars(obj) is equivalent to obj.__dict__, already blocked.
+            raise InterpreterError(
+                "Access to '__dict__' is not allowed."
+            )
 
     def _execute_subscript(self, subscript: ast.Subscript):
         index = self._execute_ast(subscript.slice)

--- a/camel/interpreters/internal_python_interpreter.py
+++ b/camel/interpreters/internal_python_interpreter.py
@@ -24,6 +24,16 @@ from camel.interpreters.base import BaseInterpreter
 from camel.interpreters.interpreter_error import InterpreterError
 
 
+_UNSAFE_ATTRIBUTES = frozenset({
+    "__class__", "__bases__", "__subclasses__", "__mro__",
+    "__init__", "__globals__", "__builtins__", "__code__",
+    "__reduce__", "__reduce_ex__", "__dict__",
+    "__func__", "__self__", "__wrapped__",
+    "gi_frame", "gi_code", "f_globals", "f_locals", "f_builtins",
+    "co_consts", "co_names", "cr_frame", "ag_frame",
+})
+
+
 class InternalPythonInterpreter(BaseInterpreter):
     r"""A customized python interpreter to control the execution of
     LLM-generated codes. The interpreter makes sure the code can only execute
@@ -301,6 +311,10 @@ class InternalPythonInterpreter(BaseInterpreter):
             # and return the new value
             return self._execute_augassign(expression)
         elif isinstance(expression, ast.Attribute):
+            if expression.attr in _UNSAFE_ATTRIBUTES:
+                raise InterpreterError(
+                    f"Access to '{expression.attr}' is not allowed."
+                )
             value = self._execute_ast(expression.value)
             return getattr(value, expression.attr)
         elif isinstance(expression, ast.BinOp):

--- a/test/interpreters/test_python_interpreter.py
+++ b/test/interpreters/test_python_interpreter.py
@@ -445,3 +445,40 @@ def test_not_allow_builtins(
         not_allow_builtins_interpreter.execute(code)
     exec_msg = e.value.args[0]
     assert "The variable `len` is not defined." in exec_msg
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        "(1).__class__",
+        "getattr(1, '__class__')",
+        "getattr(getattr(1, '__class__'), '__subclasses__')()",
+        "getattr(1, '__cla' + 'ss__')",
+        "setattr((1).__class__, 'x', 1)",
+    ],
+)
+def test_block_dunder_access(
+    interpreter: InternalPythonInterpreter, code: str
+):
+    # Dunder access must be blocked whether spelled as attribute syntax
+    # or laundered through getattr/setattr, otherwise the sandbox escape
+    # (__class__ -> __subclasses__ MRO walk) stays reachable.
+    with pytest.raises(InterpreterError) as e:
+        interpreter.execute(code)
+    assert "is not allowed" in e.value.args[0]
+
+
+@pytest.mark.parametrize(
+    "code, expected",
+    [
+        ("getattr('abc', 'upper')()", "ABC"),
+        ("getattr({'a': 1}, 'keys')()", None),
+    ],
+)
+def test_safe_getattr_still_works(
+    interpreter: InternalPythonInterpreter, code: str, expected
+):
+    # Legitimate reflection on non-dunder attributes must keep working.
+    result = interpreter.execute(code)
+    if expected is not None:
+        assert result == expected


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Related Issue

Fixes camel-ai/camel#4224

### Description

Gate MRO-traversal attributes (__class__, __bases__, __subclasses__, __globals__, etc.) in the ast.Attribute handler to prevent sandbox escape via getattr() when unsafe_mode=False.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Checklist

- [X] I have read and agree to the [AI-Generated Code Policy](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md#ai-generated-code-policy) (**required**)
- [X] I have linked this PR to an issue (**required**)
- [X] I have checked if any dependencies need to be added or updated in `pyproject.toml` and run `uv lock`
- [X] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [X] I have updated the documentation if needed
- [X] I have added examples if this is a new feature

If you are unsure about any of these, don't hesitate to ask. We are here to help!
