### PR TITLE
fix: RedisStorage sync methods hung or silently no-opped when called from async code

### DIFF
--- a/camel/storages/key_value_storages/redis.py
+++ b/camel/storages/key_value_storages/redis.py
@@ -15,6 +15,7 @@
 import asyncio
 import json
 import logging
+import threading
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from camel.storages.key_value_storages import BaseKeyValueStorage
@@ -58,7 +59,15 @@ class RedisStorage(BaseKeyValueStorage):
         self._client: Optional[aredis.Redis] = None
         self._url = url
         self._sid = sid
-        self._loop = loop or asyncio.get_event_loop()
+        # A loop is no longer captured eagerly. ``asyncio.get_event_loop()``
+        # raises in a thread that has none, and a loop captured at
+        # construction time is the wrong one to wait on if the caller later
+        # runs a different loop on the same thread. When no loop is supplied,
+        # one is created on a background thread on first use instead.
+        self._loop = loop
+        self._owned_loop: Optional[asyncio.AbstractEventLoop] = None
+        self._owned_thread: Optional[threading.Thread] = None
+        self._owned_loop_lock = threading.Lock()
 
         self._create_client(**kwargs)
 
@@ -66,7 +75,14 @@ class RedisStorage(BaseKeyValueStorage):
         return self
 
     def __exit__(self, exc_type, exc, tb):
-        self._run_async(self.close())
+        try:
+            self._run_async(self.close())
+        finally:
+            # The background loop runs on a daemon thread, so leaving it alive
+            # would not block interpreter exit, but a caller who scopes the
+            # storage with ``with`` should not be left with a thread per
+            # instance either.
+            self._close_background_loop()
 
     async def close(self) -> None:
         r"""Closes the Redis client asynchronously."""
@@ -156,9 +172,87 @@ class RedisStorage(BaseKeyValueStorage):
         except Exception as e:
             logger.error(f"Error clearing records: {e}")
 
+    def _background_loop(self) -> asyncio.AbstractEventLoop:
+        r"""Returns this instance's loop, starting it on first use.
+
+        The loop lives on a daemon thread for the lifetime of the storage, so
+        every coroutine runs on the same loop. ``redis.asyncio`` binds its
+        connection pool to the loop that first uses it, so a fresh loop per
+        call would discard the pool and can leave the previous loop's
+        connections unusable.
+        """
+        with self._owned_loop_lock:
+            if self._owned_loop is None or self._owned_loop.is_closed():
+                loop = asyncio.new_event_loop()
+                started = threading.Event()
+
+                def run() -> None:
+                    asyncio.set_event_loop(loop)
+                    loop.call_soon(started.set)
+                    loop.run_forever()
+
+                thread = threading.Thread(
+                    target=run,
+                    name=f"camel-redis-{self._sid}",
+                    daemon=True,
+                )
+                thread.start()
+                # The loop must be confirmed running before it is returned:
+                # a caller that sees ``is_running() is False`` would try to
+                # drive it with ``run_until_complete`` from its own thread.
+                started.wait(timeout=10)
+                self._owned_loop = loop
+                self._owned_thread = thread
+            return self._owned_loop
+
     def _run_async(self, coro):
-        if not self._loop.is_running():
-            return self._loop.run_until_complete(coro)
+        r"""Runs a coroutine from a synchronous caller.
+
+        A caller-supplied loop is used when it can be, so an application that
+        passes its own loop keeps its Redis traffic there. Two situations rule
+        it out, and both used to fail:
+
+        - it is the loop running in *this* thread. ``.result()`` would occupy
+          the very thread that loop needs in order to advance the coroutine,
+          so the call would hang forever.
+        - it is idle while this thread runs some other loop.
+          ``run_until_complete`` refuses to drive a second loop on a thread
+          that is already running one.
+
+        In either case the coroutine goes to the background loop, which runs
+        on a thread of its own and so is never the one being blocked.
+        """
+        try:
+            running_loop: Optional[asyncio.AbstractEventLoop] = (
+                asyncio.get_running_loop()
+            )
+        except RuntimeError:
+            running_loop = None
+
+        supplied = self._loop
+        if (
+            supplied is None
+            or supplied.is_closed()
+            or supplied is running_loop
+            or (running_loop is not None and not supplied.is_running())
+        ):
+            loop = self._background_loop()
         else:
