### PR TITLE
feat(agents): add max_tool_calls budget to ChatAgent

### DIFF
--- a/camel/agents/chat_agent.py
+++ b/camel/agents/chat_agent.py
@@ -423,6 +423,19 @@ class ChatAgent(BaseAgent):
             calling iterations allowed per step. If `None` (default), there's
             no explicit limit. If `1`, it performs a single model call. If `N
             > 1`, it allows up to N model calls. (default: :obj:`None`)
+        max_tool_calls (Optional[int], optional): Maximum number of internal
+            tool executions allowed per step (or per :obj:`astep` call). This
+            is independent from `max_iteration`: a single model response can
+            request several tool calls (e.g. parallel tool calls), and each
+            executed call counts against this budget. The counter resets at
+            the start of every `step`/`astep` call. If `None` (default),
+            there's no explicit limit. Once the budget is exhausted, tool
+            calls beyond the limit are rejected (they still receive a valid
+            tool-result message so the conversation history stays
+            structurally consistent) and tools are omitted from subsequent
+            model calls within the same step, allowing the model to produce
+            a final textual response from the results already gathered.
+            (default: :obj:`None`)
         agent_id (str, optional): The ID of the agent. If not provided, a
             random UUID will be generated. (default: :obj:`None`)
         stop_event (Optional[threading.Event], optional): Event to signal
@@ -510,6 +523,7 @@ class ChatAgent(BaseAgent):
         response_terminators: Optional[List[ResponseTerminator]] = None,
         scheduling_strategy: str = "round_robin",
         max_iteration: Optional[int] = None,
+        max_tool_calls: Optional[int] = None,
         agent_id: Optional[str] = None,
         stop_event: Optional[threading.Event] = None,
         tool_execution_timeout: Optional[float] = Constants.TIMEOUT_THRESHOLD,
@@ -624,6 +638,16 @@ class ChatAgent(BaseAgent):
         self.terminated = False
         self.response_terminators = response_terminators or []
         self.max_iteration = max_iteration
+        if max_tool_calls is not None and (
+            isinstance(max_tool_calls, bool)
+            or not isinstance(max_tool_calls, int)
+            or max_tool_calls < 1
+        ):
+            raise ValueError(
+                "max_tool_calls must be a positive integer or None, got "
+                f"{max_tool_calls!r}"
+            )
+        self.max_tool_calls = max_tool_calls
         self.stop_event = stop_event
         self.tool_execution_timeout = tool_execution_timeout
         self.mask_tool_output = mask_tool_output
@@ -2998,6 +3022,12 @@ class ChatAgent(BaseAgent):
         iteration_count: int = 0
         prev_num_openai_messages: int = 0
 
+        # Cumulative count of internal tool calls executed during this step.
+        # This is per-step local state (not persisted on the instance) so
+        # the max_tool_calls budget resets automatically on every new
+        # step()/astep() call.
+        tool_call_count: int = 0
+
         # Track if we've recorded tool calls for the current response
         # to avoid duplicate assistant message recording
         recorded_tool_calls = False
@@ -3021,13 +3051,20 @@ class ChatAgent(BaseAgent):
                 return self._step_terminate(
                     e.args[1], tool_call_records, "max_tokens_exceeded"
                 )
+            # Once the tool-call budget is exhausted, stop offering tools so
+            # the model can produce a final textual response from the tool
+            # results already gathered.
+            tool_budget_exhausted = (
+                self.max_tool_calls is not None
+                and tool_call_count >= self.max_tool_calls
+            )
             # Get response from model backend
             response = self._get_model_response(
                 openai_messages,
                 current_iteration=iteration_count,
                 response_format=response_format,
                 tool_schemas=[]
-                if disable_tools
+                if (disable_tools or tool_budget_exhausted)
                 else self._get_full_tool_schemas(),
                 prev_num_openai_messages=prev_num_openai_messages,
             )
@@ -3090,8 +3127,28 @@ class ChatAgent(BaseAgent):
                 )
                 recorded_tool_calls = True
 
