### PR TITLE
fix(models): map the Bedrock and Mistral finish reasons that are not OpenAI values

### DIFF
--- a/camel/models/aws_bedrock_converse_model.py
+++ b/camel/models/aws_bedrock_converse_model.py
@@ -624,6 +624,9 @@ class AWSBedrockConverseModel(BaseModelBackend):
             "max_tokens": "length",
             "stop_sequence": "stop",
             "tool_use": "tool_calls",
+            "content_filtered": "content_filter",
+            "guardrail_intervened": "content_filter",
+            "model_context_window_exceeded": "length",
         }.get(stop_reason or "", "stop")
 
     @staticmethod

--- a/camel/models/mistral_model.py
+++ b/camel/models/mistral_model.py
@@ -57,6 +57,11 @@ else:
     from camel.utils import observe
 
 
+# "model_length" is Mistral's own length stop, which OpenAI expresses as
+# "length".
+_FINISH_REASON_MAP = {"model_length": "length"}
+
+
 class MistralModel(BaseModelBackend):
     r"""Mistral API in a unified BaseModelBackend interface.
 
@@ -128,6 +133,18 @@ class MistralModel(BaseModelBackend):
             **kwargs,
         )
 
+    @staticmethod
+    def _map_finish_reason(mistral_reason: str) -> str:
+        r"""Map a Mistral finish reason to its OpenAI equivalent."""
+        if mistral_reason == "error":
+            raise RuntimeError(
+                "Mistral generation failed with finish reason "
+                f"{mistral_reason!r}"
+            )
+        # mistralai types FinishReason as a Literal plus UnrecognizedStr, so
+        # an unknown value is a later API addition, not a failure.
+        return _FINISH_REASON_MAP.get(mistral_reason, mistral_reason)
+
     def _to_openai_response(
         self, response: 'ChatCompletionResponse'
     ) -> ChatCompletion:
@@ -159,7 +176,9 @@ class MistralModel(BaseModelBackend):
                         "content": response.choices[0].message.content,  # type: ignore[index,union-attr]
                         "tool_calls": tool_calls,
                     },
-                    finish_reason=response.choices[0].finish_reason  # type: ignore[index]
+                    finish_reason=self._map_finish_reason(
+                        response.choices[0].finish_reason  # type: ignore[index]
+                    )
                     if response.choices[0].finish_reason  # type: ignore[index]
                     else None,
                 )

--- a/test/models/test_aws_bedrock_converse_model.py
+++ b/test/models/test_aws_bedrock_converse_model.py
@@ -352,3 +352,79 @@ def test_bedrock_client_supports_api_key_and_region_name(monkeypatch):
     assert client["service_name"] == "bedrock-runtime"
     assert client["kwargs"]["region_name"] == "us-east-1"
     assert "aws_access_key_id" not in client["kwargs"]
+
+
+@pytest.mark.model_backend
+@pytest.mark.parametrize(
+    "stop_reason,expected",
+    [
+        ("content_filtered", "content_filter"),
+        ("guardrail_intervened", "content_filter"),
+        ("model_context_window_exceeded", "length"),
+    ],
+)
+def test_converse_maps_non_default_stop_reasons(stop_reason, expected):
+    r"""Non-streaming: a filtered, guardrailed or context-exceeded turn
+    must not be reported as a normal completion."""
+
+    class DummyClient:
+        def converse(self, **kwargs):
+            return {
+                "output": {
+                    "message": {
+                        "role": "assistant",
+                        "content": [{"text": "partial"}],
+                    }
+                },
+                "stopReason": stop_reason,
+            }
+
+    model = _make_model(bedrock_client=DummyClient())
+    response = model._run([{"role": "user", "content": "hi"}])
+    assert response.choices[0].finish_reason == expected
+
+
+@pytest.mark.model_backend
+@pytest.mark.parametrize(
+    "stop_reason,expected",
+    [
+        ("content_filtered", "content_filter"),
+        ("guardrail_intervened", "content_filter"),
+        ("model_context_window_exceeded", "length"),
+    ],
+)
+def test_converse_stream_maps_non_default_stop_reasons(stop_reason, expected):
+    r"""Streaming path reports the same finish_reason as non-streaming."""
+
+    class DummyEventStream:
+        def __init__(self, events):
+            self._events = events
+
+        def __iter__(self):
+            return iter(self._events)
+
+    class DummyClient:
+        def converse_stream(self, **kwargs):
+            return {
+                "stream": DummyEventStream(
+                    [
+                        {"messageStart": {"role": "assistant"}},
+                        {"contentBlockDelta": {"delta": {"text": "partial"}}},
+                        {"messageStop": {"stopReason": stop_reason}},
+                    ]
+                )
+            }
+
+    model = _make_model(
+        BedrockConfig(stream=True).as_dict(),
+        bedrock_client=DummyClient(),
+    )
+    chunks = list(model._run([{"role": "user", "content": "hi"}]))
+    assert chunks[-1].choices[0].finish_reason == expected
+
+
+@pytest.mark.model_backend
+def test_converse_unknown_stop_reason_still_defaults_to_stop():
+    r"""Values with no OpenAI equivalent keep the generic default."""
+    for stop_reason in ("malformed_model_output", "malformed_tool_use"):
+        assert AWSBedrockConverseModel._map_stop_reason(stop_reason) == "stop"

--- a/test/models/test_mistral_model.py
+++ b/test/models/test_mistral_model.py
@@ -12,12 +12,35 @@
 # limitations under the License.
 # ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
 
+from types import SimpleNamespace
+
 import pytest
 
 from camel.configs import MistralConfig
 from camel.models import MistralModel
 from camel.types import ModelType
 from camel.utils import OpenAITokenCounter
+
+
+def _mock_mistral_response(finish_reason):
+    r"""A minimal Mistral ChatCompletionResponse carrying one choice."""
+    return SimpleNamespace(
+        id="cmpl-1",
+        created=1700000000,
+        model="mistral-large-latest",
+        usage=SimpleNamespace(
+            prompt_tokens=11, completion_tokens=7, total_tokens=18
+        ),
+        choices=[
+            SimpleNamespace(
+                index=0,
+                finish_reason=finish_reason,
+                message=SimpleNamespace(
+                    role="assistant", content="hi", tool_calls=None
+                ),
+            )
+        ],
+    )
 
 
 @pytest.mark.model_backend
@@ -105,3 +128,63 @@ def test_to_mistral_chatmessage_preserves_tool_call_ids(monkeypatch):
     second_tool_message = mistral_messages[3]
     assert first_tool_message.tool_call_id == tool_call_id_1
     assert second_tool_message.tool_call_id == tool_call_id_2
+
+
+@pytest.mark.model_backend
+def test_to_openai_response_maps_model_length_to_length(monkeypatch):
+    r"""Mistral's own context-limit stop must reach the caller as the
+    OpenAI term for a length stop. Left raw, a truncated generation is
+    unreadable to any consumer that branches on "length"."""
+    monkeypatch.setenv("MISTRAL_API_KEY", "test_key")
+    model = MistralModel(ModelType.MISTRAL_LARGE, MistralConfig().as_dict())
+
+    result = model._to_openai_response(_mock_mistral_response("model_length"))
+
+    assert result.choices[0].finish_reason == "length"
+
+
+@pytest.mark.model_backend
+@pytest.mark.parametrize("finish_reason", ["stop", "length", "tool_calls"])
+def test_to_openai_response_passes_through_openai_reasons(
+    monkeypatch, finish_reason
+):
+    r"""The three Mistral reasons that are already OpenAI terms are
+    unchanged by the mapping."""
+    monkeypatch.setenv("MISTRAL_API_KEY", "test_key")
+    model = MistralModel(ModelType.MISTRAL_LARGE, MistralConfig().as_dict())
+
+    result = model._to_openai_response(_mock_mistral_response(finish_reason))
+
+    assert result.choices[0].finish_reason == finish_reason
+
+
+@pytest.mark.model_backend
+def test_to_openai_response_raises_for_failed_generation(monkeypatch):
+    r"""Mistral's "error" reason has no OpenAI equivalent, so it is raised
+    rather than reported as a finished generation."""
+    monkeypatch.setenv("MISTRAL_API_KEY", "test_key")
+    model = MistralModel(ModelType.MISTRAL_LARGE, MistralConfig().as_dict())
+
+    with pytest.raises(RuntimeError, match="error"):
+        model._to_openai_response(_mock_mistral_response("error"))
+
+
+@pytest.mark.model_backend
+def test_to_openai_response_finish_reason_none_stays_none(monkeypatch):
+    r"""A response with no finish reason still maps to None, not to a
+    default, so an unfinished generation is not reported as completed."""
+    monkeypatch.setenv("MISTRAL_API_KEY", "test_key")
+    model = MistralModel(ModelType.MISTRAL_LARGE, MistralConfig().as_dict())
+
+    result = model._to_openai_response(_mock_mistral_response(None))
+
+    assert result.choices[0].finish_reason is None
+
+
+def test_map_finish_reason_unknown_value_passes_through():
+    r"""mistralai types FinishReason as a Literal plus UnrecognizedStr, so a
+    value added by a later API version is forwarded unchanged instead of
+    raising."""
+    assert MistralModel._map_finish_reason("some_new_reason") == (
+        "some_new_reason"
+    )


### PR DESCRIPTION
### Related Issue

Closes #4261
Closes #4266

### Description

Two finish-reason mappings, folded into one PR at @fengju0213's request (#4262 comment, 2026-08-21). They were opened separately as #4262 and #4267; #4267 is now closed in favour of this one. The two halves touch disjoint files and are described separately below, so they can still be reviewed or reverted independently.

## 1. Bedrock (`camel/models/aws_bedrock_converse_model.py`, closes #4261)

`AWSBedrockConverseModel._map_stop_reason` normalizes Bedrock's `stopReason` to the OpenAI `finish_reason` vocabulary, but listed only 4 of the 9 values the Converse API can return. The rest fell through to the generic `"stop"` default, and three of them have a distinct OpenAI meaning that was being lost:

| Bedrock `stopReason` | before | after |
| --- | --- | --- |
| `content_filtered` | `stop` | `content_filter` |
| `guardrail_intervened` | `stop` | `content_filter` |
| `model_context_window_exceeded` | `stop` | `length` |

A guardrail intervention or content filter was reported to callers as a normal completion, and a context-window truncation was reported as a normal completion rather than a truncation, so code branching on `finish_reason == "content_filter"` or `"length"` could not see either event.

**Scope.** Both paths that compute a `finish_reason` for this model go through this one helper (`_convert_converse_to_openai_response` for non-streaming, `_converse_stream_to_openai_chunks` for streaming), so one change covers both and both are tested.

`malformed_model_output` and `malformed_tool_use` are the other two values not listed. Neither has a clean OpenAI equivalent, so they are left on the generic `stop` default rather than guessed at; there is a test pinning that so the choice is deliberate rather than incidental. Happy to map them if you would rather they were.

## 2. Mistral (`camel/models/mistral_model.py`, closes #4266)

`MistralModel._to_openai_response` copied Mistral's `finish_reason` into the returned `ChatCompletion` verbatim. Three of Mistral's five values (`stop`, `length`, `tool_calls`) are OpenAI values too, so they were fine. The other two are not:

| Mistral `finish_reason` | before | after |
| --- | --- | --- |
| `model_length` | `model_length` | `length` |
| `error` | `error` | `RuntimeError` |

`model_length` is Mistral's own context-limit stop, so a truncated generation was reaching callers as a string no OpenAI-compatible consumer looks for. `ChatAgent` also forwards the value untouched into `ChatAgentResponse.info["finish_reasons"]`, so it surfaced there as well. `error` arrived looking like a finished generation carrying content.

The response is built with `ChatCompletion.construct`, which skips validation, so neither value was rejected on the way out: `ChatCompletion.model_validate(...)` on the old output fails with `literal_error`.

**On `error`.** It has no OpenAI equivalent, so this raises rather than guessing a mapping, which is what `CohereModel._map_finish_reason` already does for Cohere's `ERROR` and `TIMEOUT`. If you would rather it passed through, or mapped to `stop`, say so and I will change it. The `model_length` half stands on its own either way.

**On unknown values.** `mistralai` types `FinishReason` as a `Literal` plus `UnrecognizedStr`, so a value added by a later API version is forwarded unchanged rather than raising, and there is a test pinning that. This is the one place the fix deviates from the Cohere helper, which raises `ValueError`.

One thing I did not check: Mistral's API reference lists `finish_reason` without documenting what the values mean, so the `model_length` mapping is read off the value name and the SDK type, not off a spec.

Both halves are the same disjoint-vocabulary fix already merged for Cohere in #4202 and in #4210.

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Proof of testing

Both value sets are read from the installed SDKs rather than hand-written.

Bedrock, from the installed botocore service model (`bedrock-runtime/2023-09-30/service-2.json.gz`):

```
['end_turn', 'tool_use', 'max_tokens', 'stop_sequence', 'guardrail_intervened',
 'content_filtered', 'malformed_model_output', 'malformed_tool_use',
 'model_context_window_exceeded']
```

Driving all 9 through the real conversion methods, before and after:

```
                                 before             after
end_turn                         'stop'             'stop'
tool_use                         'tool_calls'       'tool_calls'
max_tokens                       'length'           'length'
stop_sequence                    'stop'             'stop'
guardrail_intervened             'stop'             'content_filter'
content_filtered                 'stop'             'content_filter'
malformed_model_output           'stop'             'stop'   (out of scope)
malformed_tool_use               'stop'             'stop'   (out of scope)
model_context_window_exceeded    'stop'             'length'
```

Same result through the streaming path (`messageStop` event) as through the non-streaming one.

Mistral, from `mistralai/models/chatcompletionchoice.py`:

```
FinishReason = Union[
    Literal['stop', 'length', 'model_length', 'error', 'tool_calls'],
    UnrecognizedStr,
]
```

Driving all five through the real `_to_openai_response` with real `mistralai` response objects, before and after:

```
                 before                after
stop             'stop'                'stop'
length           'length'              'length'
model_length     'model_length'        'length'
error            'error'               RuntimeError: Mistral generation failed
                                       with finish reason 'error'
tool_calls       'tool_calls'          'tool_calls'
```

**Re-verified on the combined branch**, since the point of folding them together is that the pair is what you review. Clean `python:3.11-slim` container on the merged tree at `759cbf71`, camel installed from source (`pip install -e .`), `botocore` 1.43.65 and `mistralai` 1.12.4 (inside camel's own `mistralai>=1.1.0,<2` pin). `camel.models.aws_bedrock_converse_model.__file__` and `camel.models.mistral_model.__file__` both resolve to the in-tree files under test.

```
pytest -q test/models/test_aws_bedrock_converse_model.py test/models/test_mistral_model.py
38 passed in 7.14s
```

with `MISTRAL_API_KEY` set to a dummy value so the 12 pre-existing constructor tests can run. Without it those 12 fail on `master` the same way, which is the only difference between the two runs.

Tests added, in `test/models/test_aws_bedrock_converse_model.py`:

- `test_map_stop_reason_content_filtered`
- `test_map_stop_reason_guardrail_intervened`
- `test_map_stop_reason_context_window_exceeded`
- `test_map_stop_reason_malformed_values_stay_stop` (pins the deliberate non-mapping)
- streaming and non-streaming coverage for the three changed values

and in `test/models/test_mistral_model.py`:

- `test_to_openai_response_maps_model_length_to_length`
- `test_to_openai_response_raises_for_failed_generation`
- `test_map_finish_reason_unknown_value_passes_through`
- `test_to_openai_response_passes_through_openai_reasons` (3 cases, regression guard)
- `test_to_openai_response_finish_reason_none_stays_none` (regression guard)

`pre-commit run --files` on the four changed files is clean on `ruff`, `ruff-format`, `codespell`, license and secret checks.

### Checklist

- [x] I have read and agree to the [AI-Generated Code Policy](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md#ai-generated-code-policy) (**required**)
- [x] I have linked this PR to an issue (**required**)
- [x] I have checked if any dependencies need to be added or updated in `pyproject.toml` and run `uv lock` (none needed)
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed
- [ ] I have added examples if this is a new feature