-            future = asyncio.run_coroutine_threadsafe(coro, self._loop)
-            return future.result()
+            loop = supplied
+
+        if loop.is_running():
+            return asyncio.run_coroutine_threadsafe(coro, loop).result()
+        return loop.run_until_complete(coro)
+
+    def _close_background_loop(self) -> None:
+        r"""Stops the background event loop, if one was started."""
+        with self._owned_loop_lock:
+            loop, thread = self._owned_loop, self._owned_thread
+            self._owned_loop, self._owned_thread = None, None
+
+        if loop is None:
+            return
+        loop.call_soon_threadsafe(loop.stop)
+        if thread is not None:
+            thread.join(timeout=5)
+        loop.close()

--- a/test/storages/key_value_storages/test_redis.py
+++ b/test/storages/key_value_storages/test_redis.py
@@ -14,6 +14,7 @@
 
 import asyncio
 import json
+import threading
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -75,3 +76,226 @@ def test_clear(sid, redis_storage, mock_redis_client):
     redis_storage.clear()
 
     mock_redis_client.delete.assert_called_once_with(sid)
+
+
+def _make_storage(sid, client, loop=None):
+    r"""Builds a RedisStorage with a stub client and no real connection.
+
+    ``_create_client`` is patched out rather than pointed at a fake server:
+    what is under test is the sync/async bridging in ``_run_async``, which is
+    upstream of any Redis I/O.
+    """
+    with patch(
+        'camel.storages.key_value_storages.RedisStorage._create_client'
+    ) as create_client_mock:
+        create_client_mock.return_value = None
+        storage = RedisStorage(sid=sid, loop=loop)
+    storage._client = client
+    return storage
+
+
+def _call_from_inside_a_running_loop(fn, *args, **kwargs):
+    r"""Calls ``fn`` from a thread that is *running* an event loop.
+
+    The sync methods have to be invoked on the loop thread itself -- that is
+    what a FastAPI handler or a notebook cell does, and it is the only way to
+    reach the branch that used to hang. Offloading with
+    ``asyncio.to_thread`` would leave the worker with no running loop and
+    would silently exercise the plain ``run_until_complete`` path instead.
+
+    The call runs on a daemon thread with a join timeout, so a regression
+    that hangs fails the test rather than stalling the suite: ``_run_async``
+    waits on ``future.result()`` with no timeout at all, so nothing else
+    would ever end the wait.
+    """
+    outcome = {}
+
+    def target():
+        async def main():
+            try:
+                outcome["value"] = fn(*args, **kwargs)
+            except BaseException as exc:
+                outcome["error"] = exc
+
+        asyncio.run(main())
+
+    thread = threading.Thread(target=target, daemon=True)
+    thread.start()
+    thread.join(timeout=30)
+
+    assert not thread.is_alive(), (
+        "the call never returned: the coroutine is waiting on a loop that "
+        "this thread is blocking"
+    )
+    if "error" in outcome:
+        raise outcome["error"]
+    return outcome["value"]
+
+
+def test_constructing_in_a_thread_without_a_loop(sid, mock_redis_client):
+    r"""Construction must not require the calling thread to have a loop.
+
+    ``asyncio.get_event_loop()`` raises ``RuntimeError`` in a thread that has
+    no loop, so building a ``RedisStorage`` from a worker thread failed
+    outright.
+    """
+    outcome = {}
+
+    def target():
+        try:
+            storage = _make_storage(sid, mock_redis_client)
+            outcome["value"] = storage.load()
+        except BaseException as exc:
+            outcome["error"] = exc
+
+    thread = threading.Thread(target=target, daemon=True)
+    thread.start()
+    thread.join(timeout=30)
+
+    assert not thread.is_alive()
+    assert "error" not in outcome, outcome.get("error")
+    assert outcome["value"] == []
+
+
+def test_save_and_load_inside_a_running_loop(sid, mock_redis_client):
+    r"""The regression: sync methods called while a loop runs on this thread.
+
+    ``_run_async`` handed the coroutine to the caller's own loop and then
+    blocked on ``future.result()`` with no timeout. The loop cannot advance a
+    coroutine while the thread it runs on is blocked, so the call hung
+    forever.
+    """
+    records = [{"key1": "value1"}]
+    mock_redis_client.get.return_value = json.dumps(records)
+    storage = _make_storage(sid, mock_redis_client)
+
+    def exercise():
+        storage.save(records)
+        return storage.load()
+
+    assert _call_from_inside_a_running_loop(exercise) == records
+    mock_redis_client.set.assert_called_once_with(sid, json.dumps(records))
+
+
+def test_supplied_idle_loop_is_not_driven_from_an_async_thread(
+    sid, mock_redis_client
+):
+    r"""A caller-supplied loop that is idle must not be run re-entrantly.
+
+    Even when the supplied loop is *not* the one running here,
+    ``run_until_complete`` refuses to drive it from a thread that is already
+    running another loop, raising "Cannot run the event loop while another
+    loop is running". This is the failure mode of the common shape where a
+    storage is built at import time and used from async code later.
+
+    The assertion is on ``_run_async`` directly rather than on ``load()``:
+    ``load()`` catches every exception and returns ``[]``, so an assertion on
+    its result cannot distinguish "the load worked and the store was empty"
+    from "the bridge raised and the error was swallowed" -- which is also why
+    this bug can surface as silent data loss rather than as a traceback.
+    """
+    idle_loop = asyncio.new_event_loop()
+
+    async def probe():
+        return "done"
+
+    try:
+        storage = _make_storage(sid, mock_redis_client, loop=idle_loop)
+        assert (
+            _call_from_inside_a_running_loop(storage._run_async, probe())
+            == "done"
+        )
+    finally:
+        idle_loop.close()
+
+
+def test_coroutine_does_not_run_on_the_callers_loop(sid, mock_redis_client):
+    r"""The coroutine must run on a loop other than the one being blocked.
+
+    Scheduling it on the caller's loop is the cause of the hang, so the
+    property is asserted directly rather than inferred from the absence of a
+    timeout.
+    """
+    storage = _make_storage(sid, mock_redis_client)
+    seen = []
+
+    async def probe():
+        seen.append(asyncio.get_running_loop())
+        return "done"
+
+    def exercise():
+        caller_loop = asyncio.get_running_loop()
+        assert storage._run_async(probe()) == "done"
+        return caller_loop
+
+    caller_loop = _call_from_inside_a_running_loop(exercise)
+
+    assert seen and seen[0] is not caller_loop
+
+
+def test_supplied_running_loop_is_still_used_from_another_thread(
+    sid, mock_redis_client
+):
+    r"""A supplied loop running elsewhere is used, not bypassed.
+
+    This is the case ``run_coroutine_threadsafe`` is actually for, and the
+    only one the original code got right, so the fix must not regress it: an
+    application that hands in its own loop should keep its Redis traffic
+    there.
+    """
+    other_loop = asyncio.new_event_loop()
+    ready = threading.Event()
+
+    def run():
+        asyncio.set_event_loop(other_loop)
+        other_loop.call_soon(ready.set)
+        other_loop.run_forever()
+
+    thread = threading.Thread(target=run, daemon=True)
+    thread.start()
+    assert ready.wait(timeout=10)
+
+    try:
+        storage = _make_storage(sid, mock_redis_client, loop=other_loop)
+        seen = []
+
+        async def probe():
+            seen.append(asyncio.get_running_loop())
+            return "done"
+
+        assert storage._run_async(probe()) == "done"
+        assert seen == [other_loop]
+    finally:
+        other_loop.call_soon_threadsafe(other_loop.stop)
+        thread.join(timeout=10)
+        other_loop.close()
+
+
+def test_exceptions_propagate_from_inside_a_running_loop(
+    sid, mock_redis_client
+):
+    r"""A failure in the coroutine must reach the synchronous caller."""
+    storage = _make_storage(sid, mock_redis_client)
+
+    async def boom():
+        raise RuntimeError("coroutine failed")
+
+    def exercise():
+        return storage._run_async(boom())
+
+    with pytest.raises(RuntimeError, match="coroutine failed"):
+        _call_from_inside_a_running_loop(exercise)
+
+
+def test_context_manager_stops_the_background_loop(sid, mock_redis_client):
+    r"""Leaving the ``with`` block must not leave a thread per instance."""
+    storage = _make_storage(sid, mock_redis_client)
+
+    with storage:
+        assert storage.load() == []
+        loop = storage._owned_loop
+        assert loop is not None and loop.is_running()
+
+    assert storage._owned_loop is None
+    assert loop.is_closed()
+    mock_redis_client.close.assert_awaited_once()


