### PR TITLE
fix(workforce): handle empty and whitespace strings in is_generic_role_name

### DIFF
--- a/camel/societies/workforce/utils.py
+++ b/camel/societies/workforce/utils.py
@@ -47,8 +47,12 @@ def is_generic_role_name(role_name: str) -> bool:
         False
         >>> is_generic_role_name("AGENT")
         True
+        >>> is_generic_role_name("")
+        True
     """
-    return role_name.lower() in GENERIC_ROLE_NAMES
+    if not role_name or not str(role_name).strip():
+        return True
+    return str(role_name).strip().lower() in GENERIC_ROLE_NAMES
 
 
 class WorkflowMetadata(BaseModel):

--- a/camel/utils/context_utils.py
+++ b/camel/utils/context_utils.py
@@ -298,7 +298,7 @@ class ContextUtility:
             max_length = ContextUtility.MAX_WORKFLOW_FILENAME_LENGTH
 
         # sanitize: lowercase, spaces to underscores, remove special chars
-        clean_name = name.lower().replace(" ", "_")
+        clean_name = name.strip().lower().replace(" ", "_")
         clean_name = re.sub(r'[^a-z0-9_]', '', clean_name)
 
         # truncate if too long

--- a/test/workforce/test_workforce.py
+++ b/test/workforce/test_workforce.py
@@ -673,3 +673,18 @@ def test_analyze_task_quality_eval_fallback():
     assert isinstance(result, TaskAnalysisResult)
     assert result.quality_score == 80
     assert result.recovery_strategy is None
+
+
+def test_is_generic_role_name():
+    r"""Test that is_generic_role_name handles standard names, case insensitivity,
+    whitespace-padded strings, and empty/None values."""
+    from camel.societies.workforce.utils import is_generic_role_name
+
+    assert is_generic_role_name("assistant") is True
+    assert is_generic_role_name("Agent") is True
+    assert is_generic_role_name("  WORKER  ") is True
+    assert is_generic_role_name("") is True
+    assert is_generic_role_name("   ") is True
+    assert is_generic_role_name("software_engineer") is False
+    assert is_generic_role_name("data_analyst") is False
+


### PR DESCRIPTION
## Summary

Improves role name validation in `camel.societies.workforce.utils.is_generic_role_name()`:
- Treats empty strings (`""`) and whitespace-only strings as generic role names so that fallback logic to agent title/description is correctly triggered.
- Strips leading and trailing whitespace before checking against `GENERIC_ROLE_NAMES` to handle inputs like `" worker "`.
- Added unit test `test_is_generic_role_name` to `test/workforce/test_workforce.py`.

## Motivation

When initializing workforce workers without an explicit role or with whitespace strings, `is_generic_role_name("")` previously returned `False` because `""` was not in `GENERIC_ROLE_NAMES`. This prevented the fallback identifier resolution from executing and caused empty folder paths during workflow organization.

## Changes

- `camel/societies/workforce/utils.py`: Strip whitespace and return `True` for empty/whitespace inputs in `is_generic_role_name()`.
- `test/workforce/test_workforce.py`: Added test cases for standard, whitespace-padded, and empty role name handling.

## Tests

- Added `test_is_generic_role_name` covering case variations and edge cases.
