### PR TITLE
fix: update Nebius provider for Token Factory

### DIFF
--- a/camel/configs/nebius_config.py
+++ b/camel/configs/nebius_config.py
@@ -20,9 +20,9 @@ from camel.configs.base_config import BaseConfig
 
 class NebiusConfig(BaseConfig):
     r"""Defines the parameters for generating chat completions using OpenAI
-    compatibility with Nebius AI Studio.
+    compatibility with Nebius Token Factory.
 
-    Reference: https://nebius.com/docs/ai-studio/api
+    Reference: https://docs.tokenfactory.nebius.com/api-reference/introduction
 
     Args:
         temperature (float, optional): Sampling temperature to use, between

--- a/camel/models/nebius_model.py
+++ b/camel/models/nebius_model.py
@@ -24,7 +24,7 @@ from camel.utils import (
 
 
 class NebiusModel(OpenAICompatibleModel):
-    r"""LLM API served by Nebius AI Studio in a unified OpenAICompatibleModel
+    r"""LLM API served by Nebius Token Factory in an OpenAI-compatible
     interface.
 
     Args:
@@ -35,8 +35,8 @@ class NebiusModel(OpenAICompatibleModel):
             If:obj:`None`, :obj:`NebiusConfig().as_dict()` will be used.
             (default: :obj:`None`)
         api_key (Optional[str], optional): The API key for authenticating
-            with the Nebius AI Studio service. (default: :obj:`None`).
-        url (Optional[str], optional): The url to the Nebius AI Studio service.
+            with Nebius Token Factory. (default: :obj:`None`).
+        url (Optional[str], optional): The URL to Nebius Token Factory.
             (default: :obj:`None`)
         token_counter (Optional[BaseTokenCounter], optional): Token counter to
             use for the model. If not provided, :obj:`OpenAITokenCounter(
@@ -68,7 +68,8 @@ class NebiusModel(OpenAICompatibleModel):
             model_config_dict = NebiusConfig().as_dict()
         api_key = api_key or os.environ.get("NEBIUS_API_KEY")
         url = url or os.environ.get(
-            "NEBIUS_API_BASE_URL", "https://api.studio.nebius.com/v1"
+            "NEBIUS_API_BASE_URL",
+            "https://api.tokenfactory.nebius.com/v1",
         )
         timeout = timeout or float(os.environ.get("MODEL_TIMEOUT", 180))
         super().__init__(

--- a/camel/types/enums.py
+++ b/camel/types/enums.py
@@ -124,7 +124,7 @@ class ModelType(UnifiedModelType, Enum):
     CEREBRAS_QWEN_3_32B = "qwen-3-32b"
 
     # Nebius AI Studio platform models
-    NEBIUS_GPT_OSS_120B = "gpt-oss-120b"
+    NEBIUS_GPT_OSS_120B = "openai/gpt-oss-120b"
     NEBIUS_GPT_OSS_20B = "gpt-oss-20b"
     NEBIUS_GLM_4_5 = "GLM-4.5"
     NEBIUS_DEEPSEEK_V3 = "deepseek-ai/DeepSeek-V3"

--- a/docs/key_modules/models.md
+++ b/docs/key_modules/models.md
@@ -65,7 +65,7 @@ CAMEL supports a wide range of models, including [OpenAI’s GPT series](https:/
 | **SambaNova**    | [supported models](https://docs.sambanova.ai/cloud/docs/get-started/supported-models) |
 | **Ollama**       | [supported models](https://ollama.com/library) |
 | **CometAPI**     | [supported models](https://api.cometapi.com/pricing) |
-| **Nebius**       | [supported models](https://studio.nebius.com/) |
+| **Nebius**       | [supported models](https://tokenfactory.nebius.com/model-catalog.md) |
 | **OpenRouter**   | [supported models](https://openrouter.ai/models) |
 | **OrcaRouter**   | [supported models](https://www.orcarouter.ai/models) |
 | **PPIO**         | [supported models](https://ppio.com/model-api/console) |
@@ -283,21 +283,21 @@ Integrate your favorite models into CAMEL-AI with straightforward Python calls. 
 
   <Tab title="Nebius">
 
-  Leverage [Nebius AI Studio](https://nebius.com/)'s high-performance GPU cloud with OpenAI-compatible models:
+  Use [Nebius Token Factory](https://tokenfactory.nebius.com/) with CAMEL's OpenAI-compatible model interface:
 
- - **Nebius AI Studio** ([Platform](https://studio.nebius.com/)): Access powerful models through their cloud infrastructure.
- - **API Key Setup** ([Generate Key](https://studio.nebius.ai/settings/api-keys)): Obtain your Nebius API key to start integration.
- - **Nebius Docs** ([Documentation](https://nebius.com/docs/)): Explore detailed Nebius API capabilities.
+ - **Token Factory** ([Platform](https://tokenfactory.nebius.com/)): Run models through the managed inference API.
+ - **API Key Setup** ([Generate Key](https://tokenfactory.nebius.com/)): Obtain a Token Factory API key.
+ - **Token Factory Docs** ([Documentation](https://docs.tokenfactory.nebius.com/)): Explore the API and supported capabilities.
 
   ```python
   from camel.models import ModelFactory
-  from camel.types import ModelPlatformType, ModelType
+  from camel.types import ModelPlatformType
   from camel.configs import NebiusConfig
   from camel.agents import ChatAgent
 
   model = ModelFactory.create(
       model_platform=ModelPlatformType.NEBIUS,
-      model_type=ModelType.NEBIUS_GPT_OSS_120B,
+      model_type="openai/gpt-oss-120b",
       model_config_dict=NebiusConfig(temperature=0.2).as_dict(),
   )
 
@@ -311,26 +311,26 @@ Integrate your favorite models into CAMEL-AI with straightforward Python calls. 
   ```
 
   <Note type="info">
-    **Flexible Model Access:** You can use any model available on Nebius by passing the model name as a string to `model_type`, even if it's not in the predefined enums.
+    **Flexible Model Access:** Pass a model ID from the live [Token Factory model catalog](https://tokenfactory.nebius.com/model-catalog.md) as a string to `model_type`. This avoids coupling an application to CAMEL's legacy convenience enums as the catalog changes.
   </Note>
 
   **Environment Variables:**
   ```bash
   export NEBIUS_API_KEY="your_nebius_api_key"
-  export NEBIUS_API_BASE_URL="https://api.studio.nebius.com/v1"  # Optional
+  export NEBIUS_API_BASE_URL="https://api.tokenfactory.nebius.com/v1"  # Optional
   ```
 
   **Model Support:**
-  - **Complete Access:** All models available on [Nebius AI Studio](https://studio.nebius.com/) are supported
-  - **Predefined Enums:** Common models like `NEBIUS_GPT_OSS_120B`, `NEBIUS_DEEPSEEK_V3`, etc.
-  - **String-based Access:** Use any model name directly as a string for maximum flexibility
+  - **Catalog-backed selection:** Choose an active model ID from the [public catalog](https://tokenfactory.nebius.com/model-catalog.md)
+  - **String-based access:** Use the catalog model ID directly so newly available models do not require a CAMEL release
+  - **Compatibility:** Existing `NEBIUS_*` enum values remain available, but their upstream model lifecycle may differ
 
   **Example with any model:**
   ```python
-  # Use any model available on Nebius
+  # Use any active model ID from the Token Factory model catalog
   model = ModelFactory.create(
       model_platform=ModelPlatformType.NEBIUS,
-      model_type="your-custom-model-name"  # Any Nebius model
+      model_type="openai/gpt-oss-120b"
   )
   ```
 

--- a/docs/mintlify/key_modules/models.mdx
+++ b/docs/mintlify/key_modules/models.mdx
@@ -65,7 +65,7 @@ CAMEL supports a wide range of models, including [OpenAI’s GPT series](https:/
 | **SambaNova**    | [supported models](https://docs.sambanova.ai/cloud/docs/get-started/supported-models) |
 | **Ollama**       | [supported models](https://ollama.com/library) |
 | **CometAPI**     | [supported models](https://api.cometapi.com/pricing) |
-| **Nebius**       | [supported models](https://studio.nebius.com/) |
+| **Nebius**       | [supported models](https://tokenfactory.nebius.com/model-catalog.md) |
 | **OpenRouter**   | [supported models](https://openrouter.ai/models) |
 | **OrcaRouter**   | [supported models](https://www.orcarouter.ai/models) |
 | **PPIO**         | [supported models](https://ppio.com/model-api/console) |
@@ -283,21 +283,21 @@ Integrate your favorite models into CAMEL-AI with straightforward Python calls. 
 
   <Tab title="Nebius">
 
-  Leverage [Nebius AI Studio](https://nebius.com/)'s high-performance GPU cloud with OpenAI-compatible models:
+  Use [Nebius Token Factory](https://tokenfactory.nebius.com/) with CAMEL's OpenAI-compatible model interface:
 
- - **Nebius AI Studio** ([Platform](https://studio.nebius.com/)): Access powerful models through their cloud infrastructure.
- - **API Key Setup** ([Generate Key](https://studio.nebius.ai/settings/api-keys)): Obtain your Nebius API key to start integration.
- - **Nebius Docs** ([Documentation](https://nebius.com/docs/)): Explore detailed Nebius API capabilities.
+ - **Token Factory** ([Platform](https://tokenfactory.nebius.com/)): Run models through the managed inference API.
+ - **API Key Setup** ([Generate Key](https://tokenfactory.nebius.com/)): Obtain a Token Factory API key.
+ - **Token Factory Docs** ([Documentation](https://docs.tokenfactory.nebius.com/)): Explore the API and supported capabilities.
 
   ```python
   from camel.models import ModelFactory
-  from camel.types import ModelPlatformType, ModelType
+  from camel.types import ModelPlatformType
   from camel.configs import NebiusConfig
   from camel.agents import ChatAgent
 
   model = ModelFactory.create(
       model_platform=ModelPlatformType.NEBIUS,
-      model_type=ModelType.NEBIUS_GPT_OSS_120B,
+      model_type="openai/gpt-oss-120b",
       model_config_dict=NebiusConfig(temperature=0.2).as_dict(),
   )
 
@@ -311,26 +311,26 @@ Integrate your favorite models into CAMEL-AI with straightforward Python calls. 
   ```
 
   <Note type="info">
-    **Flexible Model Access:** You can use any model available on Nebius by passing the model name as a string to `model_type`, even if it's not in the predefined enums.
+    **Flexible Model Access:** Pass a model ID from the live [Token Factory model catalog](https://tokenfactory.nebius.com/model-catalog.md) as a string to `model_type`. This avoids coupling an application to CAMEL's legacy convenience enums as the catalog changes.
   </Note>
 
   **Environment Variables:**
   ```bash
   export NEBIUS_API_KEY="your_nebius_api_key"
-  export NEBIUS_API_BASE_URL="https://api.studio.nebius.com/v1"  # Optional
+  export NEBIUS_API_BASE_URL="https://api.tokenfactory.nebius.com/v1"  # Optional
   ```
 
   **Model Support:**
-  - **Complete Access:** All models available on [Nebius AI Studio](https://studio.nebius.com/) are supported
-  - **Predefined Enums:** Common models like `NEBIUS_GPT_OSS_120B`, `NEBIUS_DEEPSEEK_V3`, etc.
-  - **String-based Access:** Use any model name directly as a string for maximum flexibility
+  - **Catalog-backed selection:** Choose an active model ID from the [public catalog](https://tokenfactory.nebius.com/model-catalog.md)
+  - **String-based access:** Use the catalog model ID directly so newly available models do not require a CAMEL release
+  - **Compatibility:** Existing `NEBIUS_*` enum values remain available, but their upstream model lifecycle may differ
 
   **Example with any model:**
   ```python
-  # Use any model available on Nebius
+  # Use any active model ID from the Token Factory model catalog
   model = ModelFactory.create(
       model_platform=ModelPlatformType.NEBIUS,
-      model_type="your-custom-model-name"  # Any Nebius model
+      model_type="openai/gpt-oss-120b"
   )
   ```
 

--- a/examples/models/nebius_model_example.py
+++ b/examples/models/nebius_model_example.py
@@ -15,11 +15,13 @@
 from camel.agents import ChatAgent
 from camel.configs import NebiusConfig
 from camel.models import ModelFactory
-from camel.types import ModelPlatformType, ModelType
+from camel.types import ModelPlatformType
 
 model = ModelFactory.create(
     model_platform=ModelPlatformType.NEBIUS,
-    model_type=ModelType.NEBIUS_GPT_OSS_120B,
+    # The public catalog is the source of truth for current model IDs:
+    # https://tokenfactory.nebius.com/model-catalog.md
+    model_type="openai/gpt-oss-120b",
     model_config_dict=NebiusConfig(temperature=0.2).as_dict(),
 )
 

--- a/test/models/test_nebius_model.py
+++ b/test/models/test_nebius_model.py
@@ -12,7 +12,10 @@
 # limitations under the License.
 # ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
 
+from unittest.mock import MagicMock
+
 import pytest
+from httpx import URL
 
 from camel.configs import NebiusConfig
 from camel.models import NebiusModel
@@ -58,7 +61,7 @@ class TestNebiusModel:
         monkeypatch.setenv("NEBIUS_API_KEY", "test_key")
 
         model = NebiusModel(ModelType.NEBIUS_GPT_OSS_120B)
-        assert model._url == "https://api.studio.nebius.com/v1"
+        assert model._url == URL("https://api.tokenfactory.nebius.com/v1")
 
     def test_nebius_model_custom_url(self, monkeypatch):
         # Test custom URL from environment variable
@@ -81,6 +84,65 @@ class TestNebiusModel:
         # Should use the default OpenAI token counter
         assert model.token_counter is not None
         assert hasattr(model.token_counter, "count_tokens_from_messages")
+
+    @pytest.mark.parametrize("stream", [False, True])
+    def test_nebius_chat_completion_request(self, stream: bool):
+        client = MagicMock()
+        async_client = MagicMock()
+        expected_response = MagicMock()
+        client.chat.completions.create.return_value = expected_response
+        model = NebiusModel(
+            model_type="openai/gpt-oss-120b",
+            model_config_dict=NebiusConfig(stream=stream).as_dict(),
+            api_key="test-key",
+            client=client,
+            async_client=async_client,
+        )
+        messages = [{"role": "user", "content": "Hello"}]
+
+        result = model._run(messages)
+
+        client.chat.completions.create.assert_called_once_with(
+            messages=messages,
+            model="openai/gpt-oss-120b",
+            stream=stream,
+        )
+        assert result is expected_response
+
+    def test_nebius_tool_request(self):
+        client = MagicMock()
+        async_client = MagicMock()
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get the weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                        "required": ["city"],
+                    },
+                },
+            }
+        ]
+        model = NebiusModel(
+            model_type="openai/gpt-oss-120b",
+            model_config_dict=NebiusConfig(tool_choice="auto").as_dict(),
+            api_key="test-key",
+            client=client,
+            async_client=async_client,
+        )
+        messages = [{"role": "user", "content": "Weather in Paris?"}]
+
+        model._run(messages, tools=tools)
+
+        client.chat.completions.create.assert_called_once_with(
+            messages=messages,
+            model="openai/gpt-oss-120b",
+            tool_choice="auto",
+            tools=tools,
+        )
 
     @pytest.mark.parametrize(
         "model_type",

--- a/test/models/test_nebius_model.py
+++ b/test/models/test_nebius_model.py
@@ -85,6 +85,8 @@ class TestNebiusModel:
         assert model.token_counter is not None
         assert hasattr(model.token_counter, "count_tokens_from_messages")
 
+
+class TestNebiusModelRequests:
     @pytest.mark.parametrize("stream", [False, True])
     def test_nebius_chat_completion_request(self, stream: bool):
         client = MagicMock()
@@ -92,7 +94,7 @@ class TestNebiusModel:
         expected_response = MagicMock()
         client.chat.completions.create.return_value = expected_response
         model = NebiusModel(
-            model_type="openai/gpt-oss-120b",
+            model_type=ModelType.NEBIUS_GPT_OSS_120B,
             model_config_dict=NebiusConfig(stream=stream).as_dict(),
             api_key="test-key",
             client=client,
@@ -127,7 +129,7 @@ class TestNebiusModel:
             }
         ]
         model = NebiusModel(
-            model_type="openai/gpt-oss-120b",
+            model_type=ModelType.NEBIUS_GPT_OSS_120B,
             model_config_dict=NebiusConfig(tool_choice="auto").as_dict(),
             api_key="test-key",
             client=client,
@@ -144,6 +146,9 @@ class TestNebiusModel:
             tools=tools,
         )
 
+
+@pytest.mark.model_backend
+class TestNebiusModelTypes:
     @pytest.mark.parametrize(
         "model_type",
         [


### PR DESCRIPTION
### Related Issue

Closes #4270

### Description

CAMEL's existing Nebius provider still used the retired Nebius AI Studio endpoint and branding. This updates that provider to the current Token Factory endpoint while keeping its public configuration and legacy enum values compatible.

The docs and example now use the public model catalog as the source of truth and pass a current model ID as a string. Deterministic mocked-client tests verify non-streaming, streaming, and tool request payloads without a live API key or network request.

This continues to use Chat Completions. It does not add a duplicate provider or claim stateful Responses support.

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Verification

```text
NEBIUS_API_KEY=test-key uv run --no-sync pytest test/models/test_nebius_model.py -q
19 passed in 1.10s

uv run --no-sync ruff check camel/models/nebius_model.py camel/configs/nebius_config.py examples/models/nebius_model_example.py test/models/test_nebius_model.py
All checks passed!

uv run --no-sync ruff format --check camel/models/nebius_model.py camel/configs/nebius_config.py examples/models/nebius_model_example.py test/models/test_nebius_model.py
4 files already formatted
```

### Checklist

- [x] I have read and agree to the [AI-Generated Code Policy](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md#ai-generated-code-policy) (**required; requires human confirmation**)
- [x] I have linked this PR to an issue (**required**)
- [x] I have checked if any dependencies need to be added or updated in `pyproject.toml` and run `uv lock` (none changed)
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [x] I have updated the documentation if needed
- [ ] I have added examples if this is a new feature (not applicable; this repairs an existing provider)
