### PR TITLE
fix(agents): MCPAgent.step() works inside a running event loop

### DIFF
--- a/camel/agents/mcp_agent.py
+++ b/camel/agents/mcp_agent.py
@@ -430,11 +430,17 @@ class MCPAgent(ChatAgent):
             loop = None
 
         if loop and loop.is_running():
-            # Running inside an existing loop (e.g., Jupyter/FastAPI)
-            # Use create_task and run with a future
-            coro = self.astep(input_message, *args, **kwargs)
-            future = asyncio.ensure_future(coro)
-            return asyncio.run_coroutine_threadsafe(future, loop).result()  # type: ignore [arg-type]
+            # Running inside an existing loop (e.g., Jupyter/FastAPI).
+            # asyncio.run() would raise "cannot be called from a running
+            # event loop", and run_coroutine_threadsafe + .result() on the
+            # *same* thread deadlocks.  Run in a helper thread instead.
+            import concurrent.futures
+
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                return pool.submit(
+                    asyncio.run,
+                    self.astep(input_message, *args, **kwargs),
+                ).result()
         else:
             # Safe to run normally
             return asyncio.run(self.astep(input_message, *args, **kwargs))

--- a/test/agents/test_mcp_agent.py
+++ b/test/agents/test_mcp_agent.py
@@ -115,3 +115,26 @@ def test_extract_tool_calls_from_yaml_block() -> None:
 
     assert len(tool_calls) == 1
     assert tool_calls[0] == expected
+
+
+def test_step_inside_running_loop():
+    """step() must not raise TypeError when called from a running loop (#4239)."""
+    import asyncio
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from camel.agents.mcp_agent import MCPAgent
+
+    agent = MCPAgent.__new__(MCPAgent)
+    # Bypass __init__; only the step() code path matters here.
+    expected = MagicMock()
+    agent.astep = AsyncMock(return_value=expected)
+
+    async def caller():
+        # We are inside a running event loop — the old code raised
+        # TypeError because run_coroutine_threadsafe received a Task
+        # instead of a coroutine.
+        return agent.step("hello")
+
+    result = asyncio.run(caller())
+    assert result is expected
+    agent.astep.assert_awaited_once_with("hello")


### PR DESCRIPTION
## Summary

`MCPAgent.step()` has a branch for being called from inside an already-running event loop (Jupyter / FastAPI). That branch could never succeed:

1. `asyncio.ensure_future(coro)` returns a **Task**, but `run_coroutine_threadsafe` expects a **coroutine** → always `TypeError`
2. Even with the correct type, `.result()` on the same thread that owns the loop would **deadlock**

## Change

Replace with `ThreadPoolExecutor` + `asyncio.run()` in a helper thread — the standard sync-over-async pattern from within an existing loop.

## Testing

```
pytest test/agents/test_mcp_agent.py::test_step_inside_running_loop -xvs
# 1 passed
```

Test calls `step()` from inside `asyncio.run()` (a running loop) and verifies the response comes back without TypeError.

Closes #4239