### PR TITLE
fix(agents): clear Responses API chain state on reset

### DIFF
--- a/camel/agents/chat_agent.py
+++ b/camel/agents/chat_agent.py
@@ -657,6 +657,8 @@ class ChatAgent(BaseAgent):
         r"""Resets the :obj:`ChatAgent` to its initial state."""
         self.terminated = False
         self.init_messages()
+        for model in self.model_backend.models:
+            model.reset(self.agent_id)
         # Snapshot-clean cache is per-conversation state and must not survive
         # agent reuse (e.g. pooled workers across different tasks).
         self._tool_output_history.clear()

--- a/camel/agents/chat_agent.py
+++ b/camel/agents/chat_agent.py
@@ -2922,6 +2922,17 @@ class ChatAgent(BaseAgent):
         Raises:
             TimeoutError: If the step operation exceeds the configured timeout.
         """
+        # Set agent_id in context-local storage for logging
+        from camel.utils.agent_context import set_current_agent_id
+
+        set_current_agent_id(self.agent_id)
+
+        try:
+            from camel.utils.langfuse import set_current_agent_session_id
+
+            set_current_agent_session_id(self.agent_id)
+        except ImportError:
+            pass  # Langfuse not available
 
         stream = self.model_backend.model_config_dict.get("stream", False)
 

--- a/camel/agents/chat_agent.py
+++ b/camel/agents/chat_agent.py
@@ -657,8 +657,6 @@ class ChatAgent(BaseAgent):
         r"""Resets the :obj:`ChatAgent` to its initial state."""
         self.terminated = False
         self.init_messages()
-        for model in self.model_backend.models:
-            model.reset(self.agent_id)
         # Snapshot-clean cache is per-conversation state and must not survive
         # agent reuse (e.g. pooled workers across different tasks).
         self._tool_output_history.clear()
@@ -2478,6 +2476,8 @@ class ChatAgent(BaseAgent):
                 summarization. Defaults to True for full memory clearing.
         """
         self.memory.clear()
+        for model in self.model_backend.models:
+            model.reset(self.agent_id)
 
         if reset_summary_state:
             self._reset_summary_state()

--- a/camel/agents/chat_agent.py
+++ b/camel/agents/chat_agent.py
@@ -2894,6 +2894,18 @@ class ChatAgent(BaseAgent):
             message.content = response.output_messages[0].content
             self._try_format_message(message, response_format)
 
+    def _set_current_agent_context(self) -> None:
+        from camel.utils.agent_context import set_current_agent_id
+
+        set_current_agent_id(self.agent_id)
+
+        try:
+            from camel.utils.langfuse import set_current_agent_session_id
+
+            set_current_agent_session_id(self.agent_id)
+        except ImportError:
+            pass
+
     @observe()
     def step(
         self,
@@ -2922,17 +2934,7 @@ class ChatAgent(BaseAgent):
         Raises:
             TimeoutError: If the step operation exceeds the configured timeout.
         """
-        # Set agent_id in context-local storage for logging
-        from camel.utils.agent_context import set_current_agent_id
-
-        set_current_agent_id(self.agent_id)
-
-        try:
-            from camel.utils.langfuse import set_current_agent_session_id
-
-            set_current_agent_session_id(self.agent_id)
-        except ImportError:
-            pass  # Langfuse not available
+        self._set_current_agent_context()
 
         stream = self.model_backend.model_config_dict.get("stream", False)
 
@@ -2965,18 +2967,7 @@ class ChatAgent(BaseAgent):
         response_format: Optional[Type[BaseModel]] = None,
     ) -> ChatAgentResponse:
         r"""Implementation of non-streaming step logic."""
-        # Set agent_id in context-local storage for logging
-        from camel.utils.agent_context import set_current_agent_id
-
-        set_current_agent_id(self.agent_id)
-
-        # Set Langfuse session_id using agent_id for trace grouping
-        try:
-            from camel.utils.langfuse import set_current_agent_session_id
-
-            set_current_agent_session_id(self.agent_id)
-        except ImportError:
-            pass  # Langfuse not available
+        self._set_current_agent_context()
 
         # Check if this call is from a RegisteredAgentToolkit to prevent tool
         # use
@@ -3234,17 +3225,7 @@ class ChatAgent(BaseAgent):
             asyncio.TimeoutError: If the step operation exceeds the configured
                 timeout.
         """
-        # Set agent_id in context-local storage for logging
-        from camel.utils.agent_context import set_current_agent_id
-
-        set_current_agent_id(self.agent_id)
-
-        try:
-            from camel.utils.langfuse import set_current_agent_session_id
-
-            set_current_agent_session_id(self.agent_id)
-        except ImportError:
-            pass  # Langfuse not available
+        self._set_current_agent_context()
 
         stream = self.model_backend.model_config_dict.get("stream", False)
         if stream:
@@ -3275,17 +3256,7 @@ class ChatAgent(BaseAgent):
         response_format: Optional[Type[BaseModel]] = None,
     ) -> ChatAgentResponse:
         r"""Internal async method for non-streaming astep logic."""
