### PR TITLE
fix(utils): sanitize_filename covers all Windows reserved names, checks after truncation

### DIFF
--- a/camel/utils/filename.py
+++ b/camel/utils/filename.py
@@ -21,13 +21,8 @@ WINDOWS_RESERVED = {
     'PRN',
     'AUX',
     'NUL',
-    'COM1',
-    'COM2',
-    'COM3',
-    'COM4',
-    'LPT1',
-    'LPT2',
-    'LPT3',
+    *(f'COM{i}' for i in range(1, 10)),
+    *(f'LPT{i}' for i in range(1, 10)),
 }
 
 
@@ -73,8 +68,11 @@ def sanitize_filename(
     if not url_name:
         return default
 
-    # Handle Windows reserved names
+    # Truncate first, then check for Windows reserved names — truncation
+    # can produce a reserved name (e.g. "COM5_long_name"[:4] == "COM5").
+    url_name = url_name[:max_length]
+
     if platform.system() == "Windows" and url_name.upper() in WINDOWS_RESERVED:
         url_name = f"_{url_name}"
 
-    return url_name[:max_length]
+    return url_name

--- a/test/utils/test_filename.py
+++ b/test/utils/test_filename.py
@@ -116,3 +116,34 @@ def test_sanitize_filename_invalid_max_length():
         sanitize_filename("test.txt", max_length=0)
     with pytest.raises(ValueError):
         sanitize_filename("test.txt", max_length=-1)
+
+
+def test_sanitize_filename_windows_reserved_full_range():
+    """COM1-9 and LPT1-9 must all be guarded, not just 1-4/1-3."""
+    from unittest.mock import patch as _patch
+
+    with _patch("camel.utils.filename.platform") as mock_plat:
+        mock_plat.system.return_value = "Windows"
+        for i in range(1, 10):
+            assert sanitize_filename(f"com{i}") == f"_com{i}"
+            assert sanitize_filename(f"COM{i}") == f"_COM{i}"
+            assert sanitize_filename(f"lpt{i}") == f"_lpt{i}"
+            assert sanitize_filename(f"LPT{i}") == f"_LPT{i}"
+        # Non-reserved names pass through
+        assert sanitize_filename("com0") == "com0"
+        assert sanitize_filename("lpt0") == "lpt0"
+        assert sanitize_filename("console") == "console"
+
+
+def test_sanitize_filename_truncation_produces_reserved():
+    """Truncation must not yield a Windows reserved device name."""
+    from unittest.mock import patch as _patch
+
+    with _patch("camel.utils.filename.platform") as mock_plat:
+        mock_plat.system.return_value = "Windows"
+        # "COM5_extra_stuff" truncated to 4 chars -> "COM5"
+        result = sanitize_filename("COM5_extra_stuff", max_length=4)
+        assert result == "_COM5"
+        # "LPT9abc" truncated to 4 -> "LPT9"
+        result = sanitize_filename("LPT9abc", max_length=4)
+        assert result == "_LPT9"


### PR DESCRIPTION
## Summary

Two bugs in `sanitize_filename`:

1. **Incomplete reserved set**: only listed COM1–COM4 and LPT1–LPT3. Windows reserves COM1–COM9 and LPT1–LPT9, so `sanitize_filename("com5")` returned the name unchanged.

2. **Check before truncation**: the reserved-name guard ran before the length cut, so truncating a long name could produce a reserved name (e.g. `"COM5_long_name"[:4]` → `"COM5"`).

## Change

- Expand `WINDOWS_RESERVED` to COM1–9 / LPT1–9
- Move the reserved-name check after truncation

Closes #4248