-                # Execute internal tools only
-                for tool_call_request in internal_tool_requests:
+                # Execute internal tools only, honoring the max_tool_calls
+                # budget. The remaining budget is computed once before any
+                # tool in this batch is dispatched, so a single model
+                # response containing several (e.g. parallel) tool calls
+                # cannot execute more tools than the configured limit.
+                remaining_tool_budget = self._remaining_tool_call_budget(
+                    tool_call_count
+                )
+                for idx, tool_call_request in enumerate(
+                    internal_tool_requests
+                ):
+                    if (
+                        remaining_tool_budget is not None
+                        and idx >= remaining_tool_budget
+                    ):
+                        tool_call_records.append(
+                            self._record_tool_call_budget_exceeded(
+                                tool_call_request
+                            )
+                        )
+                        continue
+
                     if (
                         self.pause_event is not None
                         and not self.pause_event.is_set()
@@ -3103,6 +3160,7 @@ class ChatAgent(BaseAgent):
                                 time.sleep(0.001)
                     result = self._execute_tool(tool_call_request)
                     tool_call_records.append(result)
+                    tool_call_count += 1
 
                 # If we found external tool calls, break the loop
                 if external_tool_call_requests:
@@ -3304,6 +3362,12 @@ class ChatAgent(BaseAgent):
         iteration_count: int = 0
         prev_num_openai_messages: int = 0
 
+        # Cumulative count of internal tool calls executed during this step.
+        # This is per-step local state (not persisted on the instance) so
+        # the max_tool_calls budget resets automatically on every new
+        # step()/astep() call.
+        tool_call_count: int = 0
+
         # Track if we've recorded tool calls for the current response
         # to avoid duplicate assistant message recording
         recorded_tool_calls = False
@@ -3326,13 +3390,20 @@ class ChatAgent(BaseAgent):
                 return self._step_terminate(
                     e.args[1], tool_call_records, "max_tokens_exceeded"
                 )
+            # Once the tool-call budget is exhausted, stop offering tools so
+            # the model can produce a final textual response from the tool
+            # results already gathered.
+            tool_budget_exhausted = (
+                self.max_tool_calls is not None
+                and tool_call_count >= self.max_tool_calls
+            )
             # Get response from model backend
             response = await self._aget_model_response(
                 openai_messages,
                 current_iteration=iteration_count,
                 response_format=response_format,
                 tool_schemas=[]
-                if disable_tools
+                if (disable_tools or tool_budget_exhausted)
                 else self._get_full_tool_schemas(),
                 prev_num_openai_messages=prev_num_openai_messages,
             )
@@ -3395,8 +3466,28 @@ class ChatAgent(BaseAgent):
                 )
                 recorded_tool_calls = True
 
-                # Execute internal tools only
-                for tool_call_request in internal_tool_requests:
+                # Execute internal tools only, honoring the max_tool_calls
+                # budget. The remaining budget is computed once before any
+                # tool in this batch is dispatched, so a single model
+                # response containing several (e.g. parallel) tool calls
+                # cannot execute more tools than the configured limit.
+                remaining_tool_budget = self._remaining_tool_call_budget(
+                    tool_call_count
+                )
+                for idx, tool_call_request in enumerate(
+                    internal_tool_requests
+                ):
+                    if (
+                        remaining_tool_budget is not None
+                        and idx >= remaining_tool_budget
+                    ):
+                        tool_call_records.append(
+                            self._record_tool_call_budget_exceeded(
+                                tool_call_request
+                            )
+                        )
+                        continue
+
                     if (
                         self.pause_event is not None
                         and not self.pause_event.is_set()
@@ -3412,6 +3503,7 @@ class ChatAgent(BaseAgent):
                         tool_call_request
                     )
                     tool_call_records.append(tool_call_record)
+                    tool_call_count += 1
 
                 # If we found an external tool call, break the loop
                 if external_tool_call_requests:
@@ -4085,6 +4177,57 @@ class ChatAgent(BaseAgent):
             msgs=[],
             terminated=self.terminated,
             info=info,
