### PR TITLE
fix: Workforce.reset() blocked forever on a loop that could not advance it

### DIFF
--- a/camel/societies/workforce/workforce.py
+++ b/camel/societies/workforce/workforce.py
@@ -3201,10 +3201,6 @@ class Workforce(BaseNode):
         self._start_child_node_when_paused(workforce.start())
         return self
 
-    async def _async_reset(self) -> None:
-        r"""Async implementation of reset to run on the event loop."""
-        self._pause_event.set()
-
     @check_if_running(False)
     def reset(self) -> None:
         r"""Reset the workforce and all the child nodes under it. Can only
@@ -3237,20 +3233,28 @@ class Workforce(BaseNode):
         self._state = WorkforceState.IDLE
         self._stop_requested = False
         self._skip_requested = False
-        # Handle asyncio.Event in a thread-safe way
-        if self._loop and not self._loop.is_closed():
-            # If we have a loop, use it to set the event safely
-            try:
-                asyncio.run_coroutine_threadsafe(
-                    self._async_reset(), self._loop
-                ).result()
-            except RuntimeError as e:
-                logger.warning(f"Failed to reset via existing loop: {e}")
-                # Fallback to direct event manipulation
-                self._pause_event.set()
-        else:
-            # No active loop, directly set the event
-            self._pause_event.set()
+        # ``asyncio.Event.set()`` is called directly rather than routed onto
+        # ``self._loop``. It only flips a flag and schedules the wake-ups of
+        # already-awaiting tasks onto the loop those tasks belong to, so it
+        # needs no loop of its own -- which is why every sibling intervention
+        # method already sets it synchronously when no loop is available.
+        #
+        # Routing it was also unsafe here. Waiting on
+        # ``run_coroutine_threadsafe(...).result()`` blocks until the target
+        # loop advances the coroutine, and ``reset()`` is reachable in two
+        # states where it never will:
+        #
+        # - ``self._loop`` is open but idle.
+        #   ``_process_task_with_intervention`` deliberately leaves the loop
+        #   open when it returns in the ``PAUSED`` state so that
+        #   ``continue_from_pause`` can reuse it, and nothing drives it in
+        #   between.
+        # - ``self._loop`` is the loop running on this very thread, which the
+        #   wait would be occupying.
+        #
+        # Neither raises, so the ``except RuntimeError`` fallback could not
+        # fire, and the wait had no timeout.
+        self._pause_event.set()
 
         for cb in self._callbacks:
             if isinstance(cb, WorkforceMetrics):

--- a/test/workforce/test_workforce_reset_lifecycle.py
+++ b/test/workforce/test_workforce_reset_lifecycle.py
@@ -1,0 +1,208 @@
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+r"""Regression tests for ``Workforce.reset()`` and its event loop.
+
+``reset()`` used to hand ``_pause_event.set()`` to ``self._loop`` and block on
+the result. Both cases below reach a loop that will never advance that
+coroutine, so ``reset()`` never returned.
+
+Every assertion runs ``reset()`` on a separate daemon thread and checks that
+the thread finished, rather than calling it inline. A reintroduced hang then
+*fails* the test instead of stalling the run: the original code has no timeout
+anywhere on that path.
+"""
+
+import asyncio
+import os
+import threading
+
+import pytest
+
+from camel.societies.workforce.workforce import Workforce, WorkforceState
+
+
+@pytest.fixture(autouse=True)
+def stub_openai_api_key(monkeypatch):
+    r"""Ensure OPENAI_API_KEY is set during tests."""
+    previous_value = os.environ.get("OPENAI_API_KEY")
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+    yield
+    if previous_value is None:
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    else:
+        monkeypatch.setenv("OPENAI_API_KEY", previous_value)
+
+
+def call_off_thread(func, timeout: float = 5.0) -> None:
+    r"""Runs ``func`` on a daemon thread and asserts that it returned.
+
+    Assertions inside the thread would be swallowed, so the outcome is
+    collected and re-raised on the caller.
+    """
+    outcome: list = []
+
+    def body() -> None:
+        try:
+            func()
+            outcome.append(None)
+        except BaseException as exc:
+            outcome.append(exc)
+
+    thread = threading.Thread(target=body, daemon=True)
+    thread.start()
+    thread.join(timeout)
+    assert not thread.is_alive(), (
+        f"{getattr(func, '__name__', func)} did not return within "
+        f"{timeout}s -- it is waiting on an event loop that cannot advance it"
+    )
+    if outcome and outcome[0] is not None:
+        raise outcome[0]
+
+
+def test_reset_returns_when_the_stored_loop_is_open_but_idle():
+    r"""``_process_task_with_intervention`` deliberately leaves ``self._loop``
+    open when it returns in the ``PAUSED`` state, so that
+    ``continue_from_pause`` can reuse it. Nothing drives the loop in between,
+    so anything submitted to it there is never advanced -- and the loop looks
+    healthy to ``not self._loop.is_closed()``.
+    """
+    workforce = Workforce("reset-idle-loop")
+    loop = asyncio.new_event_loop()
+    try:
+        workforce._loop = loop
+        # What ``run_until_complete`` leaves behind: open, but not running.
+        loop.run_until_complete(asyncio.sleep(0))
+        workforce._state = WorkforceState.PAUSED
+        workforce._pause_event.clear()
+        assert not loop.is_closed() and not loop.is_running()
+
+        call_off_thread(workforce.reset)
+
+        assert workforce._pause_event.is_set(), (
+            "reset() must release the pause, otherwise the next task waits "
+            "on an event nobody sets"
+        )
+        assert workforce._state == WorkforceState.IDLE
+    finally:
+        loop.close()
+
+
+def test_reset_returns_when_called_on_its_own_loops_thread():
+    r"""``reset()`` is reachable from the thread running ``self._loop``:
+    ``process_task`` stores the caller's running loop
+    (``self._loop = current_loop``) and ``handle_decompose_append_task`` calls
+    ``reset()``. Waiting there for a coroutine that only this thread can
+    advance wedges the loop permanently -- and takes every task on it along.
+    """
+    workforce = Workforce("reset-own-thread")
+    loop = asyncio.new_event_loop()
+    loop_running = threading.Event()
+
+    def run_loop() -> None:
+        asyncio.set_event_loop(loop)
+        loop.call_soon(loop_running.set)
+        loop.run_forever()
+
+    thread = threading.Thread(target=run_loop, daemon=True)
+    thread.start()
+    assert loop_running.wait(5)
+
+    try:
+        workforce._loop = loop
+        workforce._pause_event.clear()
+
+        reset_done = threading.Event()
+
+        def reset_on_the_loop() -> None:
+            workforce.reset()
+            reset_done.set()
+
+        loop.call_soon_threadsafe(reset_on_the_loop)
+        assert reset_done.wait(5), "reset() never returned on the loop thread"
+
+        # Probed by scheduling onto the loop rather than by elapsed time: a
+        # wedged loop still reports ``is_running()``, so only work that has to
+        # go through it can tell the difference.
+        probe = asyncio.run_coroutine_threadsafe(asyncio.sleep(0), loop)
+        probe.result(timeout=5)
+        assert workforce._pause_event.is_set()
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+        thread.join(timeout=5)
+        loop.close()
+
+
+def test_reset_releases_the_pause_for_tasks_awaiting_on_another_loop():
+    r"""The pause event is shared with child workforces and awaited from
+    whichever loop is running the work, so setting it must actually wake those
+    waiters -- which is the reason the old code routed it onto ``self._loop``
+    in the first place.
+
+    ``asyncio.Event.set()`` schedules the wake-ups on the loop each waiter is
+    attached to, not on the loop of whoever calls it, so a plain synchronous
+    call is enough.
+
+    This one passes against the old code too: it guards the premise of the fix
+    rather than the hang, since a direct ``set()`` would be worthless if the
+    waiters did not wake.
+    """
+    workforce = Workforce("reset-wakes-waiters")
+    workforce._pause_event.clear()
+    resumed = threading.Event()
+
+    async def wait_for_resume() -> None:
+        await workforce._pause_event.wait()
+        resumed.set()
+
+    async def main() -> None:
+        workforce._loop = asyncio.get_running_loop()
+        waiter = asyncio.ensure_future(wait_for_resume())
+        await asyncio.sleep(0)  # let the waiter reach the ``wait()``
+        # ``reset()`` runs off the loop, which is the arrangement
+        # ``process_task`` produces for a caller on another thread.
+        await asyncio.to_thread(workforce.reset)
+        await asyncio.wait_for(waiter, timeout=5)
+
+    asyncio.run(main())
+    assert resumed.is_set()
+
+
+def test_reset_returns_when_no_loop_was_ever_created():
+    r"""The pre-existing path: ``reset()`` before any task has run. Kept so the
+    common case cannot regress while the loop-bearing paths are changed.
+    """
+    workforce = Workforce("reset-no-loop")
+    workforce._pause_event.clear()
+    assert workforce._loop is None
+
+    call_off_thread(workforce.reset)
+
+    assert workforce._pause_event.is_set()
+    assert workforce._state == WorkforceState.IDLE
+
+
+def test_reset_returns_when_the_stored_loop_is_closed():
+    r"""``_process_task_with_intervention`` closes the loop on any non-paused
+    exit, leaving ``self._loop`` pointing at a closed loop.
+    """
+    workforce = Workforce("reset-closed-loop")
+    loop = asyncio.new_event_loop()
+    loop.close()
+    workforce._loop = loop
+    workforce._pause_event.clear()
+
+    call_off_thread(workforce.reset)
+
+    assert workforce._pause_event.is_set()
+    assert workforce._state == WorkforceState.IDLE


### PR DESCRIPTION
## Description

`Workforce.reset()` routed `self._pause_event.set()` onto `self._loop` and blocked on the result with no timeout. `not self._loop.is_closed()` does not establish that the loop will ever advance the submission, so in two reachable states `reset()` never returned.

Fixes #4243

## Root cause

```python
if self._loop and not self._loop.is_closed():
    try:
        asyncio.run_coroutine_threadsafe(
            self._async_reset(), self._loop
        ).result()
    except RuntimeError as e:
        logger.warning(f"Failed to reset via existing loop: {e}")
        self._pause_event.set()
```

**1. `self._loop` is open but idle.** `_process_task_with_intervention` deliberately leaves the loop open when it returns in the `PAUSED` state so that `continue_from_pause` can reuse it. Nothing drives it in between, so the submission sits in the queue. The guard passes because the loop is open.

**2. `reset()` runs on the loop's own thread.** `process_task` stores the caller's running loop (`self._loop = current_loop`), and `handle_decompose_append_task` calls `reset()`. Waiting on `.result()` there occupies the thread the coroutine needs, so the loop wedges permanently and takes every task on it along.

Neither state raises, so the `except RuntimeError` fallback could not fire, and the `.result()` had no timeout. The wedged-thread stack in #4243 shows the loop thread stopped at `workforce.py:3246` and never moved.

## The change

Set the event synchronously and drop `_async_reset`, whose entire body was that one call:

```python
self._pause_event.set()
```

`asyncio.Event.set()` needs no loop of its own — it flips a flag and schedules the wake-ups of already-awaiting tasks onto the loop each waiter is attached to, not onto the loop of whoever calls it. So the routing bought nothing a direct call does not already give, while introducing the two hangs.

This is also what every sibling intervention method in the same file already does when no loop is available: `stop_gracefully`, `stop_immediately`, `skip_gracefully`, `stop`. The ones that *do* route work onto the loop go through `_submit_coro_to_loop`, which guards `running_loop is loop` and is fire-and-forget, so neither case above can hang them. `reset()` was the only intervention method that blocked on the bridge.

`_async_reset` was private and had no other caller or doc reference, so removing it keeps nothing dead behind.

## Tests

`test/workforce/test_workforce_reset_lifecycle.py`, new. No existing test covered `reset()` with a non-`None` `self._loop` — the three call sites in `test/workforce/` all run after a completed `process_task`, which closes the loop, so they took the `else` branch. That is why neither hang was caught.

| test | asserts |
| --- | --- |
| `test_reset_returns_when_the_stored_loop_is_open_but_idle` | **failure 1**: `reset()` returns, and the pause is released, against the loop state the `PAUSED` exit leaves behind |
| `test_reset_returns_when_called_on_its_own_loops_thread` | **failure 2**: `reset()` returns on the loop's own thread, and the loop is still responsive afterwards |
| `test_reset_releases_the_pause_for_tasks_awaiting_on_another_loop` | the premise of the fix: a direct `set()` does wake waiters attached to a different loop |
| `test_reset_returns_when_no_loop_was_ever_created` | the pre-existing `else` branch cannot regress |
| `test_reset_returns_when_the_stored_loop_is_closed` | the other pre-existing path, `self._loop` closed by a non-paused exit |

Two things worth flagging for review:

- **Every case calls `reset()` off the test's own thread and asserts the thread finished**, rather than calling it inline. A reintroduced hang then *fails* the test instead of stalling the run — the original code has no timeout anywhere on that path.
- **The own-thread test probes by scheduling onto the loop, not by elapsed time.** A wedged loop still reports `is_running()`, so only work that has to go through it can tell the difference.
- `test_reset_releases_the_pause_for_tasks_awaiting_on_another_loop` passes against the old code too, and its docstring says so. It guards the premise rather than the bug: a direct `set()` would be worthless if the waiters did not wake.

### Control experiment

Reverting only `camel/societies/workforce/workforce.py` and keeping the new tests:

| test | on unfixed source |
| --- | --- |
| `..._the_stored_loop_is_open_but_idle` | failed |
| `..._called_on_its_own_loops_thread` | failed |
| `..._awaiting_on_another_loop` | passed (by design, see above) |
| `..._no_loop_was_ever_created` | passed |
| `..._the_stored_loop_is_closed` | passed |

2 failed / 3 passed, both per-test and as a whole file: the wedged loop lives on a daemon thread, so the run still reports rather than stalling.

## Verification

| check | result |
| --- | --- |
| `test/workforce/test_workforce_reset_lifecycle.py` | **5 passed** |
| `test/workforce/` | failing-test set **name-identical** to `master` |
| `ruff check` / `ruff format --check` | clean on both changed files |
| `mypy camel/societies/workforce/workforce.py` | **0 errors in the changed file** (the 20 reported are pre-existing, in 10 other files) |
