### PR TITLE
fix(mcp): read config files with explicit UTF-8 encoding

### DIFF
--- a/camel/agents/mcp_agent.py
+++ b/camel/agents/mcp_agent.py
@@ -153,7 +153,7 @@ class MCPAgent(ChatAgent):
             self.registry_configs = registry_configs or []
 
         if local_config_path:
-            with open(local_config_path, 'r') as f:
+            with open(local_config_path, 'r', encoding='utf-8') as f:
                 local_config = json.load(f)
 
         self.local_config = local_config
@@ -269,7 +269,7 @@ class MCPAgent(ChatAgent):
         # Load additional configs from file if provided
         if config_path:
             try:
-                with open(config_path, 'r') as f:
+                with open(config_path, 'r', encoding='utf-8') as f:
                     config_data = json.load(f)
 
                 # Create registry configs from the loaded data

--- a/camel/utils/mcp_client.py
+++ b/camel/utils/mcp_client.py
@@ -1185,7 +1185,7 @@ def create_mcp_client_from_config_file(
     import json
 
     config_path = Path(config_path)
-    with open(config_path, 'r') as f:
+    with open(config_path, 'r', encoding='utf-8') as f:
         config_data = json.load(f)
 
     servers = config_data.get("mcpServers", {})

--- a/test/utils/test_mcp_client.py
+++ b/test/utils/test_mcp_client.py
@@ -829,5 +829,34 @@ class TestSSEFallback:
         assert observed_timeouts == [42.0, 42.0]
 
 
+def test_config_file_read_as_utf8(tmp_path):
+    """Config files must be decoded as UTF-8 regardless of locale (#4232)."""
+    import json
+
+    from camel.utils.mcp_client import create_mcp_client_from_config_file
+
+    # Non-ASCII server name that would corrupt under GBK/Latin-1
+    config = {
+        "mcpServers": {
+            "服务器": {
+                "command": "echo",
+                "args": ["héllo"],
+            }
+        }
+    }
+    cfg_file = tmp_path / "mcp_config.json"
+    cfg_file.write_text(json.dumps(config, ensure_ascii=False), encoding="utf-8")
+
+    # Should parse without error; the key must survive intact
+    with pytest.raises(ValueError, match="not_here"):
+        # We only care that the file was *read* correctly; the server
+        # name won't be found, which proves the JSON parsed fine.
+        import asyncio
+
+        asyncio.get_event_loop().run_until_complete(
+            create_mcp_client_from_config_file(str(cfg_file), "not_here")
+        )
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
## Summary

Three `open()` calls for MCP config files omitted `encoding=`, so Python fell back to the locale encoding (e.g. cp936/GBK on Chinese Windows). JSON is UTF-8 by definition (RFC 8259 §8.1), so non-ASCII config content was corrupted or crashed on non-UTF-8 hosts.

## Change

Add `encoding='utf-8'` to all three call sites:

- `camel/agents/mcp_agent.py:156` — local config load
- `camel/agents/mcp_agent.py:272` — additional config load
- `camel/utils/mcp_client.py:1188` — `create_mcp_client_from_config_file`

## Testing

```
pytest test/utils/test_mcp_client.py::test_config_file_read_as_utf8 -xvs
# 1 passed
```

Test writes a config with non-ASCII keys (中文 server name + accented args) as UTF-8 and verifies it parses correctly.

Closes #4232