### PR DESCRIPTION
## Description

`RedisStorage`'s synchronous `save()` / `load()` / `clear()` all funnel through `_run_async`, which could not bridge to async code in any of three ways — one of them a permanent hang, one of them a silent no-op.

Fixes #4241

## Root cause

`camel/storages/key_value_storages/redis.py:159-164` and `:61` on `master` (`ec48f99`):

```python
self._loop = loop or asyncio.get_event_loop()   # __init__

def _run_async(self, coro):
    if not self._loop.is_running():
        return self._loop.run_until_complete(coro)
    else:
        future = asyncio.run_coroutine_threadsafe(coro, self._loop)
        return future.result()
```

| # | situation | result on `master` |
| --- | --- | --- |
| 1 | constructed in a thread with no loop | `RuntimeError: There is no current event loop in thread '...'` — construction fails outright |
| 2 | captured loop is the loop running in *this* thread | **hangs forever.** `.result()` occupies the thread the loop needs to advance the coroutine, and there is no timeout |
| 3 | captured loop is idle while this thread runs another loop | `RuntimeError: Cannot run the event loop while another loop is running` |

`run_coroutine_threadsafe` is documented as being for a loop running in a **different** thread. Here the loop came from `asyncio.get_event_loop()` on this thread, so case 2 inverts the precondition.

