### PR TITLE
fix(utils): compare against all earlier texts when deduplicating in batches

### DIFF
--- a/camel/utils/deduplication.py
+++ b/camel/utils/deduplication.py
@@ -193,10 +193,14 @@ def deduplicate_internally(
             embeddings_array[i:batch_end], embeddings_array[:batch_end]
         )
 
-        # Create mask for lower triangle (avoid self-comparison and redundant
+        # Keep only comparisons against earlier texts, using the global
+        # indices of the batch rows (avoid self-comparison and redundant
         # checks)
-        tril_mask = np.tril(np.ones_like(batch_similarities), k=-1)
-        batch_similarities = batch_similarities * tril_mask
+        row_indices = np.arange(i, batch_end)[:, None]
+        column_indices = np.arange(batch_end)[None, :]
+        batch_similarities = np.where(
+            column_indices < row_indices, batch_similarities, 0
+        )
 
         # Find duplicates in current batch
         masked_similarities = np.where(

--- a/test/utils/test_deduplication.py
+++ b/test/utils/test_deduplication.py
@@ -228,3 +228,48 @@ def test_deduplicate_internally_with_inconsistent_embeddings():
             # but the length of embeddings is 2.
             strategy="top1",
         )
+
+
+def test_deduplicate_internally_batched_matches_single_batch():
+    texts = ["A", "B", "A"]
+    embeddings = [[1.0, 0.0], [0.0, 1.0], [1.0, 0.0]]
+
+    expected_map = {2: 0}
+    for batch_size in (1, 2, 3, 1000):
+        result = deduplicate_internally(
+            texts=texts,
+            threshold=0.9,
+            embeddings=embeddings,
+            strategy="top1",
+            batch_size=batch_size,
+        )
+        assert result.duplicate_to_target_map == expected_map, (
+            f"batch_size={batch_size} produced "
+            f"{result.duplicate_to_target_map}, expected {expected_map}"
+        )
+        assert result.unique_ids == [0, 1]
+
+
+def test_deduplicate_internally_batching_finds_cross_batch_duplicates():
+    # Each text duplicates the text five positions earlier, so every
+    # duplicate pair spans a batch boundary when batch_size is 5.
+    base_embeddings = [
+        [1.0, 0.0],
+        [0.0, 1.0],
+        [1.0, 1.0],
+        [1.0, -1.0],
+        [-1.0, 1.0],
+    ]
+    embeddings = base_embeddings * 2
+    texts = [f"text-{i}" for i in range(len(embeddings))]
+
+    result = deduplicate_internally(
+        texts=texts,
+        threshold=0.99,
+        embeddings=embeddings,
+        strategy="top1",
+        batch_size=5,
+    )
+
+    assert result.duplicate_to_target_map == {5: 0, 6: 1, 7: 2, 8: 3, 9: 4}
+    assert result.unique_ids == [0, 1, 2, 3, 4]


### PR DESCRIPTION
## Description

Closes #4305.

`deduplicate_internally` masks each similarity batch with `np.tril(..., k=-1)`, but the batch matrix is not square: rows are texts `i .. batch_end`, columns are texts `0 .. batch_end`. `np.tril` masks relative to the *local* row index, so from the second batch onwards row `j` (global index `i + j`) is only compared with columns `< j` instead of `< i + j`. Columns below the local row index do survive, so the dropped window is `[local_row, global_row)`: a duplicate whose original sits near the front of the corpus is still caught, which is why this survives casual testing, while a duplicate whose original sits inside that window comes back as unique, so the output depends on `batch_size` (documented only as a memory knob, default 1000 — i.e. any corpus over 1000 texts is affected).

```diff
-        tril_mask = np.tril(np.ones_like(batch_similarities), k=-1)
-        batch_similarities = batch_similarities * tril_mask
+        row_indices = np.arange(i, batch_end)[:, None]
+        column_indices = np.arange(batch_end)[None, :]
+        batch_similarities = np.where(
+            column_indices < row_indices, batch_similarities, 0
+        )
```

Masking on global indices keeps the intent (compare only with earlier texts, never with itself) and makes the batched result identical to the single-batch result.

## Motivation and Context

Silent recall loss in deduplication: on `master`, `deduplicate_internally(texts=["A", "B", "A"], threshold=0.9, embeddings=[[1,0],[0,1],[1,0]], batch_size=2)` returns `duplicate_to_target_map == {}` instead of `{2: 0}`.

- [x] I have raised an issue to propose this change ([#4305](https://github.com/camel-ai/camel/issues/4305))

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Ran locally (Python 3.13, `uv` env):

- `uv run pytest test/utils/test_deduplication.py` → **9 passed**.
- Reverting only `camel/utils/deduplication.py` to `master` → the two new tests **fail**, the 7 existing ones pass.
- Randomized cross-check (60 random 4-d embeddings + 20 repeated ones, threshold 0.8): with the fix, `batch_size` 3, 7 and 25 all produce the same `duplicate_to_target_map` as a single batch (79 duplicates); on `master` they do not.
- `mypy camel/utils/deduplication.py test/utils/test_deduplication.py` clean; `ruff`/`ruff-format`/codespell/license pre-commit hooks pass. The repo-wide `mypy` pre-commit hook reports 98 pre-existing errors in unrelated files here because several optional extras (playwright, nebula3, telebot, ...) cannot be installed on Python 3.13 in my environment, so that hook was skipped for the commit; nothing in the diff is affected.

New tests:
- `test_deduplicate_internally_batched_matches_single_batch` — `["A", "B", "A"]` gives `{2: 0}` for `batch_size` 1, 2, 3 and 1000.
- `test_deduplicate_internally_batching_finds_cross_batch_duplicates` — 10 texts where every duplicate pair spans a `batch_size=5` boundary.

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md) guide.
- [x] I have linked this PR to an issue.
- [x] My change requires a change to the documentation: no.
- [x] I have updated the tests accordingly.

*Disclosure: written with an AI coding assistant; I reproduced the bug, reviewed the diff and ran the tests myself.*