### PR TITLE
fix: warn when chat history window truncates with preserved system message

### DIFF
--- a/camel/memories/agent_memories.py
+++ b/camel/memories/agent_memories.py
@@ -66,7 +66,7 @@ class ChatHistoryMemory(AgentMemory):
 
     def retrieve(self) -> List[ContextRecord]:
         records = self._chat_history_block.retrieve(self._window_size)
-        if self._window_size is not None and len(records) == self._window_size:
+        if self._is_window_truncated():
             warnings.warn(
                 f"Chat history window size limit ({self._window_size}) "
                 f"reached. Some earlier messages will not be included in "
@@ -76,6 +76,27 @@ class ChatHistoryMemory(AgentMemory):
                 stacklevel=2,
             )
         return records
+
+    def _is_window_truncated(self) -> bool:
+        if self._window_size is None:
+            return False
+
+        record_dicts = self._chat_history_block.storage.load()
+        if not record_dicts:
+            return False
+
+        start_index = (
+            1
+            if (
+                record_dicts[0]['role_at_backend']
+                in {
+                    OpenAIBackendRole.SYSTEM.value,
+                    OpenAIBackendRole.DEVELOPER.value,
+                }
+            )
+            else 0
+        )
+        return len(record_dicts) - start_index > self._window_size
 
     def write_records(self, records: List[MemoryRecord]) -> None:
         for record in records:

--- a/test/memories/test_agent_memories.py
+++ b/test/memories/test_agent_memories.py
@@ -11,6 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+import warnings
 from datetime import datetime
 from unittest.mock import MagicMock
 
@@ -123,6 +124,79 @@ class TestLongtermAgentMemory:
         memory.clear()
         mock_chat_history_block.clear.assert_called_once()
         mock_vector_db_block.clear.assert_called_once()
+
+
+class TestChatHistoryMemoryWindowWarnings:
+    @pytest.fixture
+    def mock_context_creator(self):
+        creator = MagicMock(spec=BaseContextCreator)
+        creator.create_context.return_value = ([], 0)
+        return creator
+
+    @staticmethod
+    def _record(
+        role_at_backend: OpenAIBackendRole,
+        role_type: RoleType,
+        content: str,
+    ) -> MemoryRecord:
+        return MemoryRecord(
+            message=BaseMessage(
+                role_at_backend.value, role_type, None, content
+            ),
+            role_at_backend=role_at_backend,
+        )
+
+    def test_retrieve_warns_when_window_truncates_preserved_system_message(
+        self, mock_context_creator
+    ):
+        memory = ChatHistoryMemory(mock_context_creator, window_size=2)
+        records = [
+            self._record(
+                OpenAIBackendRole.SYSTEM, RoleType.DEFAULT, "System prompt"
+            ),
+            *[
+                self._record(
+                    OpenAIBackendRole.USER, RoleType.USER, f"User {i}"
+                )
+                for i in range(3)
+            ],
+        ]
+        memory.write_records(records)
+
+        with pytest.warns(
+            UserWarning, match="Chat history window size limit"
+        ):
+            retrieved = memory.retrieve()
+
+        assert [r.memory_record.message.content for r in retrieved] == [
+            "System prompt",
+            "User 1",
+            "User 2",
+        ]
+
+    def test_retrieve_does_not_warn_when_window_exactly_fits_preserved_system(
+        self, mock_context_creator
+    ):
+        memory = ChatHistoryMemory(mock_context_creator, window_size=2)
+        records = [
+            self._record(
+                OpenAIBackendRole.SYSTEM, RoleType.DEFAULT, "System prompt"
+            ),
+            self._record(OpenAIBackendRole.USER, RoleType.USER, "User 0"),
+            self._record(OpenAIBackendRole.USER, RoleType.USER, "User 1"),
+        ]
+        memory.write_records(records)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            retrieved = memory.retrieve()
+
+        assert len(caught) == 0
+        assert [r.memory_record.message.content for r in retrieved] == [
+            "System prompt",
+            "User 0",
+            "User 1",
+        ]
 
 
 class TestChatHistoryMemoryCleanToolCalls:


### PR DESCRIPTION
## Summary

- Fix `ChatHistoryMemory.retrieve()` window warning detection when the first `SYSTEM`/`DEVELOPER` message is preserved outside the sliding window.
- Warn only when the non-protected sliding history actually exceeds `window_size`.
- Add regression coverage for the preserved system-message case and the exact-fit case.

Fixes #4297

## Tests

- `python -m pytest test/memories/test_agent_memories.py -q -k "window"`
- `python -m ruff check camel/memories/agent_memories.py test/memories/test_agent_memories.py`
- `python -m pytest "test/memories/test_chat_history_memory.py::test_chat_history_memory[in-memory]" "test/memories/test_chat_history_memory.py::test_chat_history_memory_pop_records[in-memory]" -q`