+        )
+
+    def _remaining_tool_call_budget(
+        self, executed_count: int
+    ) -> Optional[int]:
+        r"""Returns the number of internal tool calls still allowed during
+        the current step, given how many have already been executed.
+
+        Args:
+            executed_count (int): The number of internal tool calls already
+                executed during the current step.
+
+        Returns:
+            Optional[int]: The remaining budget, or :obj:`None` if
+                `max_tool_calls` is not configured (i.e. unlimited).
+        """
+        if self.max_tool_calls is None:
+            return None
+        return max(0, self.max_tool_calls - executed_count)
+
+    def _record_tool_call_budget_exceeded(
+        self, tool_call_request: ToolCallRequest
+    ) -> ToolCallingRecord:
+        r"""Record a tool-result message for a call that was rejected
+        because the `max_tool_calls` budget for the current step was
+        already exhausted.
+
+        The tool itself is never invoked. This reuses the standard
+        tool-result recording path so the resulting message history stays
+        structurally valid: every `tool_calls` entry recorded on the
+        assistant message is matched by a corresponding tool-role result
+        message.
+
+        Args:
+            tool_call_request (ToolCallRequest): The rejected tool call
+                request.
+
+        Returns:
+            ToolCallingRecord: A record describing the rejected tool call.
+        """
+        result = (
+            f"Tool call '{tool_call_request.tool_name}' was not executed "
+            f"because the maximum number of tool calls "
+            f"({self.max_tool_calls}) for this step has been reached."
+        )
+        return self._record_tool_calling(
+            tool_call_request.tool_name,
+            tool_call_request.args,
+            result,
+            tool_call_request.tool_call_id,
+            extra_content=tool_call_request.extra_content,
         )
 
     @observe()
@@ -6235,6 +6378,7 @@ class ChatAgent(BaseAgent):
                 self.model_backend.scheduling_strategy.__name__
             ),
             max_iteration=self.max_iteration,
+            max_tool_calls=self.max_tool_calls,
             stop_event=self.stop_event,
             tool_execution_timeout=self.tool_execution_timeout,
             pause_event=self.pause_event,

--- a/test/agents/test_chat_agent_max_tool_calls.py
+++ b/test/agents/test_chat_agent_max_tool_calls.py
@@ -1,16 +1,32 @@
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
 """Tests for ChatAgent max_tool_calls behavior."""
 
 import asyncio
-
-import pytest
+from typing import Literal
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 from openai.types.chat import (
     ChatCompletion,
     ChatCompletionMessage,
     ChatCompletionMessageFunctionToolCall,
 )
-from openai.types.chat.chat_completion_message_function_tool_call import Function
+from openai.types.chat.chat_completion import Choice
+from openai.types.chat.chat_completion_message_function_tool_call import (
+    Function,
+)
 from openai.types.completion_usage import CompletionUsage
 
 from camel.agents import ChatAgent
@@ -46,17 +62,23 @@ class DummyToolModel(BaseModelBackend):
 def _make_chat_completion(
     response_id: str,
     message: ChatCompletionMessage,
-    finish_reason: str,
+    finish_reason: Literal[
+        "stop",
+        "length",
+        "tool_calls",
+        "content_filter",
+        "function_call",
+    ],
 ) -> ChatCompletion:
     """Create a deterministic chat completion for tool-call tests."""
     return ChatCompletion(
         id=response_id,
         choices=[
-            {
-                "finish_reason": finish_reason,
-                "index": 0,
-                "message": message,
-            }
+            Choice(
+                finish_reason=finish_reason,
+                index=0,
+                message=message,
+            )
         ],
         created=1730753000,
         model="test-model",
@@ -156,9 +178,7 @@ def test_chat_agent_max_tool_calls_limits_tool_execution():
         "stop",
     )
 
