### PR TITLE
fix(workforce): re-queue tasks moved back by resume_from_task

### DIFF
--- a/camel/societies/workforce/workforce.py
+++ b/camel/societies/workforce/workforce.py
@@ -2520,17 +2520,13 @@ class Workforce(BaseNode):
             logger.warning(f"Task {task_id} not found in pending tasks.")
             return False
 
-        # Move completed tasks that come after the target task back to pending
+        # Tasks that were ahead of the target task get reset and re-queued
+        # alongside it, rather than being dropped from tracking entirely.
         tasks_to_move_back = tasks_list[:target_index]
         remaining_tasks = tasks_list[target_index:]
 
-        # Update pending tasks to start from the target task
-        self._pending_tasks = deque(remaining_tasks)
-
-        # Move previously "completed" tasks that are after target back to
-        # pending and reset their state
+        # Reset state for tasks being moved back to pending
         if tasks_to_move_back:
-            # Reset state for tasks being moved back to pending
             for task in tasks_to_move_back:
                 # Handle all possible task states
                 if task.state in [TaskState.DONE, TaskState.OPEN]:
@@ -2544,6 +2540,11 @@ class Workforce(BaseNode):
                 f"Moving {len(tasks_to_move_back)} tasks back to pending "
                 f"state."
             )
+
+        # Re-queue every task in its original order (moved-back tasks
+        # ahead of the target) so none of them is dropped from both
+        # _pending_tasks and _completed_tasks.
+        self._pending_tasks = deque(tasks_to_move_back + remaining_tasks)
 
         logger.info(f"Ready to resume from task: {task_id}")
         return True

--- a/test/workforce/test_workforce.py
+++ b/test/workforce/test_workforce.py
@@ -344,6 +344,39 @@ def test_workforce_initialization(mock_model, share_memory):
     assert workforce.graceful_shutdown_timeout == 2.0
 
 
+def test_resume_from_task_requeues_tasks_moved_back(mock_model):
+    r"""Tasks ahead of the resume target must stay tracked in
+    _pending_tasks, not vanish from both _pending_tasks and
+    _completed_tasks."""
+    from camel.societies.workforce.workforce import WorkforceState
+
+    coordinator_agent = ChatAgent(
+        "You are a helpful coordinator.", model=mock_model
+    )
+    task_agent = ChatAgent("You are a helpful task planner.", model=mock_model)
+
+    workforce = Workforce(
+        description="Resume Test",
+        coordinator_agent=coordinator_agent,
+        task_agent=task_agent,
+    )
+    workforce._state = WorkforceState.PAUSED
+
+    task_done = Task(content="first", id="1", state=TaskState.DONE)
+    task_target = Task(content="second", id="2", state=TaskState.OPEN)
+    task_after = Task(content="third", id="3", state=TaskState.OPEN)
+    workforce._pending_tasks = deque([task_done, task_target, task_after])
+
+    assert workforce.resume_from_task("2") is True
+
+    pending_ids = [task.id for task in workforce._pending_tasks]
+    completed_ids = [task.id for task in workforce._completed_tasks]
+    assert pending_ids == ["1", "2", "3"]
+    assert completed_ids == []
+    assert task_done.state == TaskState.FAILED
+    assert task_done.result is None
+
+
 def test_shared_memory_operations(
     mock_model, mock_agent, sample_shared_memory
 ):


### PR DESCRIPTION
### Related Issue

Fixes #4227

### Description

`Workforce.resume_from_task` computes `tasks_to_move_back` (the tasks ahead of the resume target) and resets each one's state, but its own comment ("Tasks that were ahead of the target task get reset and re-queued alongside it") did not match what the code did: `self._pending_tasks` was reassigned to `deque(remaining_tasks)` only, so `tasks_to_move_back` was never written back anywhere. Those tasks ended up in neither `_pending_tasks` nor `_completed_tasks`.

`self._pending_tasks` is now built from `tasks_to_move_back + remaining_tasks`, preserving original order with the moved-back tasks ahead of the resume target, after their state reset.

### Verification

Reproduced on unmodified `master` (`ec48f997`) in a clean `python:3.11-slim` Docker container, using a bare `Workforce` instance (`object.__new__`, bypassing `__init__`) seeded with three tasks:

```
resume_from_task returned: True
pending: ['2', '3']
completed: []
```

Task `'1'` (ahead of the resume target `'2'`) is in neither collection. With the fix, same input:

```
resume_from_task returned: True
pending: ['1', '2', '3']
completed: []
```

Added `test_resume_from_task_requeues_tasks_moved_back` to `test/workforce/test_workforce.py`. Ran both ways in the same container:

```
# on unmodified master
1 failed in 2.41s

# on this branch
1 passed in 2.49s
```

Also ran the full `test/workforce/test_workforce.py` file under this repo's own `pytest --fast-test-mode -m "not heavy_dependency"` invocation: 11 passed on this branch vs. 10 on master (the one new test), with the same 8 pre-existing failures on both (missing `OPENAI_API_KEY` and other sandbox-only environment gaps, unrelated to this change).

Clean on the two changed files: `ruff check` (pinned 0.7.4), `ruff format --check`, `mypy --namespace-packages -p camel -p test -p apps` (zero errors attributable to either file; the 95 errors on this tree are all pre-existing `import-not-found` on optional extras not installed here), `codespell`, `gitleaks`.

This fix is local to `resume_from_task`'s own re-queue step; it does not touch the other ~20 call sites that write `_pending_tasks`/`_completed_tasks` elsewhere in this class, which are outside this bug's scope.

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Checklist

- [x] I have read and agree to the [AI-Generated Code Policy](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md#ai-generated-code-policy) (**required**)
- [x] I have linked this PR to an issue (**required**)
- [ ] I have checked if any dependencies need to be added or updated in `pyproject.toml` and run `uv lock`
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed
- [ ] I have added examples if this is a new feature
