### PR TITLE
fix(models): preserve Responses terminal outcomes end to end

### DIFF
--- a/camel/agents/chat_agent.py
+++ b/camel/agents/chat_agent.py
@@ -4820,12 +4820,13 @@ class ChatAgent(BaseAgent):
                 should_finalize = stream_completed or not has_choices
                 if should_finalize:
                     final_content = content_accumulator.get_full_content()
-                    if final_content.strip():
-                        final_reasoning = (
-                            content_accumulator.get_full_reasoning_content()
-                            or None
-                        )
+                    final_reasoning = (
+                        content_accumulator.get_full_reasoning_content()
+                        or None
+                    )
+                    has_final_content = bool(final_content.strip())
 
+                    if has_final_content:
                         # Extract <think> tags from accumulated
                         # streaming content when reasoning_content
                         # is not already set by the model.
@@ -4835,48 +4836,49 @@ class ChatAgent(BaseAgent):
                             )
                         )
 
-                        # In delta mode, final response content should be empty
-                        # since all content was already yielded incrementally
-                        display_content = (
-                            final_content if self.stream_accumulate else ""
-                        )
-                        display_reasoning = (
-                            final_reasoning if self.stream_accumulate else None
-                        )
-                        final_message = BaseMessage(
-                            role_name=self.role_name,
-                            role_type=self.role_type,
-                            meta_dict={},
-                            content=display_content,
-                            reasoning_content=display_reasoning,
+                    # In delta mode, final response content should be empty
+                    # since all content was already yielded incrementally
+                    display_content = (
+                        final_content if self.stream_accumulate else ""
+                    )
+                    display_reasoning = (
+                        final_reasoning if self.stream_accumulate else None
+                    )
+                    final_message = BaseMessage(
+                        role_name=self.role_name,
+                        role_type=self.role_type,
+                        meta_dict={},
+                        content=display_content,
+                        reasoning_content=display_reasoning,
+                    )
+
+                    if response_format and has_final_content:
+                        self._try_format_message(
+                            final_message, response_format
                         )
 
-                        if response_format:
-                            self._try_format_message(
-                                final_message, response_format
-                            )
-
-                        # Create final response with final usage (not partial)
-                        final_response = ChatAgentResponse(
-                            msgs=[final_message],
-                            terminated=False,
-                            info={
-                                "id": getattr(chunk, 'id', ''),
-                                "usage": step_token_usage.copy(),
-                                "finish_reasons": [terminal_finish_reason],
-                                "num_tokens": self._get_token_count(
-                                    final_content
-                                ),
-                                "tool_calls": tool_call_records or [],
-                                "external_tool_requests": None,
-                                "streaming": False,
-                                "partial": False,
-                                "stream_accumulate_mode": "accumulate"
-                                if self.stream_accumulate
-                                else "delta",
-                            },
-                        )
-                        yield final_response
+                    # Create final response with final usage (not partial).
+                    # Always yield so a truncated/filtered terminal outcome
+                    # with no text content still surfaces its
+                    # finish_reasons (see #4250).
+                    final_response = ChatAgentResponse(
+                        msgs=[final_message],
+                        terminated=False,
+                        info={
+                            "id": getattr(chunk, 'id', ''),
+                            "usage": step_token_usage.copy(),
+                            "finish_reasons": [terminal_finish_reason],
+                            "num_tokens": self._get_token_count(final_content),
+                            "tool_calls": tool_call_records or [],
+                            "external_tool_requests": None,
+                            "streaming": False,
+                            "partial": False,
+                            "stream_accumulate_mode": "accumulate"
+                            if self.stream_accumulate
+                            else "delta",
+                        },
+                    )
+                    yield final_response
                     break
             elif stream_completed:
                 # We've seen finish_reason but no usage chunk yet; keep
@@ -5954,12 +5956,13 @@ class ChatAgent(BaseAgent):
                 should_finalize = stream_completed or not has_choices
                 if should_finalize:
                     final_content = content_accumulator.get_full_content()
-                    if final_content.strip():
-                        final_reasoning = (
-                            content_accumulator.get_full_reasoning_content()
-                            or None
-                        )
+                    final_reasoning = (
+                        content_accumulator.get_full_reasoning_content()
+                        or None
+                    )
+                    has_final_content = bool(final_content.strip())
 
+                    if has_final_content:
                         # Extract <think> tags from accumulated
                         # streaming content when reasoning_content
                         # is not already set by the model.
@@ -5969,48 +5972,49 @@ class ChatAgent(BaseAgent):
                             )
                         )
 