-        # Set agent_id in context-local storage for logging
-        from camel.utils.agent_context import set_current_agent_id
-
-        set_current_agent_id(self.agent_id)
-
-        try:
-            from camel.utils.langfuse import set_current_agent_session_id
-
-            set_current_agent_session_id(self.agent_id)
-        except ImportError:
-            pass  # Langfuse not available
+        self._set_current_agent_context()
 
         # Check if this call is from a RegisteredAgentToolkit to prevent tool
         # use
@@ -3668,6 +3639,7 @@ class ChatAgent(BaseAgent):
 
         for attempt in range(self.retry_attempts):
             try:
+                self._set_current_agent_context()
                 response = self.model_backend.run(
                     openai_messages, response_format, tool_schemas or None
                 )
@@ -3730,6 +3702,7 @@ class ChatAgent(BaseAgent):
 
         for attempt in range(self.retry_attempts):
             try:
+                self._set_current_agent_context()
                 response = await self.model_backend.arun(
                     openai_messages, response_format, tool_schemas or None
                 )
@@ -4480,6 +4453,7 @@ class ChatAgent(BaseAgent):
 
             # Get streaming response from model
             try:
+                self._set_current_agent_context()
                 response = self.model_backend.run(
                     openai_messages,
                     response_format,
@@ -5491,6 +5465,7 @@ class ChatAgent(BaseAgent):
 
             # Get async streaming response from model
             try:
+                self._set_current_agent_context()
                 response = await self.model_backend.arun(
                     openai_messages,
                     response_format,

--- a/camel/models/base_model.py
+++ b/camel/models/base_model.py
@@ -306,6 +306,15 @@ class BaseModelBackend(ABC, metaclass=ModelBackendMeta):
             default=False,
         )
 
+    def reset(self, session_id: Optional[str] = None) -> None:
+        r"""Reset conversation state stored by the model backend.
+
+        Args:
+            session_id (Optional[str]): Session whose state should be reset.
+                If :obj:`None`, reset all conversation state.
+                (default: :obj:`None`)
+        """
+
     @property
     @abstractmethod
     def token_counter(self) -> BaseTokenCounter:

--- a/camel/models/openai_compatible_model.py
+++ b/camel/models/openai_compatible_model.py
@@ -548,6 +548,20 @@ class OpenAICompatibleModel(BaseModelBackend):
     def _get_response_chain_session_key(self) -> str:
         return get_current_agent_session_id() or "__default__"
 
+    def reset(self, session_id: Optional[str] = None) -> None:
+        r"""Reset Responses API chaining state.
+
+        Args:
+            session_id (Optional[str]): Session whose chaining state should
+                be reset. If :obj:`None`, reset all sessions.
+                (default: :obj:`None`)
+        """
+        if session_id is None:
+            self._responses_previous_response_id_by_session.clear()
+            self._responses_last_message_count_by_session.clear()
+        else:
+            self._clear_response_chain_state(session_id)
+
     def _clear_response_chain_state(self, session_key: str) -> None:
         self._responses_previous_response_id_by_session.pop(session_key, None)
         self._responses_last_message_count_by_session.pop(session_key, None)

--- a/camel/models/openai_model.py
+++ b/camel/models/openai_model.py
@@ -551,6 +551,20 @@ class OpenAIModel(BaseModelBackend):
     def _get_response_chain_session_key(self) -> str:
         return get_current_agent_session_id() or "__default__"
 
+    def reset(self, session_id: Optional[str] = None) -> None:
+        r"""Reset Responses API chaining state.
+
+        Args:
+            session_id (Optional[str]): Session whose chaining state should
+                be reset. If :obj:`None`, reset all sessions.
+                (default: :obj:`None`)
+        """
+        if session_id is None:
+            self._responses_previous_response_id_by_session.clear()
+            self._responses_last_message_count_by_session.clear()
+        else:
+            self._clear_response_chain_state(session_id)
+
     def _clear_response_chain_state(self, session_key: str) -> None:
         self._responses_previous_response_id_by_session.pop(session_key, None)
         self._responses_last_message_count_by_session.pop(session_key, None)

--- a/test/agents/test_chat_agent_clone.py
+++ b/test/agents/test_chat_agent_clone.py
@@ -11,11 +11,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
+from unittest.mock import MagicMock
+
 from camel.agents import ChatAgent
 from camel.messages import BaseMessage
-from camel.models import StubModel
+from camel.models import OpenAIModel, StubModel
 from camel.terminators import ResponseWordsTerminator
 from camel.types import ModelType
+from camel.utils.langfuse import set_current_agent_session_id
 
 
 def _make_agent() -> ChatAgent:
@@ -78,3 +81,40 @@ def test_resetting_clone_does_not_reset_another_clone_terminator():
     )
     assert terminated
     assert reason is not None
