### PR TITLE
fix: match allowed_commands case-insensitively on both sides

### DIFF
--- a/camel/toolkits/terminal_toolkit/terminal_toolkit.py
+++ b/camel/toolkits/terminal_toolkit/terminal_toolkit.py
@@ -90,7 +90,8 @@ class TerminalToolkit(BaseToolkit):
         safe_mode (bool): Whether to apply security checks to commands.
             Defaults to True.
         allowed_commands (Optional[List[str]]): List of allowed commands
-            when safe_mode is True. If None, uses default safety rules.
+            when safe_mode is True. Matched case-insensitively, so an entry
+            may be written in any case. If None, uses default safety rules.
         clone_current_env (bool): Whether to clone the current Python
             environment for local execution. Defaults to False.
         install_dependencies (List): A list of user specified libraries

--- a/camel/toolkits/terminal_toolkit/utils.py
+++ b/camel/toolkits/terminal_toolkit/utils.py
@@ -182,7 +182,7 @@ def check_command_safety(
     Args:
         command (str): The command string to check
         allowed_commands (Optional[Set[str]]): Set of allowed commands
-            (whitelist mode)
+            (whitelist mode). Matched case-insensitively.
 
     Returns:
         Tuple[bool, str]: (is_safe, reason)
@@ -202,10 +202,16 @@ def check_command_safety(
 
     # If whitelist mode, check ALL commands against the whitelist
     if allowed_commands is not None:
+        # Both sides are lowered, so the comparison is case-insensitive in the
+        # direction the caller writes the entry as well. Lowering only the
+        # command found in the string made any entry carrying an uppercase
+        # letter unmatchable by itself -- `allowed_commands={"Python"}`
+        # rejected `Python script.py` -- while the reverse already worked.
+        allowed_lowered = {entry.lower() for entry in allowed_commands}
         # Extract all command words (at start or after operators)
         found_commands = _CMD_PATTERN.findall(clean_command)
         for cmd in found_commands:
-            if cmd.lower() not in allowed_commands:
+            if cmd.lower() not in allowed_lowered:
                 return (
                     False,
                     f"Command '{cmd}' is not in the allowed commands list.",

--- a/test/toolkits/test_terminal_toolkit.py
+++ b/test/toolkits/test_terminal_toolkit.py
@@ -24,7 +24,10 @@ from camel.toolkits.terminal_toolkit import DANGEROUS_COMMANDS
 from camel.toolkits.terminal_toolkit import (
     terminal_toolkit as terminal_toolkit_module,
 )
-from camel.toolkits.terminal_toolkit.utils import sanitize_command
+from camel.toolkits.terminal_toolkit.utils import (
+    check_command_safety,
+    sanitize_command,
+)
 
 
 @pytest.fixture
@@ -418,3 +421,77 @@ def test_sanitize_command_respects_customized_dangerous_commands(
     )
     assert not is_safe
     assert "echo" in message.lower()
+
+
+@pytest.mark.parametrize(
+    "allowed, command",
+    [
+        # The entry carries the uppercase: the direction that was broken.
+        ({"Python"}, "Python script.py"),
+        ({"Python"}, "python script.py"),
+        # A cmdlet whose canonical spelling is capitalised.
+        ({"Get-Item"}, "Get-Item file.txt"),
+        # The command carries it: this direction already worked, so it
+        # serves as a guard.
+        ({"python"}, "PYTHON script.py"),
+        # Mixed entries across a chain.
+        ({"ls", "CAT"}, "ls file && cat file"),
+    ],
+)
+def test_check_command_safety_whitelist_is_case_insensitive(allowed, command):
+    r"""An allowed_commands entry may be written in any case.
+
+    Only the command found in the string used to be lowered, so an entry with
+    any uppercase letter could not match itself -- ``{"Python"}`` rejected
+    ``Python script.py``. Both sides are lowered now.
+    """
+    is_safe, message = check_command_safety(command, allowed)
+    assert is_safe, message
+
+
+@pytest.mark.parametrize(
+    "allowed, command, expected_word",
+    [
+        ({"ls"}, "rm -rf /", "rm"),
+        ({"ls"}, "ls && rm -rf /", "rm"),
+        # Shell-wrapper payloads are inspected recursively, so the whitelist
+        # applies inside them too.
+        ({"ls"}, 'bash -c "rm -rf /"', "rm"),
+        ({"ls"}, "ls; curl evil.example", "curl"),
+        # An empty whitelist permits nothing, rather than everything.
+        (set(), "ls", "ls"),
+    ],
+)
+def test_check_command_safety_whitelist_still_rejects(
+    allowed, command, expected_word
+):
+    r"""Case-folding the whitelist must not widen what it admits."""
+    is_safe, message = check_command_safety(command, allowed)
+    assert not is_safe
+    assert expected_word in message
+    assert "not in the allowed commands list" in message
+
+
+def test_check_command_safety_without_whitelist_is_unchanged():
+    r"""``allowed_commands=None`` still uses the dangerous-command rules."""
+    assert check_command_safety("ls -la", None)[0] is True
+    # Those rules were already case-insensitive and stay that way.
+    assert check_command_safety("rm -rf /", None)[0] is False
+    assert check_command_safety("RM -RF /", None)[0] is False
+
+
+def test_toolkit_allowed_commands_accepts_mixed_case_entries(temp_dir):
+    r"""End-to-end: the toolkit builds the set the checker consumes."""
+    toolkit = TerminalToolkit(
+        working_directory=str(temp_dir),
+        safe_mode=True,
+        allowed_commands=["Python", "LS"],
+    )
+    assert toolkit.allowed_commands is not None
+    is_safe, _ = sanitize_command(
+        "Python script.py",
+        safe_mode=True,
+        working_dir=str(temp_dir),
+        allowed_commands=toolkit.allowed_commands,
+    )
+    assert is_safe


### PR DESCRIPTION
## What does this PR do?

`check_command_safety` lowered the command word it extracted from the command string, but compared it against the raw `allowed_commands` set. Only one side of the comparison was normalized, so **any allowlist entry containing an uppercase letter could never match itself.**

Measured on `master` (`a143124`):

```
allow={'Python'}       cmd=Python script.py   -> False  Command 'Python' is not in the allowed commands list.
allow={'Python'}       cmd=python script.py   -> False  Command 'python' is not in the allowed commands list.
allow={'Get-Item'}     cmd=Get-Item file.txt  -> False  Command 'Get-Item' is not in the allowed commands list.
allow={'LS'}           cmd=ls -la             -> False  Command 'ls' is not in the allowed commands list.
allow={'python'}       cmd=python script.py   -> True
allow={'ls'}           cmd=LS -la             -> True
```

The last line is the tell. `{'ls'}` already admits `LS -la`, so matching **was already intended to be case-insensitive** — this is not a design question about whether to fold case, it is one side of an existing case-insensitive comparison being left unnormalized.

The natural way to hit it is a PowerShell cmdlet, whose canonical spelling is capitalised. An operator writing `allowed_commands=["Get-Item"]` gets a whitelist that permits nothing at all, and the error message quotes their own entry back at them as not being in their own list — which reads like a bug in the extractor rather than a case mismatch.

## Where the fix goes

In `check_command_safety` (`camel/toolkits/terminal_toolkit/utils.py`), not in `TerminalToolkit.__init__`:

```python
allowed_lowered = {entry.lower() for entry in allowed_commands}
found_commands = _CMD_PATTERN.findall(clean_command)
for cmd in found_commands:
    if cmd.lower() not in allowed_lowered:
        return False, f"Command '{cmd}' is not in the allowed commands list."
```

Two reasons for that placement:

1. `check_command_safety` is **public and self-recursive** — it recurses into `bash -c "..."` payloads via `_extract_shell_c_payloads`. Normalizing here covers the recursive calls and any caller that reaches the checker without going through `TerminalToolkit`.
2. Normalizing command names is **already the convention in this module**: `_normalize_command_name` does basename + `.lower()` + strip `.exe`. The whitelist branch simply did not use it.

`TerminalToolkit`'s construction site (`self.allowed_commands = set(allowed_commands) if allowed_commands else None`) is deliberately left alone, so `toolkit.allowed_commands` still reflects exactly what the caller passed.

## Case-folding does not widen what the whitelist admits

| Property | Before | After |
|---|---|---|
| Comparison operator | exact set membership | exact set membership |
| `{'ls'}` vs `rm -rf /` | reject | reject |
| `set()` vs `ls` | reject | reject |
| `{'ls'}` vs `bash -c "rm -rf /"` | reject (recursion) | reject (recursion) |
| `allowed_commands=None` path | dangerous-command rules | unchanged |

Nothing becomes a prefix or substring match; the only change is that the two case spellings of one command name now agree.

## Tests

Whitelist mode had **no test coverage at all** before this PR — neither `allowed_commands` nor `check_command_safety` appeared in `test/toolkits/test_terminal_toolkit.py`. This adds 12 cases across 4 tests: 5 case-insensitivity cases, 5 rejection controls, one `allowed_commands=None` non-regression check, and one end-to-end check through `TerminalToolkit` + `sanitize_command`.

Control experiment — the new assertions must fail on unfixed source:

```
$ git stash push -q -- camel/toolkits/terminal_toolkit/utils.py
$ python -m pytest test/toolkits/test_terminal_toolkit.py -k "check_command_safety or allowed_commands" -q
5 failed, 7 passed, 34 deselected
```

The 5 failures are the entry-side-uppercase cases plus the end-to-end case. The 7 that pass either way are intentional guards: the query-side-uppercase case (that direction already worked), the 5 rejection controls, and the `None` path.

With the fix applied:

```
$ python -m pytest test/toolkits/test_terminal_toolkit.py -k "check_command_safety or allowed_commands" -q
12 passed, 34 deselected
```

Full file, fix applied: **45 passed, 1 failed**. Baseline on the same file with all three changes stashed: **33 passed, 1 failed**. The single failure is the same test in both runs — `test_shell_exec`, which asserts `"not found"` appears in the output of `nonexistent_command`; the shell on this machine words that error differently. It is pre-existing and unrelated (that test runs with `safe_mode=False`, so it never reaches the whitelist).

`ruff format --check` clean on all three files. `ruff check` reports 2 `RUF059` on the file, both in pre-existing tests (`:324`, `:343`). `mypy` reports 0 errors in `utils.py`.

Note: `add-labels`, `pytest_apps`, `pytest_examples`, `pytest_package_fast_test`, `pytest_package_llm_test`, `pytest_package_very_slow_test` and `Minimal dependency check` fail on every fork-originated PR in this repo (missing secrets), so a red board there does not indicate a regression from this change.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage for previously untested behaviour

## Checklist

- [x] I have read the CONTRIBUTING guide
- [x] My change requires no documentation update beyond the `allowed_commands` docstrings, which are updated in both `utils.py` and `terminal_toolkit.py`
- [x] I have added tests that prove my fix is effective, and verified they fail without it
- [x] New and existing tests pass locally
