### PR TITLE
fix(agents): streaming usage chunks assign instead of accumulate

### DIFF
--- a/camel/agents/chat_agent.py
+++ b/camel/agents/chat_agent.py
@@ -4803,14 +4803,21 @@ class ChatAgent(BaseAgent):
                         self.record_message(final_message)
             if chunk.usage:
                 # Handle final usage chunk, whether or not choices are present.
-                # This happens when stream_options={"include_usage": True}
-                # Update the final usage from this chunk
-                self._update_token_usage_tracker(
-                    request_token_usage, safe_model_dump(chunk.usage)
-                )
-                self._update_token_usage_tracker(
-                    step_token_usage, safe_model_dump(chunk.usage)
-                )
+                # This happens when stream_options={"include_usage": True}.
+                # Each usage chunk carries the *cumulative* total for this
+                # stream, not a delta — assign instead of accumulate to avoid
+                # double-counting when multiple chunks carry usage (#4217).
+                usage_dump = safe_model_dump(chunk.usage)
+                for _tracker in (request_token_usage, step_token_usage):
+                    _tracker["prompt_tokens"] = (
+                        usage_dump.get("prompt_tokens") or 0
+                    )
+                    _tracker["completion_tokens"] = (
+                        usage_dump.get("completion_tokens") or 0
+                    )
+                    _tracker["total_tokens"] = (
+                        usage_dump.get("total_tokens") or 0
+                    )
 
                 # Create final response with final usage
                 should_finalize = stream_completed or not has_choices
@@ -5933,14 +5940,21 @@ class ChatAgent(BaseAgent):
                         self.record_message(final_message)
             if chunk.usage:
                 # Handle final usage chunk, whether or not choices are present.
-                # This happens when stream_options={"include_usage": True}
-                # Update the final usage from this chunk
-                self._update_token_usage_tracker(
-                    request_token_usage, safe_model_dump(chunk.usage)
-                )
-                self._update_token_usage_tracker(
-                    step_token_usage, safe_model_dump(chunk.usage)
-                )
+                # This happens when stream_options={"include_usage": True}.
+                # Each usage chunk carries the *cumulative* total for this
+                # stream, not a delta — assign instead of accumulate to avoid
+                # double-counting when multiple chunks carry usage (#4217).
+                usage_dump = safe_model_dump(chunk.usage)
+                for _tracker in (request_token_usage, step_token_usage):
+                    _tracker["prompt_tokens"] = (
+                        usage_dump.get("prompt_tokens") or 0
+                    )
+                    _tracker["completion_tokens"] = (
+                        usage_dump.get("completion_tokens") or 0
+                    )
+                    _tracker["total_tokens"] = (
+                        usage_dump.get("total_tokens") or 0
+                    )
 
                 # Create final response with final usage
                 should_finalize = stream_completed or not has_choices

--- a/test/agents/test_chat_agent.py
+++ b/test/agents/test_chat_agent.py
@@ -926,6 +926,82 @@ def test_chat_agent_stream_step_on_request_usage_callback():
 
 
 @pytest.mark.model_backend
+def test_chat_agent_stream_multiple_usage_chunks_no_double_count():
+    """When multiple chunks carry usage, the last one wins — no += (#4217)."""
+    from openai.types.chat.chat_completion_chunk import (
+        ChatCompletionChunk,
+        ChoiceDelta,
+    )
+    from openai.types.chat.chat_completion_chunk import (
+        Choice as ChunkChoice,
+    )
+
+    model = ModelFactory.create(
+        model_platform=ModelPlatformType.OPENAI,
+        model_type=ModelType.GPT_5_MINI,
+        model_config_dict={"stream": True},
+    )
+
+    chunks = [
+        ChatCompletionChunk(
+            id="mock_multi_usage",
+            choices=[
+                ChunkChoice(
+                    delta=ChoiceDelta(content="Hi", role="assistant"),
+                    index=0,
+                    finish_reason=None,
+                )
+            ],
+            created=1234567890,
+            model="gpt-5-mini",
+            object="chat.completion.chunk",
+            usage={
+                "prompt_tokens": 5,
+                "completion_tokens": 1,
+                "total_tokens": 6,
+            },
+        ),
+        ChatCompletionChunk(
+            id="mock_multi_usage",
+            choices=[
+                ChunkChoice(
+                    delta=ChoiceDelta(content=" there"),
+                    index=0,
+                    finish_reason="stop",
+                )
+            ],
+            created=1234567890,
+            model="gpt-5-mini",
+            object="chat.completion.chunk",
+            # Cumulative: includes the first chunk's tokens
+            usage={
+                "prompt_tokens": 5,
+                "completion_tokens": 3,
+                "total_tokens": 8,
+            },
+        ),
+    ]
+
+    def mock_stream():
+        for chunk in chunks:
+            yield chunk
+
+    model.run = MagicMock(return_value=mock_stream())
+
+    agent = ChatAgent(
+        system_message="You are a helpful assistant.",
+        model=model,
+    )
+
+    responses = list(agent.step("Say hi"))
+    assert len(responses) > 0
+    # Must be 8 (the last cumulative value), NOT 14 (6 + 8 double-counted)
+    assert responses[-1].info["usage"]["total_tokens"] == 8
+    assert responses[-1].info["usage"]["prompt_tokens"] == 5
+    assert responses[-1].info["usage"]["completion_tokens"] == 3
+
+
+@pytest.mark.model_backend
 @pytest.mark.asyncio
 async def test_chat_agent_async_stream_on_request_usage_callback():
     from typing import AsyncGenerator


### PR DESCRIPTION
## Summary

OpenAI streaming usage chunks carry **cumulative** totals, not deltas. The old code used `+=` via `_update_token_usage_tracker`, so when multiple chunks carried `usage` the counts were double-counted.

Example: chunk 1 reports `{total: 6}`, chunk 2 reports `{total: 8}` (cumulative). Old code: `6 + 8 = 14`. Correct: `8`.

## Change

Replace `+=` with direct assignment in both sync (`_process_stream_chunks_with_accumulator`) and async (`_aprocess_stream_chunks_with_accumulator`) streaming paths. The non-streaming `_update_token_usage_tracker` is unchanged — its `+=` semantics are correct for aggregating across separate requests.

## Testing

```
OPENAI_API_KEY=sk-dummy pytest test/agents/test_chat_agent.py::test_chat_agent_stream_multiple_usage_chunks_no_double_count -xvs
# 1 passed
```

Test sends two chunks with cumulative usage (6 then 8) and asserts the final count is 8, not 14.

Closes #4217