### PR TITLE
fix(agents): RepoAgent preserves explicit similarity=0 and top_k=0

### DIFF
--- a/camel/agents/repo_agent.py
+++ b/camel/agents/repo_agent.py
@@ -461,8 +461,8 @@ class RepoAgent(ChatAgent):
                 try:
                     raw_rag_content = self.vector_retriever.query(
                         query=user_query,
-                        top_k=self.top_k or 5,
-                        similarity_threshold=self.similarity or 0.6,
+                        top_k=self.top_k if self.top_k is not None else 5,
+                        similarity_threshold=self.similarity if self.similarity is not None else 0.6,
                     )
                     # Remove duplicates and retrieve the whole file
                     paths = []

--- a/test/agents/test_repo_agent.py
+++ b/test/agents/test_repo_agent.py
@@ -338,3 +338,24 @@ def test_add_repositories(mock_vector_retriever):
     assert len(agent.repos) == 1
     assert agent.repos[0].repo_name == "test/repo2"
     assert "another_function" in agent.full_text
+
+
+def test_step_preserves_zero_top_k_and_similarity(mock_vector_retriever):
+    r"""Explicit top_k=0 and similarity=0 must not be replaced by defaults."""
+    agent = RepoAgent(
+        vector_retriever=mock_vector_retriever,
+        top_k=0,
+        similarity=0.0,
+    )
+    agent.processing_mode = ProcessingMode.RAG
+    agent.vector_retriever.query.return_value = []
+    agent.search_by_file_path = MagicMock(return_value="")
+
+    with patch('camel.agents.repo_agent.ChatAgent.step') as mock_step:
+        mock_step.return_value = MagicMock(spec=ChatAgentResponse)
+        agent.step("query")
+
+        # The retriever must receive the explicit zeros, not 5 / 0.6
+        call_kwargs = agent.vector_retriever.query.call_args
+        assert call_kwargs[1]["top_k"] == 0
+        assert call_kwargs[1]["similarity_threshold"] == 0.0


### PR DESCRIPTION
## Summary

`RepoAgent.step` resolves retrieval settings with `or`:

```python
top_k=self.top_k or 5,
similarity_threshold=self.similarity or 0.6,
```

Both are `Optional` in `__init__`, so `None` already means "unset". But `or` additionally swallows `0`, which is a legitimate value:

- `similarity=0` means "no threshold — return everything"
- `top_k=0` means "return nothing" (useful for dry-run / metadata-only passes)

## Change

Replace `or` with explicit `is not None` checks so only `None` triggers the fallback.

## Before

```python
agent = RepoAgent(similarity=0)  # "no threshold"
agent.step(...)  # silently uses 0.6 instead
```

## After

```python
agent = RepoAgent(similarity=0)
agent.step(...)  # correctly uses 0
```

Closes #4236