-                        # In delta mode, final response content should be empty
-                        # since all content was already yielded incrementally
-                        display_content = (
-                            final_content if self.stream_accumulate else ""
-                        )
-                        display_reasoning = (
-                            final_reasoning if self.stream_accumulate else None
-                        )
-                        final_message = BaseMessage(
-                            role_name=self.role_name,
-                            role_type=self.role_type,
-                            meta_dict={},
-                            content=display_content,
-                            reasoning_content=display_reasoning,
+                    # In delta mode, final response content should be empty
+                    # since all content was already yielded incrementally
+                    display_content = (
+                        final_content if self.stream_accumulate else ""
+                    )
+                    display_reasoning = (
+                        final_reasoning if self.stream_accumulate else None
+                    )
+                    final_message = BaseMessage(
+                        role_name=self.role_name,
+                        role_type=self.role_type,
+                        meta_dict={},
+                        content=display_content,
+                        reasoning_content=display_reasoning,
+                    )
+
+                    if response_format and has_final_content:
+                        self._try_format_message(
+                            final_message, response_format
                         )
 
-                        if response_format:
-                            self._try_format_message(
-                                final_message, response_format
-                            )
-
-                        # Create final response with final usage (not partial)
-                        final_response = ChatAgentResponse(
-                            msgs=[final_message],
-                            terminated=False,
-                            info={
-                                "id": getattr(chunk, 'id', ''),
-                                "usage": step_token_usage.copy(),
-                                "finish_reasons": [terminal_finish_reason],
-                                "num_tokens": self._get_token_count(
-                                    final_content
-                                ),
-                                "tool_calls": tool_call_records or [],
-                                "external_tool_requests": None,
-                                "streaming": False,
-                                "partial": False,
-                                "stream_accumulate_mode": "accumulate"
-                                if self.stream_accumulate
-                                else "delta",
-                            },
-                        )
-                        yield final_response
+                    # Create final response with final usage (not partial).
+                    # Always yield so a truncated/filtered terminal outcome
+                    # with no text content still surfaces its
+                    # finish_reasons (see #4250).
+                    final_response = ChatAgentResponse(
+                        msgs=[final_message],
+                        terminated=False,
+                        info={
+                            "id": getattr(chunk, 'id', ''),
+                            "usage": step_token_usage.copy(),
+                            "finish_reasons": [terminal_finish_reason],
+                            "num_tokens": self._get_token_count(final_content),
+                            "tool_calls": tool_call_records or [],
+                            "external_tool_requests": None,
+                            "streaming": False,
+                            "partial": False,
+                            "stream_accumulate_mode": "accumulate"
+                            if self.stream_accumulate
+                            else "delta",
+                        },
+                    )
+                    yield final_response
                     break
             elif stream_completed:
                 continue

--- a/camel/agents/chat_agent.py
+++ b/camel/agents/chat_agent.py
@@ -4696,6 +4696,9 @@ class ChatAgent(BaseAgent):
         tool_calls_complete = False
         stream_completed = False
         last_response_id = ""
+        # Preserve the model adapter's terminal finish_reason (e.g.
+        # "length" / "content_filter") instead of always reporting "stop".
+        terminal_finish_reason = "stop"
 
         for chunk in stream:
             last_response_id = getattr(chunk, 'id', '') or last_response_id
@@ -4750,6 +4753,7 @@ class ChatAgent(BaseAgent):
                 # Check if stream is complete
                 if choice.finish_reason:
                     stream_completed = True
+                    terminal_finish_reason = choice.finish_reason
 
                     # If we have complete tool calls, execute them with
                     # sync status updates
@@ -4859,7 +4863,7 @@ class ChatAgent(BaseAgent):
                             info={
                                 "id": getattr(chunk, 'id', ''),
                                 "usage": step_token_usage.copy(),
-                                "finish_reasons": ["stop"],
+                                "finish_reasons": [terminal_finish_reason],
                                 "num_tokens": self._get_token_count(
                                     final_content
                                 ),
@@ -5824,6 +5828,9 @@ class ChatAgent(BaseAgent):
         tool_calls_complete = False
         stream_completed = False
         last_response_id = ""
+        # Preserve the model adapter's terminal finish_reason (e.g.
+        # "length" / "content_filter") instead of always reporting "stop".
+        terminal_finish_reason = "stop"
 
         async for chunk in stream:
             last_response_id = getattr(chunk, 'id', '') or last_response_id
@@ -5878,6 +5885,7 @@ class ChatAgent(BaseAgent):
                 # Check if stream is complete
                 if choice.finish_reason:
                     stream_completed = True
+                    terminal_finish_reason = choice.finish_reason
 
                     # If we have complete tool calls, execute them with
                     # async status updates
@@ -5989,7 +5997,7 @@ class ChatAgent(BaseAgent):
                             info={
                                 "id": getattr(chunk, 'id', ''),
                                 "usage": step_token_usage.copy(),
-                                "finish_reasons": ["stop"],
+                                "finish_reasons": [terminal_finish_reason],
                                 "num_tokens": self._get_token_count(
                                     final_content
                                 ),

--- a/camel/models/openai_compatible_model.py
+++ b/camel/models/openai_compatible_model.py
@@ -785,6 +785,13 @@ class OpenAICompatibleModel(BaseModelBackend):
             model=self.model_type,
             **request_config,
         )
+        # Convert first so a failed Responses call raises before any
+        # previous_response_id chaining state is recorded.
+        completion = response_to_chat_completion(
+            response=response,
+            model=str(self.model_type),
+            response_format=response_format,
+        )
         if chain_enabled:
             self._save_response_chain_state(
                 session_key=chain_state["session_key"],
@@ -793,11 +800,7 @@ class OpenAICompatibleModel(BaseModelBackend):
                 else response.get("id"),
                 message_count=chain_state["message_count"],
             )
-        return response_to_chat_completion(
-            response=response,
-            model=str(self.model_type),
-            response_format=response_format,
-        )
+        return completion
 
     async def _arequest_responses(
         self,
@@ -825,6 +828,13 @@ class OpenAICompatibleModel(BaseModelBackend):
             model=self.model_type,
             **request_config,
         )
+        # Convert first so a failed Responses call raises before any
+        # previous_response_id chaining state is recorded.
+        completion = response_to_chat_completion(
+            response=response,
+            model=str(self.model_type),
+            response_format=response_format,
+        )
         if chain_enabled:
             self._save_response_chain_state(
                 session_key=chain_state["session_key"],
@@ -833,11 +843,7 @@ class OpenAICompatibleModel(BaseModelBackend):
                 else response.get("id"),
                 message_count=chain_state["message_count"],
             )
-        return response_to_chat_completion(
-            response=response,
-            model=str(self.model_type),
-            response_format=response_format,
-        )
+        return completion
 
     def _request_responses_stream(
         self,

--- a/camel/models/openai_model.py
+++ b/camel/models/openai_model.py
@@ -718,6 +718,13 @@ class OpenAIModel(BaseModelBackend):
             model=self.model_type,
             **request_config,
         )
+        # Convert first so a failed Responses call raises before any
+        # previous_response_id chaining state is recorded.
+        completion = response_to_chat_completion(
+            response=response,
+            model=str(self.model_type),
+            response_format=response_format,
+        )
         if chain_enabled:
             self._save_response_chain_state(
                 session_key=chain_state["session_key"],
@@ -726,11 +733,7 @@ class OpenAIModel(BaseModelBackend):
                 else response.get("id"),
                 message_count=chain_state["message_count"],
             )
-        return response_to_chat_completion(
-            response=response,
-            model=str(self.model_type),
-            response_format=response_format,
-        )
+        return completion
 
     async def _arequest_responses(
         self,
@@ -758,6 +761,13 @@ class OpenAIModel(BaseModelBackend):
             model=self.model_type,
             **request_config,
         )
+        # Convert first so a failed Responses call raises before any
+        # previous_response_id chaining state is recorded.
+        completion = response_to_chat_completion(
+            response=response,
+            model=str(self.model_type),
+            response_format=response_format,
+        )
         if chain_enabled:
             self._save_response_chain_state(
                 session_key=chain_state["session_key"],
@@ -766,11 +776,7 @@ class OpenAIModel(BaseModelBackend):
                 else response.get("id"),
                 message_count=chain_state["message_count"],
             )
-        return response_to_chat_completion(
-            response=response,
-            model=str(self.model_type),
-            response_format=response_format,
-        )
+        return completion
 
     def _request_responses_stream(
         self,

--- a/camel/models/openai_responses_adapter.py
+++ b/camel/models/openai_responses_adapter.py
@@ -58,6 +58,31 @@ _INCOMPLETE_REASON_TO_FINISH_REASON = {
 }
 
 
+def _failed_response_error_message(response: Any) -> str:
+    error = _get(response, "error")
+    error_code = _get(error, "code")
+    error_message = _get(error, "message") or "Unknown error"
+    if error_code:
+        error_message = f"{error_code}: {error_message}"
+    return error_message
+
+
+def _raise_for_failed_response(response: Any) -> None:
+    r"""Raise when a Responses API call terminated with ``status ==
+    "failed"``.
+
+    Streaming already surfaces ``response.failed`` as ``RuntimeError``.
+    Non-streaming must do the same so a failed call is not converted into
+    a normal Chat Completions result with ``finish_reason='stop'``.
+    """
+    if _get(response, "status") != "failed":
+        return
+    raise RuntimeError(
+        "Responses API response failed: "
+        f"{_failed_response_error_message(response)}"
+    )
+
+
 def _finish_reason_from_response(
     response: Any, *, has_tool_calls: bool
 ) -> str:
@@ -69,6 +94,9 @@ def _finish_reason_from_response(
     "max_output_tokens"``, which the Chat Completions contract reports as
     ``"length"``. Any other terminal response is ``"tool_calls"`` when it
     emitted tool calls, otherwise ``"stop"`` (the prior behavior).
+
+    Failed responses are not mapped here; callers must raise via
+    :func:`_raise_for_failed_response` before invoking this helper.
     """
     status = _get(response, "status")
     if status == "incomplete":
@@ -265,12 +293,10 @@ def _process_response_stream_event(
 
     if event_type == "response.failed":
         resp = _get(event, "response")
-        error = _get(resp, "error")
-        error_code = _get(error, "code")
-        error_message = _get(error, "message") or "Unknown error"
-        if error_code:
-            error_message = f"{error_code}: {error_message}"
-        raise RuntimeError(f"Responses API response failed: {error_message}")
+        raise RuntimeError(
+            "Responses API response failed: "
+            f"{_failed_response_error_message(resp)}"
+        )
 
     if event_type in ("response.completed", "response.incomplete"):
         resp = _get(event, "response")
@@ -301,6 +327,8 @@ def response_to_chat_completion(
     model: str,
     response_format: Optional[Type[BaseModel]] = None,
 ) -> ChatCompletion:
+    _raise_for_failed_response(response)
+
     output_items = _get(response, "output", []) or []
     content = ""
     tool_calls = []

--- a/test/agents/test_chat_agent.py
+++ b/test/agents/test_chat_agent.py
@@ -2329,3 +2329,120 @@ async def test_chat_agent_async_stream_with_structured_output():
     assert len(responses) > 1, "Should receive multiple streaming chunks"
     assert responses[-1].msg.parsed.answer == 6
     assert responses[-1].msg.parsed.explanation
+
+
+def _length_finish_reason_chunks():
+    from openai.types.chat.chat_completion_chunk import (
+        ChatCompletionChunk,
+        ChoiceDelta,
+    )
+    from openai.types.chat.chat_completion_chunk import (
+        Choice as ChunkChoice,
+    )
+
+    return [
+        ChatCompletionChunk(
+            id="mock_stream_length_1",
+            choices=[
+                ChunkChoice(
+                    delta=ChoiceDelta(content="partial", role="assistant"),
+                    index=0,
+                    finish_reason=None,
+                )
+            ],
+            created=1234567890,
+            model="gpt-4o-mini",
+            object="chat.completion.chunk",
+        ),
+        ChatCompletionChunk(
+            id="mock_stream_length_1",
+            choices=[
+                ChunkChoice(
+                    delta=ChoiceDelta(content=""),
+                    index=0,
+                    finish_reason="length",
+                )
+            ],
+            created=1234567890,
+            model="gpt-4o-mini",
+            object="chat.completion.chunk",
+            usage={
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "total_tokens": 15,
+            },
+        ),
+    ]
+
+
+def test_chat_agent_stream_preserves_length_finish_reason():
+    r"""ChatAgent must keep the adapter's terminal finish_reason.
+
+    Regression for #4250: `_process_stream_chunks_with_accumulator` used to
+    hardcode ``finish_reasons: ["stop"]`` even when the model stream ended
+    with ``finish_reason="length"`` (e.g. Responses ``response.incomplete``).
+    """
+    system_message = BaseMessage(
+        role_name="assistant",
+        role_type=RoleType.ASSISTANT,
+        meta_dict=None,
+        content="You are a help assistant.",
+    )
+    model = OpenAIModel(
+        model_type=ModelType.GPT_4O_MINI,
+        model_config_dict={"stream": True},
+        api_key="dummy",
+    )
+    agent = ChatAgent(
+        system_message=system_message,
+        model=model,
+        stream_accumulate=False,
+    )
+
+    chunks = _length_finish_reason_chunks()
+
+    def mock_stream():
+        for chunk in chunks:
+            yield chunk
+
+    agent.model_backend.run = MagicMock(return_value=mock_stream())
+
+    responses = list(agent.step("Continue until truncated"))
+    assert responses
+    assert responses[-1].info["finish_reasons"] == ["length"]
+
+
+@pytest.mark.asyncio
+async def test_chat_agent_async_stream_preserves_length_finish_reason():
+    r"""Async mirror of the #4250 ChatAgent finish_reason regression."""
+    system_message = BaseMessage(
+        role_name="assistant",
+        role_type=RoleType.ASSISTANT,
+        meta_dict=None,
+        content="You are a help assistant.",
+    )
+    model = OpenAIModel(
+        model_type=ModelType.GPT_4O_MINI,
+        model_config_dict={"stream": True},
+        api_key="dummy",
+    )
+    agent = ChatAgent(
+        system_message=system_message,
+        model=model,
+        stream_accumulate=False,
+    )
+
+    chunks = _length_finish_reason_chunks()
+
+    async def mock_async_stream():
+        for chunk in chunks:
+            yield chunk
+
+    agent.model_backend.arun = AsyncMock(return_value=mock_async_stream())
+
+    responses = []
+    async for response in await agent.astep("Continue until truncated"):
+        responses.append(response)
+
+    assert responses
+    assert responses[-1].info["finish_reasons"] == ["length"]

--- a/test/agents/test_chat_agent.py
+++ b/test/agents/test_chat_agent.py
@@ -2446,3 +2446,109 @@ async def test_chat_agent_async_stream_preserves_length_finish_reason():
 
     assert responses
     assert responses[-1].info["finish_reasons"] == ["length"]
+
+
+def _empty_content_filter_chunks():
+    from openai.types.chat.chat_completion_chunk import (
+        ChatCompletionChunk,
+        ChoiceDelta,
+    )
+    from openai.types.chat.chat_completion_chunk import (
+        Choice as ChunkChoice,
+    )
+
+    return [
+        ChatCompletionChunk(
+            id="mock_stream_content_filter_1",
+            choices=[
+                ChunkChoice(
+                    delta=ChoiceDelta(content="", role="assistant"),
+                    index=0,
+                    finish_reason="content_filter",
+                )
+            ],
+            created=1234567890,
+            model="gpt-4o-mini",
+            object="chat.completion.chunk",
+            usage={
+                "prompt_tokens": 10,
+                "completion_tokens": 0,
+                "total_tokens": 10,
+            },
+        ),
+    ]
+
+
+def test_chat_agent_stream_preserves_finish_reason_with_empty_content():
+    r"""ChatAgent must still surface the terminal finish_reason even when
+    the model produced no text content.
+
+    Regression for #4250: the final response was only yielded when
+    ``final_content.strip()`` was truthy, so a terminal outcome like
+    ``content_filter`` with empty content silently dropped its
+    finish_reason instead of surfacing it to the caller.
+    """
+    system_message = BaseMessage(
+        role_name="assistant",
+        role_type=RoleType.ASSISTANT,
+        meta_dict=None,
+        content="You are a help assistant.",
+    )
+    model = OpenAIModel(
+        model_type=ModelType.GPT_4O_MINI,
+        model_config_dict={"stream": True},
+        api_key="dummy",
+    )
+    agent = ChatAgent(
+        system_message=system_message,
+        model=model,
+        stream_accumulate=False,
+    )
+
+    chunks = _empty_content_filter_chunks()
+
+    def mock_stream():
+        for chunk in chunks:
+            yield chunk
+
+    agent.model_backend.run = MagicMock(return_value=mock_stream())
+
+    responses = list(agent.step("Say something unsafe"))
+    assert responses
+    assert responses[-1].info["finish_reasons"] == ["content_filter"]
+
+
+@pytest.mark.asyncio
+async def test_chat_agent_async_stream_preserves_finish_reason_with_empty_content():  # noqa: E501
+    r"""Async mirror of the empty-content finish_reason regression."""
+    system_message = BaseMessage(
+        role_name="assistant",
+        role_type=RoleType.ASSISTANT,
+        meta_dict=None,
+        content="You are a help assistant.",
+    )
+    model = OpenAIModel(
+        model_type=ModelType.GPT_4O_MINI,
+        model_config_dict={"stream": True},
+        api_key="dummy",
+    )
+    agent = ChatAgent(
+        system_message=system_message,
+        model=model,
+        stream_accumulate=False,
+    )
+
+    chunks = _empty_content_filter_chunks()
+
+    async def mock_async_stream():
+        for chunk in chunks:
+            yield chunk
+
+    agent.model_backend.arun = AsyncMock(return_value=mock_async_stream())
+
+    responses = []
+    async for response in await agent.astep("Say something unsafe"):
+        responses.append(response)
+
+    assert responses
+    assert responses[-1].info["finish_reasons"] == ["content_filter"]

--- a/test/models/test_openai_compatible_model.py
+++ b/test/models/test_openai_compatible_model.py
@@ -65,6 +65,39 @@ def test_openai_compatible_model_apikey_from_env(monkeypatch: MonkeyPatch):
     assert model._async_client.base_url == URL(url)
 
 
+def test_openai_compatible_responses_failed_does_not_save_chain_state():
+    mock_client = MagicMock()
+    mock_client.responses.create.return_value = {
+        "id": "resp_failed",
+        "created_at": 1741294021,
+        "status": "failed",
+        "error": {
+            "code": "server_error",
+            "message": "generation failed",
+        },
+        "incomplete_details": None,
+        "usage": None,
+        "output": [],
+    }
+
+    model = OpenAICompatibleModel(
+        model_type="dummy-model",
+        api_key="dummy",
+        url="https://example.invalid",
+        api_mode="responses",
+        client=mock_client,
+        async_client=MagicMock(),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="server_error: generation failed",
+    ):
+        model.run([{"role": "user", "content": "Hello"}])
+
+    assert model._responses_previous_response_id_by_session == {}
+
+
 def test_openai_compatible_responses_use_agent_session_scope_without_langfuse(
     monkeypatch,
 ):

--- a/test/models/test_openai_model.py
+++ b/test/models/test_openai_model.py
@@ -293,6 +293,81 @@ def test_responses_stream_tool_call_arguments_not_duplicated():
         assert chunks[-1].choices[0].finish_reason == "tool_calls"
 
 
+def test_responses_mode_failed_does_not_save_chain_state():
+    with patch("camel.models.openai_model.OpenAI") as mock_openai:
+        mock_client = MagicMock()
+        mock_openai.return_value = mock_client
+
+        mock_client.responses.create.return_value = {
+            "id": "resp_failed",
+            "created_at": 1741294021,
+            "status": "failed",
+            "error": {
+                "code": "server_error",
+                "message": "generation failed",
+            },
+            "incomplete_details": None,
+            "usage": None,
+            "output": [],
+        }
+
+        model = OpenAIModel(
+            model_type=ModelType.GPT_4O_MINI,
+            api_mode="responses",
+            api_key="dummy",
+        )
+
+        with pytest.raises(
+            RuntimeError,
+            match="server_error: generation failed",
+        ):
+            model.run([{"role": "user", "content": "Hello"}])
+
+        assert model._responses_previous_response_id_by_session == {}
+
+
+@pytest.mark.asyncio
+async def test_responses_mode_failed_async_does_not_save_chain_state():
+    with (
+        patch("camel.models.openai_model.OpenAI") as mock_openai,
+        patch("camel.models.openai_model.AsyncOpenAI") as mock_async_openai,
+    ):
+        mock_client = MagicMock()
+        mock_openai.return_value = mock_client
+        mock_async_client = MagicMock()
+        mock_async_openai.return_value = mock_async_client
+
+        async def _failed_create(**kwargs):
+            return {
+                "id": "resp_failed_async",
+                "created_at": 1741294021,
+                "status": "failed",
+                "error": {
+                    "code": "server_error",
+                    "message": "generation failed",
+                },
+                "incomplete_details": None,
+                "usage": None,
+                "output": [],
+            }
+
+        mock_async_client.responses.create = _failed_create
+
+        model = OpenAIModel(
+            model_type=ModelType.GPT_4O_MINI,
+            api_mode="responses",
+            api_key="dummy",
+        )
+
+        with pytest.raises(
+            RuntimeError,
+            match="server_error: generation failed",
+        ):
+            await model.arun([{"role": "user", "content": "Hello"}])
+
+        assert model._responses_previous_response_id_by_session == {}
+
+
 def test_responses_mode_uses_previous_response_id_and_delta_input():
     with patch("camel.models.openai_model.OpenAI") as mock_openai:
         mock_client = MagicMock()
@@ -301,6 +376,7 @@ def test_responses_mode_uses_previous_response_id_and_delta_input():
         first_response = {
             "id": "resp_first",
             "created_at": 1741294021,
+            "status": "completed",
             "usage": {
                 "input_tokens": 10,
                 "output_tokens": 6,
@@ -317,6 +393,7 @@ def test_responses_mode_uses_previous_response_id_and_delta_input():
         second_response = {
             "id": "resp_second",
             "created_at": 1741294022,
+            "status": "completed",
             "usage": {
                 "input_tokens": 11,
                 "output_tokens": 5,

--- a/test/models/test_openai_responses_adapter.py
+++ b/test/models/test_openai_responses_adapter.py
@@ -54,7 +54,7 @@ def _tool_item():
     )
 
 
-def _response(*, status, output, incomplete_reason=None):
+def _response(*, status, output, incomplete_reason=None, error=None):
     return SimpleNamespace(
         id="resp_1",
         created_at=1234567890,
@@ -64,6 +64,7 @@ def _response(*, status, output, incomplete_reason=None):
             if incomplete_reason is not None
             else None
         ),
+        error=error,
         output=output,
         usage=_usage(),
     )
@@ -118,6 +119,24 @@ def test_non_streaming_completed_tool_call_is_tool_calls():
     completion = response_to_chat_completion(response, MODEL)
 
     assert completion.choices[0].finish_reason == "tool_calls"
+
+
+def test_non_streaming_failed_raises_instead_of_stop():
+    # A failed Responses call must not look like a normal completion.
+    response = _response(
+        status="failed",
+        output=[],
+        error=SimpleNamespace(
+            code="server_error",
+            message="generation failed",
+        ),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="server_error: generation failed",
+    ):
+        response_to_chat_completion(response, MODEL)
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
### Related Issue

Closes #4250

### Description

Follow-up to #4215/#4216: Responses terminal outcomes were still inconsistent across paths.

1. **Non-streaming `status == "failed"`** — `response_to_chat_completion()` ignored failures and returned `finish_reason='stop'`. It now raises `RuntimeError`, matching the streaming `response.failed` path (Chat Completions has no `failed` finish_reason).
2. **Chaining** — `OpenAIModel` / `OpenAICompatibleModel` now convert before saving `previous_response_id`, so a failed response id is never recorded (sync + async).
3. **ChatAgent** — `_process_stream_chunks_with_accumulator` / `_aprocess_stream_chunks_with_accumulator` preserve the adapter's terminal `finish_reason` (e.g. `"length"`) instead of hardcoding `["stop"]`.

Normal completed Responses / Chat Completions behavior is unchanged.

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Checklist

- [x] I have read and agree to the [AI-Generated Code Policy](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md#ai-generated-code-policy) (**required**)
- [x] I have linked this PR to an issue (**required**)
- [x] I have checked if any dependencies need to be added or updated in `pyproject.toml` and run `uv lock`
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [x] I have updated the documentation if needed
- [x] I have added examples if this is a new feature

### Test plan / proof

```text
OPENAI_API_KEY=dummy pytest \
  test/models/test_openai_responses_adapter.py \
  test/models/test_openai_model.py::test_responses_mode_failed_does_not_save_chain_state \
  test/models/test_openai_model.py::test_responses_mode_failed_async_does_not_save_chain_state \
  test/models/test_openai_compatible_model.py::test_openai_compatible_responses_failed_does_not_save_chain_state \
  test/agents/test_chat_agent.py::test_chat_agent_stream_preserves_length_finish_reason \
  test/agents/test_chat_agent.py::test_chat_agent_async_stream_preserves_length_finish_reason \
  -q --tb=short

.............                                                            [100%]
13 passed in 0.92s
```

Also ran `pre-commit` on the touched files: `ruff`, `ruff-format`, license, codespell, trailing-whitespace hooks passed. Local `mypy` failed only on missing optional third-party stubs unrelated to this change.