-    model.run = MagicMock(
-        side_effect=[tool_call_response, final_response]
-    )
+    model.run = MagicMock(side_effect=[tool_call_response, final_response])
 
     agent = ChatAgent(
         system_message="You are a helpful assistant.",

--- a/test/agents/test_chat_agent_max_tool_calls.py
+++ b/test/agents/test_chat_agent_max_tool_calls.py
@@ -1,0 +1,466 @@
+"""Tests for ChatAgent max_tool_calls behavior."""
+
+import asyncio
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from openai.types.chat import (
+    ChatCompletion,
+    ChatCompletionMessage,
+    ChatCompletionMessageFunctionToolCall,
+)
+from openai.types.chat.chat_completion_message_function_tool_call import Function
+from openai.types.completion_usage import CompletionUsage
+
+from camel.agents import ChatAgent
+from camel.models.base_model import BaseModelBackend
+from camel.models.stub_model import StubTokenCounter
+from camel.toolkits import FunctionTool
+from camel.types import ModelType
+
+
+class DummyToolModel(BaseModelBackend):
+    """Minimal local model backend for deterministic ChatAgent tests.
+
+    Mirrors the ``StubModel`` convention used elsewhere in the test suite:
+    ``run``/``arun`` are mocked per-test with synthetic ``ChatCompletion``
+    objects, and the token counter lazily falls back to the lightweight,
+    offline ``StubTokenCounter`` so no network access or real tokenizer is
+    required.
+    """
+
+    @property
+    def token_counter(self):
+        if not self._token_counter:
+            self._token_counter = StubTokenCounter()
+        return self._token_counter
+
+    def _run(self, messages, response_format=None, tools=None):
+        return self.run_response
+
+    async def _arun(self, messages, response_format=None, tools=None):
+        return self.run_response
+
+
+def _make_chat_completion(
+    response_id: str,
+    message: ChatCompletionMessage,
+    finish_reason: str,
+) -> ChatCompletion:
+    """Create a deterministic chat completion for tool-call tests."""
+    return ChatCompletion(
+        id=response_id,
+        choices=[
+            {
+                "finish_reason": finish_reason,
+                "index": 0,
+                "message": message,
+            }
+        ],
+        created=1730753000,
+        model="test-model",
+        object="chat.completion",
+        usage=CompletionUsage(
+            completion_tokens=10,
+            prompt_tokens=20,
+            total_tokens=30,
+        ),
+    )
+
+
+def _make_tool_calls_message(calls, content=None):
+    """Build a ``ChatCompletionMessage`` requesting the given tool calls.
+
+    Args:
+        calls: An iterable of ``(tool_call_id, tool_name)`` pairs. Each
+            call is issued with empty ``{}`` arguments.
+        content: Optional assistant text content alongside the tool calls.
+    """
+    return ChatCompletionMessage(
+        content=content,
+        role="assistant",
+        function_call=None,
+        tool_calls=[
+            ChatCompletionMessageFunctionToolCall(
+                id=call_id,
+                function=Function(arguments="{}", name=name),
+                type="function",
+            )
+            for call_id, name in calls
+        ],
+    )
+
+
+def _final_text_message(text: str = "Done.") -> ChatCompletionMessage:
+    """Build a plain assistant text response with no tool calls."""
+    return ChatCompletionMessage(
+        content=text,
+        role="assistant",
+        function_call=None,
+        tool_calls=None,
+    )
+
+
+def test_chat_agent_max_tool_calls_limits_tool_execution():
+    """Limit actual tool executions within a single step."""
+    tool_a_calls = []
+    tool_b_calls = []
+
+    def tool_a() -> str:
+        tool_a_calls.append("called")
+        return "tool A result"
+
+    def tool_b() -> str:
+        tool_b_calls.append("called")
+        return "tool B result"
+
+    model = DummyToolModel(ModelType.STUB)
+
+    tool_call_response = _make_chat_completion(
+        "mock_tool_limit_1",
+        ChatCompletionMessage(
+            content=None,
+            role="assistant",
+            function_call=None,
+            tool_calls=[
+                ChatCompletionMessageFunctionToolCall(
+                    id="call_tool_a",
+                    function=Function(
+                        arguments="{}",
+                        name="tool_a",
+                    ),
+                    type="function",
+                ),
+                ChatCompletionMessageFunctionToolCall(
+                    id="call_tool_b",
+                    function=Function(
+                        arguments="{}",
+                        name="tool_b",
+                    ),
+                    type="function",
+                ),
+            ],
+        ),
+        "tool_calls",
+    )
+
+    final_response = _make_chat_completion(
+        "mock_tool_limit_2",
+        ChatCompletionMessage(
+            content="Done.",
+            role="assistant",
+            function_call=None,
+            tool_calls=None,
+        ),
+        "stop",
+    )
+
+    model.run = MagicMock(
+        side_effect=[tool_call_response, final_response]
+    )
+
+    agent = ChatAgent(
+        system_message="You are a helpful assistant.",
+        model=model,
+        max_tool_calls=1,
+        tools=[
+            FunctionTool(tool_a),
+            FunctionTool(tool_b),
+        ],
+    )
+
+    response = agent.step("Run both tools.")
+
+    assert tool_a_calls == ["called"]
+    assert tool_b_calls == []
+    assert response.msg.content == "Done."
+
+
+def test_max_tool_calls_resets_between_steps():
+    """The tool-call budget is per-step and resets automatically at the
+    start of every new step() call."""
+    calls = []
+
+    def tool() -> str:
+        """A simple tool."""
+        calls.append("called")
+        return "ok"
+
+    model = DummyToolModel(ModelType.STUB)
+
+    def tool_call_response(call_id, resp_id):
+        return _make_chat_completion(
+            resp_id,
+            _make_tool_calls_message([(call_id, "tool")]),
+            "tool_calls",
+        )
+
+    final_response = _make_chat_completion(
+        "resp_final", _final_text_message(), "stop"
+    )
+
+    # Step 1 consumes the budget of 1; step 2 should be able to consume
+    # one tool call again since the counter resets per step.
+    model.run = MagicMock(
+        side_effect=[
+            tool_call_response("call_1", "resp_1"),
+            final_response,
+            tool_call_response("call_2", "resp_2"),
+            final_response,
+        ]
+    )
+
+    agent = ChatAgent(
+        system_message="You are a helpful assistant.",
+        model=model,
+        max_tool_calls=1,
+        tools=[FunctionTool(tool)],
+    )
+
+    first = agent.step("Run the tool.")
+    assert calls == ["called"]
+    assert first.msg.content == "Done."
+
+    second = agent.step("Run the tool again.")
+    assert calls == ["called", "called"]
+    assert second.msg.content == "Done."
+
+
+def test_max_tool_calls_partial_batch_rejects_remaining_calls():
+    """A single model response requesting more tool calls than the
+    remaining budget only executes calls up to that budget; the rest are
+    rejected but still produce structurally valid tool-result messages."""
+    executed = []
+
+    def _make_tool(name):
+        def _tool() -> str:
+            executed.append(name)
+            return f"{name} result"
+
+        _tool.__name__ = name
+        _tool.__doc__ = f"Tool {name}."
+        return _tool
+
+    tool_a = _make_tool("tool_a")
+    tool_b = _make_tool("tool_b")
+    tool_c = _make_tool("tool_c")
+    tool_d = _make_tool("tool_d")
+
+    model = DummyToolModel(ModelType.STUB)
+
+    batch_response = _make_chat_completion(
+        "resp_batch",
+        _make_tool_calls_message(
+            [
+                ("call_a", "tool_a"),
+                ("call_b", "tool_b"),
+                ("call_c", "tool_c"),
+                ("call_d", "tool_d"),
+            ]
+        ),
+        "tool_calls",
+    )
+    final_response = _make_chat_completion(
+        "resp_final", _final_text_message(), "stop"
+    )
+
+    model.run = MagicMock(side_effect=[batch_response, final_response])
+
+    agent = ChatAgent(
+        system_message="You are a helpful assistant.",
+        model=model,
+        max_tool_calls=2,
+        tools=[
+            FunctionTool(tool_a),
+            FunctionTool(tool_b),
+            FunctionTool(tool_c),
+            FunctionTool(tool_d),
+        ],
+    )
+
+    response = agent.step("Run all four tools.")
+
+    # Only the first two calls (within the remaining budget) executed.
+    assert executed == ["tool_a", "tool_b"]
+    assert response.msg.content == "Done."
+
+    # Every requested tool_call_id must have a matching tool-role result
+    # message recorded, so the OpenAI-compatible message history stays
+    # structurally valid even for rejected calls.
+    openai_messages, _ = agent.memory.get_context()
+    tool_result_ids = {
+        message["tool_call_id"]
+        for message in openai_messages
+        if message.get("role") == "tool"
+    }
+    assert tool_result_ids == {"call_a", "call_b", "call_c", "call_d"}
+
+
+def test_max_tool_calls_disables_tools_after_budget_exhausted():
+    """Once the tool-call budget is exhausted, subsequent model calls
+    within the same step no longer offer tools, allowing the model to
+    produce a final textual response from the results already gathered."""
+
+    def tool_a() -> str:
+        """Tool A."""
+        return "tool A result"
+
+    def tool_b() -> str:
+        """Tool B."""
+        return "tool B result"
+
+    model = DummyToolModel(ModelType.STUB)
+
+    batch_response = _make_chat_completion(
+        "resp_batch",
+        _make_tool_calls_message([("call_a", "tool_a"), ("call_b", "tool_b")]),
+        "tool_calls",
+    )
+    final_response = _make_chat_completion(
+        "resp_final", _final_text_message(), "stop"
+    )
+
+    model.run = MagicMock(side_effect=[batch_response, final_response])
+
+    agent = ChatAgent(
+        system_message="You are a helpful assistant.",
+        model=model,
+        max_tool_calls=1,
+        tools=[FunctionTool(tool_a), FunctionTool(tool_b)],
+    )
+
+    response = agent.step("Run both tools.")
+
+    assert response.msg.content == "Done."
+    assert model.run.call_count == 2
+
+    # The tools argument is the 3rd positional argument passed to
+    # BaseModelBackend.run(messages, response_format, tools).
+    first_call_tools = model.run.call_args_list[0].args[2]
+    second_call_tools = model.run.call_args_list[1].args[2]
+    assert first_call_tools  # Tools were offered on the first call.
+    assert not second_call_tools  # Withheld once the budget is exhausted.
+
+
+def test_chat_agent_max_tool_calls_limits_tool_execution_async():
+    """The max_tool_calls budget is enforced identically through
+    astep()."""
+    tool_a_calls = []
+    tool_b_calls = []
+
+    def tool_a() -> str:
+        """Tool A."""
+        tool_a_calls.append("called")
+        return "tool A result"
+
+    def tool_b() -> str:
+        """Tool B."""
+        tool_b_calls.append("called")
+        return "tool B result"
+
+    model = DummyToolModel(ModelType.STUB)
+
+    tool_call_response = _make_chat_completion(
+        "mock_async_tool_limit_1",
+        _make_tool_calls_message(
+            [("call_tool_a", "tool_a"), ("call_tool_b", "tool_b")]
+        ),
+        "tool_calls",
+    )
+    final_response = _make_chat_completion(
+        "mock_async_tool_limit_2", _final_text_message(), "stop"
+    )
+
+    model.arun = AsyncMock(side_effect=[tool_call_response, final_response])
+
+    agent = ChatAgent(
+        system_message="You are a helpful assistant.",
+        model=model,
+        max_tool_calls=1,
+        tools=[FunctionTool(tool_a), FunctionTool(tool_b)],
+    )
+
+    response = asyncio.run(agent.astep("Run both tools."))
+
+    assert tool_a_calls == ["called"]
+    assert tool_b_calls == []
+    assert response.msg.content == "Done."
+
+
+def test_clone_preserves_max_tool_calls():
+    """ChatAgent.clone() preserves the configured max_tool_calls value."""
+    model = DummyToolModel(ModelType.STUB)
+    agent = ChatAgent(
+        system_message="You are a helpful assistant.",
+        model=model,
+        max_tool_calls=3,
+    )
+
+    cloned = agent.clone()
+
+    assert cloned.max_tool_calls == 3
+    assert cloned.max_tool_calls == agent.max_tool_calls
+
+
+@pytest.mark.parametrize("value", [None, 1, 2, 100])
+def test_max_tool_calls_accepts_valid_values(value):
+    """None and any positive integer are accepted."""
+    model = DummyToolModel(ModelType.STUB)
+    agent = ChatAgent(model=model, max_tool_calls=value)
+    assert agent.max_tool_calls == value
+
+
+@pytest.mark.parametrize("value", [0, -1, 1.5, "5", True, False])
+def test_max_tool_calls_rejects_invalid_values(value):
+    """Zero, negative numbers, non-integers, and bools are all rejected
+    (bool is a subclass of int in Python, so it must be excluded
+    explicitly)."""
+    model = DummyToolModel(ModelType.STUB)
+    with pytest.raises(ValueError):
+        ChatAgent(model=model, max_tool_calls=value)
+
+
+def test_max_tool_calls_independent_from_max_iteration():
+    """max_tool_calls and max_iteration are independent controls: leaving
+    max_iteration unset does not remove the tool-call budget, and the
+    agent keeps iterating (with tools withheld) once that budget is
+    exhausted until the model produces a final response."""
+
+    def tool() -> str:
+        """A simple tool."""
+        return "ok"
+
+    model = DummyToolModel(ModelType.STUB)
+
+    responses = [
+        _make_chat_completion(
+            "resp_1",
+            _make_tool_calls_message([("call_1", "tool")]),
+            "tool_calls",
+        ),
+        _make_chat_completion(
+            "resp_2",
+            _make_tool_calls_message([("call_2", "tool")]),
+            "tool_calls",
+        ),
+        _make_chat_completion("resp_3", _final_text_message(), "stop"),
+    ]
+    model.run = MagicMock(side_effect=responses)
+
+    agent = ChatAgent(
+        system_message="You are a helpful assistant.",
+        model=model,
+        max_iteration=None,
+        max_tool_calls=2,
+        tools=[FunctionTool(tool)],
+    )
+
+    response = agent.step("Use the tool as needed.")
+
+    assert response.msg.content == "Done."
+    # Two iterations to exhaust the tool budget, plus one more (with
+    # tools withheld) to obtain the final textual response.
+    assert model.run.call_count == 3
+    assert agent.max_iteration is None
+    assert agent.max_tool_calls == 2


### PR DESCRIPTION
## Summary

Adds an optional `max_tool_calls` budget to `ChatAgent`, independent of
`max_iteration`, to limit cumulative internal tool executions within a
single `step()` or `astep()` call.

## Changes

- Add `max_tool_calls: Optional[int] = None` to `ChatAgent`.
- Validate configured values as positive integers or `None`.
- Reject `bool` values explicitly.
- Track tool executions as per-step local state so the budget resets for
  each new `step()` / `astep()` call.
- Enforce the remaining budget before dispatching tool calls from a model
  response, so a batch cannot execute more calls than allowed.
- Record valid `tool`-role rejection messages for calls beyond the remaining
  budget, preserving OpenAI-compatible message history.
- Stop providing tool schemas once the budget is exhausted so the model can
  continue to a final textual response.
- Preserve `max_tool_calls` when cloning a `ChatAgent`.
- Keep `max_tool_calls` independent from `max_iteration`.

## Tests

Added focused coverage for:

- synchronous tool-call limiting;
- per-step budget reset;
- partial tool-call batches and rejected-call history;
- tool disabling after exhaustion;
- asynchronous execution;
- clone behavior;
- valid and invalid configuration values;
- independence from `max_iteration`.

Validation performed locally:

- `python -m pytest test/agents/test_chat_agent_max_tool_calls.py -q` — 17 passed
- `python -m pytest test/agents/test_chat_agent_clone.py -q` — 3 passed
- `python -m pytest test/agents/test_chat_agent_tool_log.py -q` — 24 passed
- `ruff check --no-fix camel/agents/chat_agent.py` — passed
- `git diff --cached --check` — passed

Streaming tool-execution paths are intentionally unchanged in this PR.

Fixes #4278