### PR TITLE
fix(toolkits): import FastMCP from mcp.server.fastmcp

### DIFF
--- a/camel/toolkits/base.py
+++ b/camel/toolkits/base.py
@@ -20,6 +20,8 @@ from camel.toolkits import FunctionTool
 from camel.utils import AgentOpsMeta, Constants, with_timeout
 
 if TYPE_CHECKING:
+    from mcp.server.fastmcp import FastMCP
+
     from camel.agents import ChatAgent
 
 F = TypeVar('F', bound=Callable)
@@ -65,9 +67,7 @@ class BaseToolkit(metaclass=AgentOpsMeta):
         timeout (Optional[float]): The timeout for the toolkit.
     """
 
-    from mcp.server.fastmcp import FastMCP
-
-    mcp: FastMCP
+    mcp: "FastMCP"
     timeout: Optional[float] = Constants.TIMEOUT_THRESHOLD
 
     def __init__(self, timeout: Optional[float] = Constants.TIMEOUT_THRESHOLD):

--- a/camel/toolkits/base.py
+++ b/camel/toolkits/base.py
@@ -65,7 +65,7 @@ class BaseToolkit(metaclass=AgentOpsMeta):
         timeout (Optional[float]): The timeout for the toolkit.
     """
 
-    from mcp.server import FastMCP
+    from mcp.server.fastmcp import FastMCP
 
     mcp: FastMCP
     timeout: Optional[float] = Constants.TIMEOUT_THRESHOLD

--- a/camel/utils/mcp.py
+++ b/camel/utils/mcp.py
@@ -218,11 +218,11 @@ class MCPServer:
                 `BaseToolkit` subclass,
                 or if a specified method cannot be found or is not callable.
         """
-        from mcp.server.fastmcp import FastMCP
-
         original_init = cls.__init__
 
         def new_init(instance, *args, **kwargs):
+            from mcp.server.fastmcp import FastMCP
+
             from camel.toolkits.base import BaseToolkit
 
             original_init(instance, *args, **kwargs)

--- a/test/utils/test_mcp_server.py
+++ b/test/utils/test_mcp_server.py
@@ -16,7 +16,7 @@ import sys
 from typing import Literal
 
 import pytest
-from mcp.server import FastMCP
+from mcp.server.fastmcp import FastMCP
 
 from camel.toolkits.mcp_toolkit import MCPClient
 from camel.utils import MCPServer


### PR DESCRIPTION
## Summary
`camel/toolkits/base.py` imported `FastMCP` via the stale path `from mcp.server import FastMCP`. The mcp SDK moved `FastMCP` into the `mcp.server.fastmcp` submodule, so the current mcp release raises `ImportError: cannot import name 'FastMCP' from 'mcp.server'` at class-definition time of `BaseToolkit`.

Because `camel.toolkits.base` is imported transitively by `camel.agents` and `camel.societies`, this single broken import cascades into failures of the **`Minimal dependency check`** CI job for essentially every PR (e.g. #4159), even though the change in that PR never touched toolkits.

## Change
- Use `from mcp.server.fastmcp import FastMCP` — the same path already used by `chat_agent.py`, `utils/mcp.py`, `workforce.py`, and `agent_mcp_server.py`.
- Align `test/utils/test_mcp_server.py` to the same path.

This makes `BaseToolkit` (and therefore `camel.agents`/`camel.societies`) importable again under minimal dependencies.

## Test plan
- [ ] `Minimal dependency check` passes.
- [ ] `test/utils/test_mcp_server.py` collects and runs.
- [ ] `pre-commit` / lint clean.