Case 3 is the most damaging in practice, because the three public methods catch everything:

```python
def load(self):
    try:
        return self._run_async(self._async_load())
    except Exception as e:
        logger.error(f"Error in load: {e}")
        return []
```

A save silently writes nothing and a load silently returns `[]`. The caller observes an empty store, not an error.

Case 3 is also the shape of the most natural usage: build the storage once (at import, or in an `__init__`), then use it from async code later.

## The change

- **No loop is captured at construction.** `self._loop` holds only what the caller passed, so building a `RedisStorage` no longer depends on the calling thread having a loop.
- **A caller-supplied loop is still used whenever it can be**, so an application that passes its own loop keeps its Redis traffic there. That case is the *only* one the old code got right, and it is pinned by a test so this PR cannot regress it.
- **Otherwise the coroutine runs on a background loop owned by the instance**, on a daemon thread — never the thread being blocked:

```python
try:
    running_loop = asyncio.get_running_loop()
except RuntimeError:
    running_loop = None

supplied = self._loop
if (
    supplied is None
    or supplied.is_closed()
    or supplied is running_loop
    or (running_loop is not None and not supplied.is_running())
):
    loop = self._background_loop()
else:
    loop = supplied

if loop.is_running():
    return asyncio.run_coroutine_threadsafe(coro, loop).result()
return loop.run_until_complete(coro)
```

Three details that are deliberate rather than incidental:

- **A persistent loop, not `asyncio.run` per call.** `redis.asyncio` binds its connection pool to the loop that first uses it. A fresh loop each call would discard the pool and can leave the previous loop's connections unusable — so the shape used for `MCPAgent.step` in #4240 (a per-call `ThreadPoolExecutor` + `asyncio.run`) is wrong here. This follows `FunctionTool._run_async_in_persistent_loop` (`camel/toolkits/function_tool.py:698`) instead, which keeps a loop alive for exactly this reason.
- **Loop start-up is synchronised on a `threading.Event`.** After `thread.start()` the loop is not yet running, so a caller that saw `is_running() is False` would fall through to `run_until_complete` and try to drive another thread's loop.
- **`__exit__` stops the background loop** in a `finally`, so scoping the storage with `with` does not leave a thread per instance. The thread is a daemon, so this is tidiness rather than a leak that would block interpreter exit.

Deliberately *not* changed: the `except Exception` swallowing in `save`/`load`/`clear`. It made this bug much harder to notice, and arguably a failed save should not return quietly — but that is a separate behavioural decision about the public API, and changing it here would mix an error-reporting change into a fix. Happy to follow up if you'd like it.

## Tests

`test/storages/key_value_storages/test_redis.py` covered only the happy path with a loop the test supplies itself (`RedisStorage(sid=sid, loop=asyncio.get_event_loop())`) — no test called the sync methods with a loop running on the calling thread, which is why none of the three failures was caught. Seven tests added:

| test | asserts |
| --- | --- |
| `test_constructing_in_a_thread_without_a_loop` | **case 1**: construction and use from a worker thread with no loop |
| `test_save_and_load_inside_a_running_loop` | **case 2, the headline regression**: `save` then `load` from inside a running loop round-trips the records |
| `test_supplied_idle_loop_is_not_driven_from_an_async_thread` | **case 3**: an idle supplied loop is not driven re-entrantly from an async thread |
| `test_coroutine_does_not_run_on_the_callers_loop` | the coroutine runs on a loop that is *not* the caller's — the property whose absence causes the hang, checked directly rather than inferred from elapsed time |
| `test_supplied_running_loop_is_still_used_from_another_thread` | the one case the old code handled correctly still works: a supplied loop running on another thread is used, not bypassed |
| `test_exceptions_propagate_from_inside_a_running_loop` | a failure in the coroutine reaches the sync caller |
| `test_context_manager_stops_the_background_loop` | leaving `with` stops the loop and closes the client |

Two details worth flagging for review:

- The helper invokes the sync methods **on** the loop thread (inside `asyncio.run`), not via `asyncio.to_thread`. Offloading with `to_thread` would leave the worker with no running loop and would silently exercise the plain `run_until_complete` path, passing against unfixed source. It joins with a timeout and asserts the thread is no longer alive, so a reintroduced hang **fails** rather than stalling CI — necessary here because the original `.result()` has no timeout at all.
- `test_supplied_idle_loop_is_not_driven_from_an_async_thread` asserts on `_run_async` directly rather than on `load()`. `load()` swallows the exception and returns `[]`, so asserting on its result cannot distinguish "the load worked and the store was empty" from "the bridge raised and the error was swallowed" — that indistinguishability is itself part of the bug, and an earlier draft of this test passed against unfixed source for exactly that reason.

`_create_client` is patched out rather than pointed at a fake server: the bridging under test sits upstream of any Redis I/O.

### Control experiment

Reverting only `camel/storages/key_value_storages/redis.py` and keeping the tests:

```
6 failed, 4 passed
```

The 4 passes are the 3 pre-existing tests plus `test_supplied_running_loop_is_still_used_from_another_thread` — precisely the scenario the old code handled — and the 6 failures are the new tests, each failing with the specific error from the table above rather than an incidental assertion.

## Verification

| suite | result |
| --- | --- |
| `test/storages/key_value_storages/test_redis.py` | **10 passed** (3 pre-existing + 7 new) |
| `test/storages/` (excluding `test_surreal.py`, which needs the absent `surrealdb`) | failing-test set **byte-identical** to `master`: 58 names before, 58 after, no additions or removals. The pre-existing failures are missing optional backends and absent API keys. |
| `ruff check` / `ruff format --check` on both changed files | clean |
| `mypy camel/storages/key_value_storages/redis.py` | no errors in the changed file |
