### PR TITLE
fix(models): map Mistral finish reasons that are not OpenAI values

### DIFF
--- a/camel/models/mistral_model.py
+++ b/camel/models/mistral_model.py
@@ -57,6 +57,11 @@ else:
     from camel.utils import observe
 
 
+# "model_length" is Mistral's own length stop, which OpenAI expresses as
+# "length".
+_FINISH_REASON_MAP = {"model_length": "length"}
+
+
 class MistralModel(BaseModelBackend):
     r"""Mistral API in a unified BaseModelBackend interface.
 
@@ -128,6 +133,18 @@ class MistralModel(BaseModelBackend):
             **kwargs,
         )
 
+    @staticmethod
+    def _map_finish_reason(mistral_reason: str) -> str:
+        r"""Map a Mistral finish reason to its OpenAI equivalent."""
+        if mistral_reason == "error":
+            raise RuntimeError(
+                "Mistral generation failed with finish reason "
+                f"{mistral_reason!r}"
+            )
+        # mistralai types FinishReason as a Literal plus UnrecognizedStr, so
+        # an unknown value is a later API addition, not a failure.
+        return _FINISH_REASON_MAP.get(mistral_reason, mistral_reason)
+
     def _to_openai_response(
         self, response: 'ChatCompletionResponse'
     ) -> ChatCompletion:
@@ -159,7 +176,9 @@ class MistralModel(BaseModelBackend):
                         "content": response.choices[0].message.content,  # type: ignore[index,union-attr]
                         "tool_calls": tool_calls,
                     },
-                    finish_reason=response.choices[0].finish_reason  # type: ignore[index]
+                    finish_reason=self._map_finish_reason(
+                        response.choices[0].finish_reason  # type: ignore[index]
+                    )
                     if response.choices[0].finish_reason  # type: ignore[index]
                     else None,
                 )

--- a/test/models/test_mistral_model.py
+++ b/test/models/test_mistral_model.py
@@ -12,12 +12,35 @@
 # limitations under the License.
 # ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
 
+from types import SimpleNamespace
+
 import pytest
 
 from camel.configs import MistralConfig
 from camel.models import MistralModel
 from camel.types import ModelType
 from camel.utils import OpenAITokenCounter
+
+
+def _mock_mistral_response(finish_reason):
+    r"""A minimal Mistral ChatCompletionResponse carrying one choice."""
+    return SimpleNamespace(
+        id="cmpl-1",
+        created=1700000000,
+        model="mistral-large-latest",
+        usage=SimpleNamespace(
+            prompt_tokens=11, completion_tokens=7, total_tokens=18
+        ),
+        choices=[
+            SimpleNamespace(
+                index=0,
+                finish_reason=finish_reason,
+                message=SimpleNamespace(
+                    role="assistant", content="hi", tool_calls=None
+                ),
+            )
+        ],
+    )
 
 
 @pytest.mark.model_backend
@@ -105,3 +128,63 @@ def test_to_mistral_chatmessage_preserves_tool_call_ids(monkeypatch):
     second_tool_message = mistral_messages[3]
     assert first_tool_message.tool_call_id == tool_call_id_1
     assert second_tool_message.tool_call_id == tool_call_id_2
+
+
+@pytest.mark.model_backend
+def test_to_openai_response_maps_model_length_to_length(monkeypatch):
+    r"""Mistral's own context-limit stop must reach the caller as the
+    OpenAI term for a length stop. Left raw, a truncated generation is
+    unreadable to any consumer that branches on "length"."""
+    monkeypatch.setenv("MISTRAL_API_KEY", "test_key")
+    model = MistralModel(ModelType.MISTRAL_LARGE, MistralConfig().as_dict())
+
+    result = model._to_openai_response(_mock_mistral_response("model_length"))
+
+    assert result.choices[0].finish_reason == "length"
+
+
+@pytest.mark.model_backend
+@pytest.mark.parametrize("finish_reason", ["stop", "length", "tool_calls"])
+def test_to_openai_response_passes_through_openai_reasons(
+    monkeypatch, finish_reason
+):
+    r"""The three Mistral reasons that are already OpenAI terms are
+    unchanged by the mapping."""
+    monkeypatch.setenv("MISTRAL_API_KEY", "test_key")
+    model = MistralModel(ModelType.MISTRAL_LARGE, MistralConfig().as_dict())
+
+    result = model._to_openai_response(_mock_mistral_response(finish_reason))
+
+    assert result.choices[0].finish_reason == finish_reason
+
+
+@pytest.mark.model_backend
+def test_to_openai_response_raises_for_failed_generation(monkeypatch):
+    r"""Mistral's "error" reason has no OpenAI equivalent, so it is raised
+    rather than reported as a finished generation."""
+    monkeypatch.setenv("MISTRAL_API_KEY", "test_key")
+    model = MistralModel(ModelType.MISTRAL_LARGE, MistralConfig().as_dict())
+
+    with pytest.raises(RuntimeError, match="error"):
+        model._to_openai_response(_mock_mistral_response("error"))
+
+
+@pytest.mark.model_backend
+def test_to_openai_response_finish_reason_none_stays_none(monkeypatch):
+    r"""A response with no finish reason still maps to None, not to a
+    default, so an unfinished generation is not reported as completed."""
+    monkeypatch.setenv("MISTRAL_API_KEY", "test_key")
+    model = MistralModel(ModelType.MISTRAL_LARGE, MistralConfig().as_dict())
+
+    result = model._to_openai_response(_mock_mistral_response(None))
+
+    assert result.choices[0].finish_reason is None
+
+
+def test_map_finish_reason_unknown_value_passes_through():
+    r"""mistralai types FinishReason as a Literal plus UnrecognizedStr, so a
+    value added by a later API version is forwarded unchanged instead of
+    raising."""
+    assert MistralModel._map_finish_reason("some_new_reason") == (
+        "some_new_reason"
+    )


### PR DESCRIPTION
### Related Issue

Closes #4266

### Description

`MistralModel._to_openai_response` copied Mistral's `finish_reason` into the returned `ChatCompletion` verbatim. Three of Mistral's five values (`stop`, `length`, `tool_calls`) are OpenAI values too, so they were fine. The other two are not:

| Mistral `finish_reason` | before | after |
| --- | --- | --- |
| `model_length` | `model_length` | `length` |
| `error` | `error` | `RuntimeError` |

`model_length` is Mistral's own context-limit stop, so a truncated generation was reaching callers as a string no OpenAI-compatible consumer looks for. `ChatAgent` also forwards the value untouched into `ChatAgentResponse.info["finish_reasons"]`, so it surfaced there as well. `error` arrived looking like a finished generation carrying content.

The response is built with `ChatCompletion.construct`, which skips validation, so neither value was rejected on the way out: `ChatCompletion.model_validate(...)` on the old output fails with `literal_error`.

**On `error`.** It has no OpenAI equivalent, so this raises rather than guessing a mapping, which is what `CohereModel._map_finish_reason` already does for Cohere's `ERROR` and `TIMEOUT`. If you would rather it passed through, or mapped to `stop`, say so and I will change it. The `model_length` half stands on its own either way.

**On unknown values.** `mistralai` types `FinishReason` as a `Literal` plus `UnrecognizedStr`, so a value added by a later API version is forwarded unchanged rather than raising, and there is a test pinning that. This is the one place the fix deviates from the Cohere helper, which raises `ValueError`.

One thing I did not check: Mistral's API reference lists `finish_reason` without documenting what the values mean, so the `model_length` mapping is read off the value name and the SDK type, not off a spec.

This is the same disjoint-vocabulary fix already merged for Cohere (#4202) and Anthropic (#4210).

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Proof of testing

Clean `python:3.11-slim` container, camel installed from source (`pip install -e .`) at master `97b6e2dd5e02d3249e618d6f59f9f4824b3a11b9`, `mistralai` 1.12.4 (inside camel's own `mistralai>=1.1.0,<2` pin). `camel.models.mistral_model.__file__` resolves to the in-tree file under test.

The value set is not hand-written. It is read from the installed SDK, `mistralai/models/chatcompletionchoice.py`:

```
FinishReason = Union[
    Literal['stop', 'length', 'model_length', 'error', 'tool_calls'],
    UnrecognizedStr,
]
```

Driving all five through the real `_to_openai_response` with real `mistralai` response objects, before and after:

```
                 before                after
stop             'stop'                'stop'
length           'length'              'length'
model_length     'model_length'        'length'
error            'error'               RuntimeError: Mistral generation failed
                                       with finish reason 'error'
tool_calls       'tool_calls'          'tool_calls'
```

Tests, in `test/models/test_mistral_model.py`:

- `test_to_openai_response_maps_model_length_to_length`
- `test_to_openai_response_raises_for_failed_generation`
- `test_map_finish_reason_unknown_value_passes_through`
- `test_to_openai_response_passes_through_openai_reasons` (3 cases, regression guard)
- `test_to_openai_response_finish_reason_none_stays_none` (regression guard)

The first three fail on `master` and pass on this branch. The last two pass on both, which is the point of them.

Whole file: `17 passed, 3 failed` on master with these tests present, `20 passed` on this branch, with `MISTRAL_API_KEY` set to a dummy value so the 12 pre-existing constructor tests can run. `ruff check --no-fix` and `ruff format --check` are clean on both changed files with the pinned `ruff 0.7.4`, and `mypy` reports no issues on the changed module.

### Checklist

- [x] I have read and agree to the [AI-Generated Code Policy](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md#ai-generated-code-policy) (**required**)
- [x] I have linked this PR to an issue (**required**)
- [x] I have checked if any dependencies need to be added or updated in `pyproject.toml` and run `uv lock` (none needed)
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation if needed
- [ ] I have added examples if this is a new feature
