### PR TITLE
fix(personas): PersonaHub.__setitem__ accepts key+value per mapping protocol

### DIFF
--- a/camel/personas/persona_hub.py
+++ b/camel/personas/persona_hub.py
@@ -63,13 +63,23 @@ class PersonaHub:
         self.model = model
         self.personas: Dict[uuid.UUID, Persona] = {}
 
-    def __setitem__(self, persona: Persona):
+    def __setitem__(self, key, value=None):
         r"""Add a persona to the group.
 
+        Supports both the mapping protocol (``hub[persona.id] = persona``)
+        and the legacy single-argument call (``hub.__setitem__(persona)``).
+
         Args:
-            persona (Persona): The persona to add.
+            key: A :class:`uuid.UUID` key, or a :class:`Persona` when called
+                with a single argument.
+            value (Persona, optional): The persona to store.  Omitted when
+                *key* is already a :class:`Persona`.
         """
-        self.personas[persona.id] = persona
+        if value is None and isinstance(key, Persona):
+            # Legacy call: __setitem__(persona)
+            self.personas[key.id] = key
+        else:
+            self.personas[key] = value
 
     def __delitem__(self, persona_id: uuid.UUID):
         r"""Remove a persona from the group by ID.

--- a/test/personas/test_persona_generator.py
+++ b/test/personas/test_persona_generator.py
@@ -81,9 +81,19 @@ def test___setitem__(persona_generator: PersonaHub):
         name="Test Persona",
         description="Test Description",
     )
-    persona_generator.__setitem__(persona)
+    # Mapping protocol: hub[key] = value
+    persona_generator[persona.id] = persona
     assert persona_generator.__len__() == 1
     assert persona_generator.personas[persona.id] == persona
+
+    # Legacy single-argument call still works
+    persona2 = Persona(
+        name="Test Persona 2",
+        description="Test Description 2",
+    )
+    persona_generator.__setitem__(persona2)
+    assert persona_generator.__len__() == 2
+    assert persona_generator.personas[persona2.id] == persona2
 
 
 def test_remove_persona(persona_generator: PersonaHub):


### PR DESCRIPTION
## Summary

`PersonaHub.__setitem__` was declared as `(self, persona)` instead of `(self, key, value)`, so subscript assignment `hub[persona_id] = persona` always raised `TypeError`. The existing tests called `__setitem__(persona)` directly, bypassing the mapping protocol and hiding the bug.

## Change

- Accept both the standard mapping protocol (`hub[key] = value`) and the legacy single-argument call (`__setitem__(persona)`) for backward compatibility
- Update tests to exercise the subscript path

## Before

```python
hub[persona.id] = persona  # TypeError: __setitem__() takes 2 positional arguments but 3 were given
```

## After

```python
hub[persona.id] = persona  # works
hub.__setitem__(persona)   # still works (backward compat)
```

## Testing

```
pytest test/personas/test_persona_generator.py::test___setitem__ -xvs
# 1 passed
```

Closes #4234