### PR TITLE
fix(models): map Reka finish_reason='context' to OpenAI 'length'

### DIFF
--- a/camel/models/reka_model.py
+++ b/camel/models/reka_model.py
@@ -139,9 +139,9 @@ class RekaModel(BaseModelBackend):
                         "role": response.responses[0].message.role,
                         "content": response.responses[0].message.content,
                     },
-                    finish_reason=response.responses[0].finish_reason
-                    if response.responses[0].finish_reason
-                    else None,
+                    finish_reason=self._normalize_finish_reason(
+                        response.responses[0].finish_reason
+                    ),
                 )
             ],
             created=None,
@@ -151,6 +151,18 @@ class RekaModel(BaseModelBackend):
         )
 
         return openai_response
+
+    @staticmethod
+    def _normalize_finish_reason(reason: Optional[str]) -> Optional[str]:
+        r"""Map Reka finish reasons to the OpenAI vocabulary.
+
+        Reka uses ``"context"`` when the context window is exhausted;
+        OpenAI's equivalent is ``"length"``.  ``"stop"`` and ``"length"``
+        pass through unchanged.
+        """
+        if reason == "context":
+            return "length"
+        return reason
 
     def _convert_openai_to_reka_messages(
         self,

--- a/test/models/test_reka_model.py
+++ b/test/models/test_reka_model.py
@@ -36,3 +36,12 @@ def test_reka_model(model_type: ModelType):
     assert isinstance(model.token_counter, OpenAITokenCounter)
     assert isinstance(model.model_type.value_for_tiktoken, str)
     assert isinstance(model.model_type.token_limit, int)
+
+
+def test_reka_normalize_finish_reason():
+    """Reka 'context' must map to OpenAI 'length'; others pass through."""
+    norm = RekaModel._normalize_finish_reason
+    assert norm("context") == "length"
+    assert norm("stop") == "stop"
+    assert norm("length") == "length"
+    assert norm(None) is None


### PR DESCRIPTION
## Summary

Reka uses `"context"` when the context window is exhausted, which is off the OpenAI `Choice.finish_reason` vocabulary (`"stop" | "length" | "tool_calls" | "content_filter"`). Downstream consumers that switch on `finish_reason` silently mis-handle Reka responses.

## Change

Add `_normalize_finish_reason` to translate `"context"` → `"length"` and pass everything else through unchanged.

## Before

```python
# Reka returns finish_reason='context'
choice.finish_reason  # 'context' — not in OpenAI vocab
```

## After

```python
choice.finish_reason  # 'length' — correct OpenAI equivalent
```

Closes #4213