+
+
+def test_resetting_clone_clears_only_its_model_session():
+    model = OpenAIModel(
+        model_type=ModelType.GPT_4O_MINI,
+        api_key="dummy",
+        client=MagicMock(),
+        async_client=MagicMock(),
+        api_mode="responses",
+    )
+    source = ChatAgent(model=model)
+    first = source.clone()
+    second = source.clone()
+    model._save_response_chain_state(first.agent_id, "first-response", 2)
+    model._save_response_chain_state(second.agent_id, "second-response", 2)
+
+    first.reset()
+
+    set_current_agent_session_id(first.agent_id)
+    chain_state = model._prepare_responses_input_and_chain(
+        [
+            {"role": "system", "content": "new system prompt"},
+            {"role": "user", "content": "new task"},
+        ]
+    )
+
+    assert chain_state["previous_response_id"] is None
+    assert chain_state["input_messages"][0]["role"] == "system"
+    assert first.agent_id not in (
+        model._responses_previous_response_id_by_session
+    )
+    assert first.agent_id not in model._responses_last_message_count_by_session
+    assert (
+        model._responses_previous_response_id_by_session[second.agent_id]
+        == "second-response"
+    )
+    assert model._responses_last_message_count_by_session[second.agent_id] == 2

--- a/test/agents/test_chat_agent_clone.py
+++ b/test/agents/test_chat_agent_clone.py
@@ -11,7 +11,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ========= Copyright 2023-2026 @ CAMEL-AI.org. All Rights Reserved. =========
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 
 from camel.agents import ChatAgent
 from camel.messages import BaseMessage
@@ -35,6 +37,36 @@ def _stop_response():
             content="stop",
         )
     ]
+
+
+def _response_events(response_id: str):
+    return [
+        {
+            "type": "response.created",
+            "response": {"id": response_id},
+        },
+        {
+            "type": "response.output_text.delta",
+            "item_id": "msg_1",
+            "delta": "Done",
+        },
+        {
+            "type": "response.completed",
+            "response": {
+                "id": response_id,
+                "usage": {
+                    "input_tokens": 2,
+                    "output_tokens": 1,
+                    "total_tokens": 3,
+                },
+            },
+        },
+    ]
+
+
+async def _async_response_events(response_id: str):
+    for event in _response_events(response_id):
+        yield event
 
 
 def test_clone_response_terminators_have_independent_identity():
@@ -148,35 +180,11 @@ def test_clearing_clone_memory_clears_only_its_model_session():
 
 
 def test_streaming_clones_use_independent_model_sessions():
