### PR TITLE
docs: fix broken links in READMEs, CONTRIBUTING and mintlify docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,7 +160,7 @@ This part outlines the guidelines and best practices for conducting code reviews
   - Readability: Is the code easy to read and understand? Is it well-commented where necessary?
   - Maintainability: Is the code structured in a way that makes future changes easy?
   - Style: Does the code follow the project’s style guidelines?
-  Currently we use Ruff for format check and take [Google Python Style Guide]("https://google.github.io/styleguide/pyguide.html") as reference.
+  Currently we use Ruff for format check and take [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html) as reference.
   - Documentation: Are public methods, classes, and any complex logic well-documented?
 - Design
   - Consistency: Does the code follow established design patterns and project architecture?

--- a/README.ja.md
+++ b/README.ja.md
@@ -351,7 +351,7 @@ CAMEL-AIエージェントと社会を構築、運用、強化するためのコ
 | **[インタープリタ](https://docs.camel-ai.org/key_modules/interpreters)** | コードとコマンドの解釈機能。 |
 | **[データローダー](https://docs.camel-ai.org/key_modules/loaders)** | データ取り込みと前処理ツール。 |
 | **[リトリーバー](https://docs.camel-ai.org/key_modules/retrievers)** | 知識検索とRAGコンポーネント。 |
-| **[ランタイム](https://github.com/camel-ai/camel/tree/master/camel/runtime)** | 実行環境とプロセス管理。 |
+| **[ランタイム](https://github.com/camel-ai/camel/tree/master/camel/runtimes)** | 実行環境とプロセス管理。 |
 | **[ヒューマン・イン・ザ・ループ](https://docs.camel-ai.org/cookbooks/advanced_features/agents_with_human_in_loop_and_tool_approval)** | 人間による監視と介入のための対話型コンポーネント。 |
 ---
 
@@ -633,7 +633,7 @@ We use the CAMEL framework \cite{li2023camel} to develop the agents used in our 
 [star-image]: https://img.shields.io/github/stars/camel-ai/camel?label=stars&logo=github&color=brightgreen
 [star-url]: https://github.com/camel-ai/camel/stargazers
 [package-license-image]: https://img.shields.io/badge/License-Apache_2.0-blue.svg
-[package-license-url]: https://github.com/camel-ai/camel/blob/master/licenses/LICENSE
+[package-license-url]: https://github.com/camel-ai/camel/blob/master/LICENSE
 [package-download-image]: https://img.shields.io/pypi/dm/camel-ai
 
 [colab-url]: https://colab.research.google.com/drive/1AzP33O8rnMW__7ocWJhVBXjKziJXPtim?usp=sharing

--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ Core components and utilities to build, operate, and enhance CAMEL-AI agents and
 | **[Interpreters](https://docs.camel-ai.org/key_modules/interpreters)** | Code and command interpretation capabilities. |
 | **[Data Loaders](https://docs.camel-ai.org/key_modules/loaders)** | Data ingestion and preprocessing tools. |
 | **[Retrievers](https://docs.camel-ai.org/key_modules/retrievers)** | Knowledge retrieval and RAG components. |
-| **[Runtime](https://github.com/camel-ai/camel/tree/master/camel/runtime)** | Execution environment and process management. |
+| **[Runtime](https://github.com/camel-ai/camel/tree/master/camel/runtimes)** | Execution environment and process management. |
 | **[Human-in-the-Loop](https://docs.camel-ai.org/cookbooks/advanced_features/agents_with_human_in_loop_and_tool_approval)** | Interactive components for human oversight and intervention. |
 ---
 
@@ -630,7 +630,7 @@ For more information please contact camel-ai@eigent.ai
 [star-image]: https://img.shields.io/github/stars/camel-ai/camel?label=stars&logo=github&color=brightgreen
 [star-url]: https://github.com/camel-ai/camel/stargazers
 [package-license-image]: https://img.shields.io/badge/License-Apache_2.0-blue.svg
-[package-license-url]: https://github.com/camel-ai/camel/blob/master/licenses/LICENSE
+[package-license-url]: https://github.com/camel-ai/camel/blob/master/LICENSE
 [package-download-image]: https://img.shields.io/pypi/dm/camel-ai
 
 [colab-url]: https://colab.research.google.com/drive/1AzP33O8rnMW__7ocWJhVBXjKziJXPtim?usp=sharing

--- a/README.zh.md
+++ b/README.zh.md
@@ -304,7 +304,7 @@ pip install camel-ai
 | **[Interpreters](https://docs.camel-ai.org/key_modules/interpreters)**                                                     | 代码与指令解释能力。           |
 | **[Data Loaders](https://docs.camel-ai.org/key_modules/loaders)**                                                          | 数据导入与预处理工具。          |
 | **[Retrievers](https://docs.camel-ai.org/key_modules/retrievers)**                                                         | 知识检索与 RAG（检索增强生成）组件。 |
-| **[Runtime](https://github.com/camel-ai/camel/tree/master/camel/runtime)**                                                      | 执行环境与进程管理。           |
+| **[Runtime](https://github.com/camel-ai/camel/tree/master/camel/runtimes)**                                                      | 执行环境与进程管理。           |
 | **[Human-in-the-Loop](https://docs.camel-ai.org/cookbooks/advanced_features/agents_with_human_in_loop_and_tool_approval)** | 支持人工监督与干预的交互组件。      |
 ---
 
@@ -551,7 +551,7 @@ We use the CAMEL framework \cite{li2023camel} to develop the agents used in our 
 [star-image]: https://img.shields.io/github/stars/camel-ai/camel?label=stars&logo=github&color=brightgreen
 [star-url]: https://github.com/camel-ai/camel/stargazers
 [package-license-image]: https://img.shields.io/badge/License-Apache_2.0-blue.svg
-[package-license-url]: https://github.com/camel-ai/camel/blob/master/licenses/LICENSE
+[package-license-url]: https://github.com/camel-ai/camel/blob/master/LICENSE
 [package-download-image]: https://img.shields.io/pypi/dm/camel-ai
 
 [colab-url]: https://colab.research.google.com/drive/1AzP33O8rnMW__7ocWJhVBXjKziJXPtim?usp=sharing

--- a/docs/cookbooks/advanced_features/agent_generate_structured_output.ipynb
+++ b/docs/cookbooks/advanced_features/agent_generate_structured_output.ipynb
@@ -170,7 +170,7 @@
       "metadata": {},
       "source": [
         "2. **Response Structure**:\n",
-        "   - We define a [JokeResponse](camel/examples/structured_response/json_format_response.py:33:0-35:69) class using Pydantic's `BaseModel`\n",
+        "   - We define a [JokeResponse](https://github.com/camel-ai/camel/blob/main/examples/structured_response/json_format_response.py) class using Pydantic's `BaseModel`\n",
         "   - Each field has a type hint and a description\n",
         "   - The model uses these descriptions to generate appropriate content\n"
       ]

--- a/docs/mintlify/cookbooks/advanced_features/agent_generate_structured_output.mdx
+++ b/docs/mintlify/cookbooks/advanced_features/agent_generate_structured_output.mdx
@@ -82,7 +82,7 @@ agent = ChatAgent(assistant_sys_msg, model=model)
 ```
 
 2. **Response Structure**:
-   - We define a [JokeResponse](camel/examples/structured_response/json_format_response.py:33:0-35:69) class using Pydantic's `BaseModel`
+   - We define a [JokeResponse](https://github.com/camel-ai/camel/blob/main/examples/structured_response/json_format_response.py) class using Pydantic's `BaseModel`
    - Each field has a type hint and a description
    - The model uses these descriptions to generate appropriate content
 

--- a/docs/mintlify/key_modules/Benchmark.mdx
+++ b/docs/mintlify/key_modules/Benchmark.mdx
@@ -143,4 +143,4 @@ To create a custom benchmark, inherit from `BaseBenchmark` and implement:
 
 ## Other Resources
 
-- Explore the [Agents](./agents.md) module for creating custom agents
+- Explore the [Agents](./agents.mdx) module for creating custom agents

--- a/docs/mintlify/key_modules/tasks.mdx
+++ b/docs/mintlify/key_modules/tasks.mdx
@@ -6,7 +6,7 @@ doc_code_map:
   - "camel/tasks/**/*.py"
 ---
 
-For more detailed usage information, please refer to our cookbook: [Task Generation Cookbook](../cookbooks/multi_agent_society/task_generation.ipynb)
+For more detailed usage information, please refer to our cookbook: [Task Generation Cookbook](../cookbooks/multi_agent_society/task_generation.mdx)
 
 <Card title="What is a Task in CAMEL?" icon="clipboard-list">
 A <b>task</b> in CAMEL is a structured assignment that can be given to one or more agents. Tasks are higher-level than prompts and managed by modules like the Planner and Workforce.

--- a/docs/mintlify/key_modules/tools.mdx
+++ b/docs/mintlify/key_modules/tools.mdx
@@ -6,7 +6,7 @@ doc_code_map:
   - "camel/toolkits/**/*.py"
 ---
 
-For more detailed usage information, please refer to our cookbook: [Tools Cookbook](../cookbooks/advanced_features/agents_with_tools.ipynb)
+For more detailed usage information, please refer to our cookbook: [Tools Cookbook](../cookbooks/advanced_features/agents_with_tools.mdx)
 
 <Card title="What is a Tool?" icon="toolbox">
   A <b>Tool</b> in CAMEL is a callable function with a name, description, input

--- a/examples/debug/README_traceroot.md
+++ b/examples/debug/README_traceroot.md
@@ -6,8 +6,8 @@ TraceRoot is an open-source LLM debugging platform that correlates logging and t
 ## Table of Contents
 
 - [Quick Start](#quick-start)
-- [Environment Configuration](#environment-configuration)
-- [Self-Hosted Deployment](#self-hosted-deployment)
+- [Environment Variables Configuration](#2-environment-variables-configuration)
+- [Self-Hosted Deployment](#3-self-hosted-deployment)
 - [Related Links](#related-links)
 
 ## Quick Start


### PR DESCRIPTION
## Summary
All verified at HEAD:

- `README.md` / `README.zh.md` / `README.ja.md`: the module table's Runtime row points at `camel/runtime`, which does not exist — the package is `camel/runtimes`.
- Same three READMEs: the license badge URL points at `licenses/LICENSE`, but `licenses/` only contains a template + script; the Apache-2.0 license is at the repo root `/LICENSE`.
- `CONTRIBUTING.md`: `[Google Python Style Guide]("https://…")` — markdown link destinations cannot be quoted, so the link renders literally.
- `examples/debug/README_traceroot.md`: TOC anchors don't match the actual headings (`#2-environment-variables-configuration`, `#3-self-hosted-deployment`).
- Mintlify `key_modules`: `tasks.mdx`/`tools.mdx` link `.ipynb` cookbooks that only exist under `docs/cookbooks` (converted to `.mdx` for the site); `Benchmark.mdx` links `./agents.md` instead of `./agents.mdx`.
- Structured-output cookbook (`.ipynb` + generated `.mdx`): the `JokeResponse` link was `camel/examples/structured_response/json_format_response.py:33:0-35:69` — no such path; pointed at the file on GitHub.