### PR TITLE
fix: make PersonaHub.__setitem__ follow the mapping protocol

### DIFF
--- a/camel/personas/persona_hub.py
+++ b/camel/personas/persona_hub.py
@@ -63,13 +63,22 @@ class PersonaHub:
         self.model = model
         self.personas: Dict[uuid.UUID, Persona] = {}
 
-    def __setitem__(self, persona: Persona):
-        r"""Add a persona to the group.
+    def add(self, persona: Persona) -> None:
+        r"""Add a persona to the group, keyed by its own ID.
 
         Args:
             persona (Persona): The persona to add.
         """
         self.personas[persona.id] = persona
+
+    def __setitem__(self, persona_id: uuid.UUID, persona: Persona):
+        r"""Add a persona to the group under the given ID.
+
+        Args:
+            persona_id (uuid.UUID): The ID to store the persona under.
+            persona (Persona): The persona to add.
+        """
+        self.personas[persona_id] = persona
 
     def __delitem__(self, persona_id: uuid.UUID):
         r"""Remove a persona from the group by ID.

--- a/docs/mintlify/reference/camel.personas.persona_hub.mdx
+++ b/docs/mintlify/reference/camel.personas.persona_hub.mdx
@@ -34,18 +34,33 @@ Please refer to the paper for more details: https://arxiv.org/pdf/2406.20094.
 def __init__(self, model: Optional[BaseModelBackend] = None):
 ```
 
+<a id="camel.personas.persona_hub.PersonaHub.add"></a>
+
+### add
+
+```python
+def add(self, persona: Persona):
+```
+
+Add a persona to the group, keyed by its own ID.
+
+**Parameters:**
+
+- **persona** (Persona): The persona to add.
+
 <a id="camel.personas.persona_hub.PersonaHub.__setitem__"></a>
 
 ### __setitem__
 
 ```python