-    def response_events(response_id: str):
-        return [
-            {
-                "type": "response.created",
-                "response": {"id": response_id},
-            },
-            {
-                "type": "response.output_text.delta",
-                "item_id": "msg_1",
-                "delta": "Done",
-            },
-            {
-                "type": "response.completed",
-                "response": {
-                    "id": response_id,
-                    "usage": {
-                        "input_tokens": 2,
-                        "output_tokens": 1,
-                        "total_tokens": 3,
-                    },
-                },
-            },
-        ]
-
     client = MagicMock()
     client.responses.create.side_effect = [
-        response_events("first-response"),
-        response_events("second-response"),
-        response_events("reset-response"),
+        _response_events("first-response"),
+        _response_events("second-response"),
+        _response_events("reset-response"),
     ]
     model = OpenAIModel(
         model_type=ModelType.GPT_4O_MINI,
@@ -192,8 +200,10 @@ def test_streaming_clones_use_independent_model_sessions():
     first = source.clone()
     second = source.clone()
 
-    list(first.step("first task"))
-    list(second.step("second task"))
+    first_stream = first.step("first task")
+    second_stream = second.step("second task")
+    list(first_stream)
+    list(second_stream)
 
     assert "previous_response_id" not in (
         client.responses.create.call_args_list[1].kwargs
@@ -208,6 +218,60 @@ def test_streaming_clones_use_independent_model_sessions():
 
     assert "previous_response_id" not in (
         client.responses.create.call_args_list[2].kwargs
+    )
+    assert (
+        model._responses_previous_response_id_by_session[first.agent_id]
+        == "reset-response"
+    )
+    assert (
+        model._responses_previous_response_id_by_session[second.agent_id]
+        == "second-response"
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_streaming_clones_use_independent_model_sessions():
+    async_client = MagicMock()
+    async_client.responses.create = AsyncMock(
+        side_effect=[
+            _async_response_events("first-response"),
+            _async_response_events("second-response"),
+            _async_response_events("reset-response"),
+        ]
+    )
+    model = OpenAIModel(
+        model_type=ModelType.GPT_4O_MINI,
+        api_key="dummy",
+        client=MagicMock(),
+        async_client=async_client,
+        model_config_dict={"stream": True},
+        api_mode="responses",
+    )
+    source = ChatAgent(
+        system_message="system", model=model, stream_accumulate=False
+    )
+    first = source.clone()
+    second = source.clone()
+
+    first_stream = await first.astep("first task")
+    second_stream = await second.astep("second task")
+    _ = [response async for response in first_stream]
+    _ = [response async for response in second_stream]
+
+    assert "previous_response_id" not in (
+        async_client.responses.create.call_args_list[1].kwargs
+    )
+    assert set(model._responses_previous_response_id_by_session) == {
+        first.agent_id,
+        second.agent_id,
+    }
+
+    first.reset()
+    reset_stream = await first.astep("new task")
+    _ = [response async for response in reset_stream]
+
+    assert "previous_response_id" not in (
+        async_client.responses.create.call_args_list[2].kwargs
     )
     assert (
         model._responses_previous_response_id_by_session[first.agent_id]

--- a/test/agents/test_chat_agent_clone.py
+++ b/test/agents/test_chat_agent_clone.py
@@ -118,3 +118,30 @@ def test_resetting_clone_clears_only_its_model_session():
         == "second-response"
     )
     assert model._responses_last_message_count_by_session[second.agent_id] == 2
+
+
+def test_clearing_clone_memory_clears_only_its_model_session():
+    model = OpenAIModel(
+        model_type=ModelType.GPT_4O_MINI,
+        api_key="dummy",
+        client=MagicMock(),
+        async_client=MagicMock(),
+        api_mode="responses",
+    )
+    source = ChatAgent(model=model)
+    first = source.clone()
+    second = source.clone()
+    model._save_response_chain_state(first.agent_id, "first-response", 2)
+    model._save_response_chain_state(second.agent_id, "second-response", 2)
+
+    first.clear_memory()
+
+    assert first.agent_id not in (
+        model._responses_previous_response_id_by_session
+    )
+    assert first.agent_id not in model._responses_last_message_count_by_session
+    assert (
+        model._responses_previous_response_id_by_session[second.agent_id]
+        == "second-response"
+    )
+    assert model._responses_last_message_count_by_session[second.agent_id] == 2

--- a/test/agents/test_chat_agent_clone.py
+++ b/test/agents/test_chat_agent_clone.py
@@ -145,3 +145,75 @@ def test_clearing_clone_memory_clears_only_its_model_session():
         == "second-response"
     )
     assert model._responses_last_message_count_by_session[second.agent_id] == 2
+
+
+def test_streaming_clones_use_independent_model_sessions():
+    def response_events(response_id: str):
+        return [
+            {
+                "type": "response.created",
+                "response": {"id": response_id},
+            },
+            {
+                "type": "response.output_text.delta",
+                "item_id": "msg_1",
+                "delta": "Done",
+            },
+            {
+                "type": "response.completed",
+                "response": {
+                    "id": response_id,
+                    "usage": {
+                        "input_tokens": 2,
+                        "output_tokens": 1,
+                        "total_tokens": 3,
+                    },
+                },
+            },
+        ]
+
+    client = MagicMock()
+    client.responses.create.side_effect = [
+        response_events("first-response"),
+        response_events("second-response"),
+        response_events("reset-response"),
+    ]
+    model = OpenAIModel(
+        model_type=ModelType.GPT_4O_MINI,
+        api_key="dummy",
+        client=client,
+        async_client=MagicMock(),
+        model_config_dict={"stream": True},
+        api_mode="responses",
+    )
+    source = ChatAgent(
+        system_message="system", model=model, stream_accumulate=False
+    )
+    first = source.clone()
+    second = source.clone()
+
+    list(first.step("first task"))
+    list(second.step("second task"))
+
+    assert "previous_response_id" not in (
+        client.responses.create.call_args_list[1].kwargs
+    )
+    assert set(model._responses_previous_response_id_by_session) == {
+        first.agent_id,
+        second.agent_id,
+    }
+
+    first.reset()
+    list(first.step("new task"))
+
+    assert "previous_response_id" not in (
+        client.responses.create.call_args_list[2].kwargs
+    )
+    assert (
+        model._responses_previous_response_id_by_session[first.agent_id]
+        == "reset-response"
+    )
+    assert (
+        model._responses_previous_response_id_by_session[second.agent_id]
+        == "second-response"
+    )

--- a/test/models/test_openai_compatible_model.py
+++ b/test/models/test_openai_compatible_model.py
@@ -98,3 +98,25 @@ def test_openai_compatible_responses_use_agent_session_scope_without_langfuse(
 
     assert chain_state["session_key"] == "agent-b"
     assert chain_state["previous_response_id"] is None
+
+
+def test_openai_compatible_reset_clears_selected_response_session():
+    model = OpenAICompatibleModel(
+        model_type="dummy-model",
+        api_key="dummy",
+        url="https://example.invalid",
+        api_mode="responses",
+        client=MagicMock(),
+        async_client=MagicMock(),
+    )
+    model._save_response_chain_state("agent-a", "resp-a", 2)
+    model._save_response_chain_state("agent-b", "resp-b", 3)
+
+    model.reset("agent-a")
+
+    assert "agent-a" not in model._responses_previous_response_id_by_session
+    assert "agent-a" not in model._responses_last_message_count_by_session
+    assert model._responses_previous_response_id_by_session["agent-b"] == (
+        "resp-b"
+    )
+    assert model._responses_last_message_count_by_session["agent-b"] == 3


### PR DESCRIPTION
### Related Issue

Closes #4299

### Description

`ChatAgent.clone()` shares model backend instances, while Responses API continuation state is stored per agent session. Clearing or resetting a pooled clone previously rebuilt its local memory but left `previous_response_id` and message-offset state behind, allowing its next task to continue an unrelated conversation.

This adds a model-backend reset hook and invokes it from the common `clear_memory()` path, covering `reset()`, system-message changes, the memory toolkit, context summarization, and direct callers. OpenAI and OpenAI-compatible backends remove both response-chain maps for only that agent session, preserving state for sibling clones sharing the backend.

Agent context is also restored immediately before each sync or async model request. This keeps lazy streaming responses scoped to their owning clone even when multiple streams are created before they are consumed.

Regression coverage verifies full agent reset, direct memory clearing, and lazy synchronous and asynchronous streaming all use fresh per-agent Responses conversations without disturbing a sibling clone’s chain.

Testing:
- `uv run pytest -q test/agents/test_chat_agent_clone.py test/models/test_openai_model.py test/models/test_openai_compatible_model.py test/models/test_azure_openai_model.py` (68 passed)
- `uv run pre-commit run --files camel/models/base_model.py camel/models/openai_model.py camel/models/openai_compatible_model.py camel/agents/chat_agent.py test/agents/test_chat_agent_clone.py test/models/test_openai_compatible_model.py`
- `uv run mypy --namespace-packages camel/models/base_model.py camel/models/openai_model.py camel/models/openai_compatible_model.py camel/agents/chat_agent.py`
- `uv lock --check`

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Checklist

- [x] I have read and agree to the [AI-Generated Code Policy](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md#ai-generated-code-policy) (**required**)
- [x] I have linked this PR to an issue (**required**)
- [x] I have checked if any dependencies need to be added or updated in `pyproject.toml` and run `uv lock`
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [x] I have updated the documentation if needed
- [ ] I have added examples if this is a new feature