-def __setitem__(self, persona: Persona):
+def __setitem__(self, persona_id: uuid.UUID, persona: Persona):
 ```
 
-Add a persona to the group.
+Add a persona to the group under the given ID.
 
 **Parameters:**
 
+- **persona_id** (uuid.UUID): The ID to store the persona under.
 - **persona** (Persona): The persona to add.
 
 <a id="camel.personas.persona_hub.PersonaHub.__delitem__"></a>

--- a/test/personas/test_persona_generator.py
+++ b/test/personas/test_persona_generator.py
@@ -76,14 +76,39 @@ def test_init(persona_generator: PersonaHub):
     assert len(persona_generator.personas) == 0
 
 
-def test___setitem__(persona_generator: PersonaHub):
+def test_add(persona_generator: PersonaHub):
     persona = Persona(
         name="Test Persona",
         description="Test Description",
     )
-    persona_generator.__setitem__(persona)
+    persona_generator.add(persona)
     assert persona_generator.__len__() == 1
     assert persona_generator.personas[persona.id] == persona
+
+
+def test___setitem__(persona_generator: PersonaHub):
+    r"""Subscript assignment must work, since PersonaHub also implements
+    __getitem__ and __delitem__ and is therefore used as a mapping."""
+    persona = Persona(
+        name="Test Persona",
+        description="Test Description",
+    )
+    persona_generator[persona.id] = persona
+    assert persona_generator.__len__() == 1
+    assert persona_generator[persona.id] == persona
+
+    # A key may differ from persona.id -- the store is keyed by what the
+    # caller passes, mirroring dict semantics.
+    other_id = uuid.uuid4()
+    persona_generator[other_id] = persona
+    assert persona_generator[other_id] == persona
+    assert persona_generator.__len__() == 2
+
+    # Assigning to an existing key replaces rather than duplicates.
+    replacement = Persona(name="Replacement", description="Replacement")
+    persona_generator[other_id] = replacement
+    assert persona_generator[other_id] == replacement
+    assert persona_generator.__len__() == 2
 
 
 def test_remove_persona(persona_generator: PersonaHub):
@@ -95,8 +120,8 @@ def test_remove_persona(persona_generator: PersonaHub):
         name="Test Persona 2",
         description="Test Description 2",
     )
-    persona_generator.__setitem__(persona1)
-    persona_generator.__setitem__(persona2)
+    persona_generator.add(persona1)
+    persona_generator.add(persona2)
 
     persona_generator.__delitem__(persona1.id)
     assert persona_generator.__len__() == 1
@@ -111,7 +136,7 @@ def test_get_persona(persona_generator: PersonaHub):
         name="Test Persona",
         description="Test Description",
     )
-    persona_generator.__setitem__(persona)
+    persona_generator.add(persona)
 
     assert persona_generator.__getitem__(persona.id) == persona
 
@@ -175,8 +200,8 @@ def test_deduplicate(persona_generator: PersonaHub):
         name="Test Persona 2",
         description="Test Description 2",
     )
-    persona_generator.__setitem__(persona1)
-    persona_generator.__setitem__(persona2)
+    persona_generator.add(persona1)
+    persona_generator.add(persona2)
 
     persona_generator.deduplicate(
         embedding_model=OpenAIEmbedding(
@@ -217,8 +242,8 @@ def test_len(persona_generator: PersonaHub):
         name="Test Persona 2",
         description="Test Description 2",
     )
-    persona_generator.__setitem__(persona1)
-    persona_generator.__setitem__(persona2)
+    persona_generator.add(persona1)
+    persona_generator.add(persona2)
 
     assert persona_generator.__len__() == 2
 
@@ -232,8 +257,8 @@ def test_iter(persona_generator: PersonaHub):
         name="Test Persona 2",
         description="Test Description 2",
     )
-    persona_generator.__setitem__(persona1)
-    persona_generator.__setitem__(persona2)
+    persona_generator.add(persona1)
+    persona_generator.add(persona2)
 
     personas = list(persona_generator)
     assert len(personas) == 2
@@ -250,8 +275,8 @@ def test_get_all_personas(persona_generator: PersonaHub):
         name="Test Persona 2",
         description="Test Description 2",
     )
-    persona_generator.__setitem__(persona1)
-    persona_generator.__setitem__(persona2)
+    persona_generator.add(persona1)
+    persona_generator.add(persona2)
 
     all_personas = persona_generator.get_all_personas()
     assert isinstance(all_personas, list)


### PR DESCRIPTION
### Related Issue

Closes #4234

### Description

`PersonaHub.__setitem__` was declared as `def __setitem__(self, persona: Persona)` — a value and no key. Python always calls `__setitem__` with both, so subscript assignment (the only syntax the dunder exists to serve) raised `TypeError` unconditionally:

```
>>> hub[persona.id] = persona
TypeError: PersonaHub.__setitem__() takes 2 positional arguments but 3 were given
```

The class behaves as a mapping in every other respect — `__getitem__(persona_id)`, `__delitem__(persona_id)`, `__len__`, `__iter__` — and both sibling dunders key on the persona ID. So reads, deletes, `len()` and iteration all worked, and only assignment was broken.

**Changes**

- `__setitem__(self, persona_id: uuid.UUID, persona: Persona)` — stores under the given key, consistent with `__getitem__`/`__delitem__`.
- New `add(self, persona)` — keeps the previous keyless behavior (`self.personas[persona.id] = persona`), which is genuinely useful and is where the old body moved to.
- `test/personas/test_persona_generator.py`: the 12 existing `persona_generator.__setitem__(persona)` calls become `persona_generator.add(persona)`, and a new `test___setitem__` exercises real subscript assignment.
- `docs/mintlify/reference/camel.personas.persona_hub.mdx` updated to match.

**Why the test suite did not catch this:** every call site invoked the dunder directly — `persona_generator.__setitem__(persona)` — which bypasses the protocol and happens to match the wrong signature. That is exactly the shape `add()` now serves, so the migration is mechanical.

**Breaking-change note:** changing a dunder's signature is technically breaking for any caller invoking `__setitem__` directly with one argument. `add()` is the drop-in for that call shape. Inside this repo the only such callers were the tests and the generated docs page; `examples/personas/personas_generation.py` only uses `text_to_persona`/`persona_to_persona`, so there are no example changes needed.

I also verified this does not disturb `deduplicate()`: it rebuilds `self.personas` from the existing storage keys rather than from `persona.id`, so a key that differs from `persona.id` stays consistent through deduplication.

### What is the purpose of this pull request?

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Checklist

- [X] I have read and agree to the [AI-Generated Code Policy](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md#ai-generated-code-policy) (**required**)
- [X] I have linked this PR to an issue (**required**)
- [X] I have checked if any dependencies need to be added or updated in `pyproject.toml` and run `uv lock` — no dependency changes
- [X] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [X] I have updated the documentation if needed
- [ ] I have added examples if this is a new feature — n/a, bug fix

---

## Proof of testing

Per the AI-Generated Code Policy, everything below is real output from my machine (Windows 11, Python 3.12.10, camel `0.2.91a5` from source at `ec48f99`).

### 1. Reproduction, before the fix

```
hub[key] = persona  -> TypeError: PersonaHub.__setitem__() takes 2 positional arguments but 3 were given
hub[p.id]           -> KeyError: 'Persona ID not found.'   # nothing was ever stored
```

`ruff` (v0.7.4, the version pinned in `.pre-commit-config.yaml`) flags the cause directly:

```
camel/personas/persona_hub.py:66:9: PLE0302 The special method `__setitem__` expects 3 parameters, 2 were given
```

### 2. After the fix, same script

```
hub[key] = persona  -> OK          (len=1, hub[key].name='Alice')
hub[p.id]           -> 'Alice'
del hub[p.id]       -> OK          (len=0)
hub.add(persona)    -> OK          (len=1)
```

### 3. Test suite

```
$ python -m pytest test/personas/test_persona_generator.py -q
2 failed, 10 passed in 2.26s
```

Baseline on unmodified `master` (same command, changes stashed) is `2 failed, 9 passed` — the same two failures, with my new test added. Those two are `test_deduplicate` and `test_is_similar`, both of which construct a real `OpenAIEmbedding`:

```
ValueError: Missing or empty required API keys in environment variables: OPENAI_API_KEY.
```

They are environment-dependent and unrelated to this change.

The new `test___setitem__` covers three behaviors that were previously untestable through the syntax: assignment under `persona.id`, assignment under a key that differs from `persona.id`, and replacement (not duplication) when assigning to an existing key.

### 4. Lint

```
$ ruff check camel/personas/persona_hub.py test/personas/test_persona_generator.py     # ruff 0.7.4
All checks passed!
$ ruff format --check <same files>
2 files already formatted
$ mypy --namespace-packages camel/personas/persona_hub.py
# no errors reported for camel/personas/*
```

(The full-repo `mypy` invocation from `.pre-commit-config.yaml` reports 87 pre-existing `import-not-found` errors across 51 other files, from optional extras that are not installed here — e.g. `github.MainClass` in `camel/agents/repo_agent.py`. None are in `camel/personas/`.)

---

*AI disclosure: I used an AI coding assistant while investigating and preparing this change. I reviewed the diff line by line, ran every command above myself, and can explain each change and how it interacts with the rest of `PersonaHub` — including why `deduplicate()` is unaffected.*
