### PR TITLE
docs(societies): unify docstrings to CAMEL standard

### DIFF
--- a/camel/societies/workforce/events.py
+++ b/camel/societies/workforce/events.py
@@ -20,6 +20,19 @@ from pydantic import BaseModel, ConfigDict, Field
 
 
 class WorkforceEventBase(BaseModel):
+    r"""Base class for all events emitted by the CAMEL workforce
+    system.
+
+    Attributes:
+        event_type (str): The type of the event, used for
+            discriminating between concrete event classes.
+        metadata (Dict[str, Any], optional): A dictionary of additional
+            key-value pairs with event-specific information. If not
+            given, it will be :obj:`None`.
+        timestamp (datetime): The UTC timestamp when the event was
+            created. Defaults to the current time.
+    """
+
     model_config = ConfigDict(frozen=True, extra='forbid')
     event_type: Literal[
         "log",
@@ -43,6 +56,20 @@ class WorkforceEventBase(BaseModel):
 
 
 class LogEvent(WorkforceEventBase):
+    r"""Event for log messages emitted during workforce execution.
+
+    Attributes:
+        event_type (str): The type of the event, always
+            :obj:`"log"`.
+        message (str): The log message content.
+        level (str): The severity level of the log message, one of
+            :obj:`"debug"`, :obj:`"info"`, :obj:`"warning"`,
+            :obj:`"error"`, or :obj:`"critical"`.
+        color (str, optional): An optional color used when rendering
+            the log message, e.g., :obj:`"red"` or :obj:`"cyan"`. If
+            not given, it will be :obj:`None`.
+    """
+
     event_type: Literal["log"] = "log"
     message: str
     level: Literal["debug", "info", "warning", "error", "critical"]
@@ -62,6 +89,22 @@ class LogEvent(WorkforceEventBase):
 
 
 class StreamChunkEvent(WorkforceEventBase):
+    r"""Event carrying a chunk of streamed text output from a worker.
+
+    Attributes:
+        event_type (str): The type of the event, always
+            :obj:`"stream_chunk"`.
+        text (str): The chunk of streamed text.
+        stream_accumulate_mode (str): The accumulation mode of the
+            streamed chunks, e.g., :obj:`"accumulate"`.
+        task_id (str, optional): The identifier of the task that
+            produced this stream chunk. If not given, it will be
+            :obj:`None`.
+        worker_id (str, optional): The identifier of the worker that
+            produced this stream chunk. If not given, it will be
+            :obj:`None`.
+    """
+
     event_type: Literal["stream_chunk"] = "stream_chunk"
     text: str
     stream_accumulate_mode: str = "accumulate"
@@ -70,6 +113,17 @@ class StreamChunkEvent(WorkforceEventBase):
 
 
 class WorkerCreatedEvent(WorkforceEventBase):
+    r"""Event emitted when a new worker is added to the workforce.
+
+    Attributes:
+        event_type (str): The type of the event, always
+            :obj:`"worker_created"`.
+        worker_id (str): The identifier of the newly created worker.
+        worker_type (str): The type of the created worker, e.g.,
+            :obj:`"single_agent_worker"`.
+        role (str): The role description of the worker.
+    """
+
     event_type: Literal["worker_created"] = "worker_created"
     worker_id: str
     worker_type: str
@@ -77,18 +131,52 @@ class WorkerCreatedEvent(WorkforceEventBase):
 
 
 class WorkerDeletedEvent(WorkforceEventBase):
+    r"""Event emitted when a worker is removed from the workforce.
+
+    Attributes:
+        event_type (str): The type of the event, always
+            :obj:`"worker_deleted"`.
+        worker_id (str): The identifier of the removed worker.
+        reason (str, optional): The reason why the worker was
+            removed. If not given, it will be :obj:`None`.
+    """
+
     event_type: Literal["worker_deleted"] = "worker_deleted"
     worker_id: str
     reason: Optional[str] = None
 
 
 class TaskDecomposedEvent(WorkforceEventBase):
+    r"""Event emitted when a task is decomposed into subtasks.
+
+    Attributes:
+        event_type (str): The type of the event, always
+            :obj:`"task_decomposed"`.
+        parent_task_id (str): The identifier of the decomposed task.
+        subtask_ids (List[str]): The identifiers of the created
+            subtasks.
+    """
+
     event_type: Literal["task_decomposed"] = "task_decomposed"
     parent_task_id: str
     subtask_ids: List[str]
 
 
 class TaskCreatedEvent(WorkforceEventBase):
+    r"""Event emitted when a new task is created in the workforce.
+
+    Attributes:
+        event_type (str): The type of the event, always
+            :obj:`"task_created"`.
+        task_id (str): The identifier of the created task.
+        description (str): The description of the task.
+        parent_task_id (str, optional): The identifier of the parent
+            task if the task was created by decomposition. If not
+            given, it will be :obj:`None`.
+        task_type (str, optional): The type of the task. If not
+            given, it will be :obj:`None`.
+    """
+
     event_type: Literal["task_created"] = "task_created"
     task_id: str
     description: str
@@ -97,6 +185,22 @@ class TaskCreatedEvent(WorkforceEventBase):
 
 
 class TaskAssignedEvent(WorkforceEventBase):
+    r"""Event emitted when a task is assigned to a worker.
+
+    Attributes:
+        event_type (str): The type of the event, always
+            :obj:`"task_assigned"`.
+        task_id (str): The identifier of the assigned task.
+        worker_id (str): The identifier of the worker the task was
+            assigned to.
+        queue_time_seconds (float, optional): The time the task spent
+            waiting in the queue before assignment, in seconds. If
+            not given, it will be :obj:`None`.
+        dependencies (List[str], optional): The identifiers of the
+            tasks this task depends on. If not given, it will be
+            :obj:`None`.
+    """
+
     event_type: Literal["task_assigned"] = "task_assigned"
     task_id: str
     worker_id: str
@@ -105,12 +209,43 @@ class TaskAssignedEvent(WorkforceEventBase):
 
 
 class TaskStartedEvent(WorkforceEventBase):
+    r"""Event emitted when a worker starts processing a task.
+
+    Attributes:
+        event_type (str): The type of the event, always
+            :obj:`"task_started"`.
+        task_id (str): The identifier of the task being started.
+        worker_id (str): The identifier of the worker processing the
+            task.
+    """
+
     event_type: Literal["task_started"] = "task_started"
     task_id: str
     worker_id: str
 
 
 class TaskUpdatedEvent(WorkforceEventBase):
+    r"""Event emitted when a task is updated during execution.
+
+    Attributes:
+        event_type (str): The type of the event, always
+            :obj:`"task_updated"`.
+        task_id (str): The identifier of the updated task.
+        worker_id (str, optional): The identifier of the worker
+            handling the task. If not given, it will be :obj:`None`.
+        update_type (str): The kind of update, one of
+            :obj:`"replan"`, :obj:`"reassign"`, or :obj:`"manual"`.
+        old_value (str, optional): The value before the update. If
+            not given, it will be :obj:`None`.
+        new_value (str, optional): The value after the update. If not
+            given, it will be :obj:`None`.
+        parent_task_id (str, optional): The identifier of the parent
+            task. If not given, it will be :obj:`None`.
+        metadata (Dict[str, Any], optional): A dictionary of
+            additional key-value pairs with update details. If not
+            given, it will be :obj:`None`.
+    """
+
     event_type: Literal["task_updated"] = "task_updated"
     task_id: str
     worker_id: Optional[str] = None
@@ -122,6 +257,26 @@ class TaskUpdatedEvent(WorkforceEventBase):
 
 
 class TaskCompletedEvent(WorkforceEventBase):
+    r"""Event emitted when a task is completed successfully.
+
+    Attributes:
+        event_type (str): The type of the event, always
+            :obj:`"task_completed"`.
+        task_id (str): The identifier of the completed task.
+        worker_id (str): The identifier of the worker that completed
+            the task.
+        parent_task_id (str, optional): The identifier of the parent
+            task. If not given, it will be :obj:`None`.
+        result_summary (str, optional): A summary of the task result.
+            If not given, it will be :obj:`None`.
+        processing_time_seconds (float, optional): The time taken to
+            process the task, in seconds. If not given, it will be
+            :obj:`None`.
+        token_usage (Dict[str, int], optional): The token usage of
+            the task processing. If not given, it will be
+            :obj:`None`.
+    """
+
     event_type: Literal["task_completed"] = "task_completed"
     task_id: str
     worker_id: str
@@ -132,6 +287,21 @@ class TaskCompletedEvent(WorkforceEventBase):
 
 
 class TaskFailedEvent(WorkforceEventBase):
+    r"""Event emitted when a task fails during execution.
+
+    Attributes:
+        event_type (str): The type of the event, always
+            :obj:`"task_failed"`.
+        task_id (str): The identifier of the failed task.
+        parent_task_id (str, optional): The identifier of the parent
+            task. If not given, it will be :obj:`None`.
+        error_message (str): The error message describing the
+            failure.
+        worker_id (str, optional): The identifier of the worker that
+            was processing the task. If not given, it will be
+            :obj:`None`.
+    """
+
     event_type: Literal["task_failed"] = "task_failed"
     task_id: str
     parent_task_id: Optional[str] = None
@@ -140,10 +310,32 @@ class TaskFailedEvent(WorkforceEventBase):
 
 
 class AllTasksCompletedEvent(WorkforceEventBase):
+    r"""Event emitted when all tasks in the workforce are completed.
+
+    Attributes:
+        event_type (str): The type of the event, always
+            :obj:`"all_tasks_completed"`.
+    """
+
     event_type: Literal["all_tasks_completed"] = "all_tasks_completed"
 
 
 class QueueStatusEvent(WorkforceEventBase):
+    r"""Event reporting the current status of a task queue.
+
+    Attributes:
+        event_type (str): The type of the event, always
+            :obj:`"queue_status"`.
+        queue_name (str): The name of the queue.
+        length (int): The current number of tasks in the queue.
+        pending_task_ids (List[str], optional): The identifiers of
+            the tasks currently pending in the queue. If not given,
+            it will be :obj:`None`.
+        metadata (Dict[str, Any], optional): A dictionary of
+            additional key-value pairs with queue details. If not
+            given, it will be :obj:`None`.
+    """
+
     event_type: Literal["queue_status"] = "queue_status"
     queue_name: str
     length: int

--- a/camel/societies/workforce/utils.py
+++ b/camel/societies/workforce/utils.py
@@ -421,7 +421,7 @@ class PipelineTaskBuilder:
     r"""Helper class for building pipeline tasks with dependencies."""
 
     def __init__(self):
-        """Initialize an empty pipeline task builder."""
+        r"""Initialize an empty pipeline task builder."""
         from camel.tasks import Task
 
         self._TaskClass = Task
@@ -442,7 +442,7 @@ class PipelineTaskBuilder:
         additional_info: Optional[dict] = None,
         auto_depend: bool = True,
     ) -> 'PipelineTaskBuilder':
-        """Add a task to the pipeline with support for chaining.
+        r"""Add a task to the pipeline with support for chaining.
 
         Args:
             content (str): The content/description of the task.
@@ -514,7 +514,7 @@ class PipelineTaskBuilder:
         task_id_prefix: str = "parallel",
         auto_depend: bool = True,
     ) -> 'PipelineTaskBuilder':
-        """Add multiple parallel tasks that can execute simultaneously.
+        r"""Add multiple parallel tasks that can execute simultaneously.
 
         Args:
             task_contents (List[str]): List of task content strings.
@@ -575,7 +575,7 @@ class PipelineTaskBuilder:
         wait_for: Optional[List[str]] = None,
         task_id: Optional[str] = None,
     ) -> 'PipelineTaskBuilder':
-        """Add a synchronization task that waits for multiple tasks.
+        r"""Add a synchronization task that waits for multiple tasks.
 
         Args:
             content (str): Content of the synchronization task.
@@ -618,7 +618,7 @@ class PipelineTaskBuilder:
         )
 
     def build(self) -> List:
-        """Build and return the complete task list with dependencies.
+        r"""Build and return the complete task list with dependencies.
 
         Returns:
             List[Task]: List of tasks with proper dependency relationships.
@@ -636,7 +636,7 @@ class PipelineTaskBuilder:
         return self.task_list.copy()
 
     def clear(self) -> None:
-        """Clear all tasks from the builder."""
+        r"""Clear all tasks from the builder."""
         self.task_list.clear()
         self._task_registry.clear()
         self.task_counter = 0
@@ -644,7 +644,7 @@ class PipelineTaskBuilder:
         self._last_parallel_tasks = []
 
     def fork(self, task_contents: List[str]) -> 'PipelineTaskBuilder':
-        """Create parallel branches from the current task (alias for
+        r"""Create parallel branches from the current task (alias for
         add_parallel_tasks).
 
         Args:
@@ -664,7 +664,7 @@ class PipelineTaskBuilder:
     def join(
         self, content: str, task_id: Optional[str] = None
     ) -> 'PipelineTaskBuilder':
-        """Join parallel branches with a synchronization task (alias for
+        r"""Join parallel branches with a synchronization task (alias for
         add_sync_task).
 
         Args:
@@ -680,7 +680,7 @@ class PipelineTaskBuilder:
         return self.add_sync_task(content, task_id=task_id)
 
     def _validate_dependencies(self) -> None:
-        """Validate that there are no circular dependencies.
+        r"""Validate that there are no circular dependencies.
 
         Raises:
             ValueError: If circular dependencies are detected.
@@ -713,7 +713,7 @@ class PipelineTaskBuilder:
                     )
 
     def get_task_info(self) -> dict:
-        """Get information about all tasks in the pipeline.
+        r"""Get information about all tasks in the pipeline.
 
         Returns:
             dict: Dictionary containing task count and task details.

--- a/camel/societies/workforce/workflow_memory_manager.py
+++ b/camel/societies/workforce/workflow_memory_manager.py
@@ -903,7 +903,7 @@ class WorkflowMemoryManager:
         """
 
         def _create_error_result(message: str) -> Dict[str, Any]:
-            """helper to create error result dict."""
+            r"""Helper to create an error result dict."""
             return {
                 "status": "error",
                 "summary": "",

--- a/camel/societies/workforce/workforce.py
+++ b/camel/societies/workforce/workforce.py
@@ -147,7 +147,26 @@ class WorkforceMode(Enum):
 
 
 class WorkforceSnapshot:
-    r"""Snapshot of workforce state for resuming execution."""
+    r"""Snapshot of workforce state for resuming execution.
+
+    Args:
+        main_task (Optional[Task], optional): The main task currently
+            being processed by the workforce. (default: :obj:`None`)
+        pending_tasks (Optional[Deque[Task]], optional): The tasks
+            waiting to be processed. (default: :obj:`None`)
+        completed_tasks (Optional[List[Task]], optional): The tasks
+            that have already been processed. (default: :obj:`None`)
+        task_dependencies (Optional[Dict[str, List[str]]], optional):
+            A mapping from task IDs to the IDs of the tasks they
+            depend on. (default: :obj:`None`)
+        assignees (Optional[Dict[str, str]], optional): A mapping from
+            task IDs to the IDs of their assigned workers.
+            (default: :obj:`None`)
+        current_task_index (int, optional): The index of the current
+            task in pipeline mode. (default: :obj:`0`)
+        description (str, optional): A description of the snapshot.
+            (default: :obj:`""`)
+    """
 
     def __init__(
         self,
@@ -831,7 +850,7 @@ class Workforce(BaseNode):
         )
 
     def set_mode(self, mode: WorkforceMode) -> Workforce:
-        """Set the execution mode of the workforce.
+        r"""Set the execution mode of the workforce.
 
         This allows switching between AUTO_DECOMPOSE and PIPELINE modes.
         Useful when you want to reuse the same workforce instance for
@@ -862,7 +881,7 @@ class Workforce(BaseNode):
         return self
 
     def _ensure_pipeline_builder(self) -> PipelineTaskBuilder:
-        """Ensure pipeline builder is initialized and switch to
+        r"""Ensure pipeline builder is initialized and switch to
         pipeline mode.
 
         Returns:
@@ -891,7 +910,7 @@ class Workforce(BaseNode):
         additional_info: Optional[Dict[str, Any]] = None,
         auto_depend: bool = True,
     ) -> Workforce:
-        """Add a task to the pipeline with support for chaining.
+        r"""Add a task to the pipeline with support for chaining.
 
         Accepts either a string for simple tasks or a Task object for
         advanced usage with metadata, images, or custom configurations.
@@ -955,7 +974,7 @@ class Workforce(BaseNode):
         task_id_prefix: str = "parallel",
         auto_depend: bool = True,
     ) -> Workforce:
-        """Add multiple parallel tasks to the pipeline.
+        r"""Add multiple parallel tasks to the pipeline.
 
         Accepts either a list of strings for simple tasks or a list of Task
         objects for advanced usage with metadata, images, or custom
@@ -1022,7 +1041,7 @@ class Workforce(BaseNode):
         wait_for: Optional[List[str]] = None,
         task_id: Optional[str] = None,
     ) -> Workforce:
-        """Add a synchronization task that waits for multiple tasks.
+        r"""Add a synchronization task that waits for multiple tasks.
 
         Accepts either a string for simple tasks or a Task object for
         advanced usage with metadata, images, or custom configurations.
@@ -1066,7 +1085,7 @@ class Workforce(BaseNode):
     def pipeline_fork(
         self, task_contents: Union[List[str], List[Task]]
     ) -> Workforce:
-        """Create parallel branches from the current task.
+        r"""Create parallel branches from the current task.
 
         Accepts either a list of strings for simple tasks or a list of Task
         objects for advanced usage with metadata, images, or custom
@@ -1114,7 +1133,7 @@ class Workforce(BaseNode):
     def pipeline_join(
         self, content: Union[str, Task], task_id: Optional[str] = None
     ) -> Workforce:
-        """Join parallel branches with a synchronization task.
+        r"""Join parallel branches with a synchronization task.
 
         Accepts either a string for simple tasks or a Task object for
         advanced usage with metadata, images, or custom configurations.
@@ -1155,7 +1174,7 @@ class Workforce(BaseNode):
         return self
 
     def pipeline_build(self) -> Workforce:
-        """Build the pipeline and set up the tasks for execution.
+        r"""Build the pipeline and set up the tasks for execution.
 
         Returns:
             Workforce: Self for method chaining.
@@ -1174,7 +1193,7 @@ class Workforce(BaseNode):
         return self
 
     def get_pipeline_builder(self) -> PipelineTaskBuilder:
-        """Get the underlying PipelineTaskBuilder for advanced usage.
+        r"""Get the underlying PipelineTaskBuilder for advanced usage.
 
         Returns:
             PipelineTaskBuilder: The pipeline builder instance.
@@ -1188,7 +1207,7 @@ class Workforce(BaseNode):
         return self._ensure_pipeline_builder()
 
     def set_pipeline_tasks(self, tasks: List[Task]) -> None:
-        """Set predefined pipeline tasks for PIPELINE mode.
+        r"""Set predefined pipeline tasks for PIPELINE mode.
 
         Args:
             tasks (List[Task]): List of tasks with dependencies already set.
@@ -2712,7 +2731,7 @@ class Workforce(BaseNode):
             return task
 
     async def _process_task_with_pipeline(self, task: Task) -> Task:
-        """Process task using predefined pipeline tasks."""
+        r"""Process task using predefined pipeline tasks."""
         if not self._pending_tasks:
             raise ValueError(
                 "No pipeline tasks defined. Use set_pipeline_tasks() first."
@@ -2756,7 +2775,7 @@ class Workforce(BaseNode):
         return task
 
     def _collect_pipeline_results(self) -> str:
-        """Collect results from all completed pipeline tasks."""
+        r"""Collect results from all completed pipeline tasks."""
         results = []
         for task in self._completed_tasks:
             if task.result:
@@ -2764,7 +2783,7 @@ class Workforce(BaseNode):
         return "\n\n".join(results) if results else "Pipeline completed"
 
     def _all_pipeline_tasks_successful(self) -> bool:
-        """Check if all pipeline tasks completed successfully.
+        r"""Check if all pipeline tasks completed successfully.
 
         INTENT: This method determines the FINAL STATE of the entire
         pipeline but does NOT affect task execution flow. It's called
@@ -3358,7 +3377,7 @@ class Workforce(BaseNode):
         async def save_single_worker(
             child: BaseNode,
         ) -> tuple[str, str]:
-            """Save workflow for a single worker, then return (node_id,
+            r"""Save workflow for a single worker, then return (node_id,
             result)."""
             if isinstance(child, SingleAgentWorker):
                 try:

--- a/camel/societies/workforce/workforce_logger.py
+++ b/camel/societies/workforce/workforce_logger.py
@@ -39,7 +39,18 @@ logger = get_logger(__name__)
 
 
 class WorkforceLogger(WorkforceCallback, WorkforceMetrics):
-    r"""Logs events and metrics for a Workforce instance."""
+    r"""Logs events and metrics for a Workforce instance.
+
+    Args:
+        workforce_id (str): The unique identifier for the workforce.
+        log_stream_chunks (bool): Whether to persist streaming chunk
+            events. Disabled by default to avoid unbounded in-memory logs
+            for high-volume streams.
+        stream_chunk_text_limit (Optional[int]): Maximum number of
+            characters to store for each stream chunk when
+            `log_stream_chunks` is enabled. Set to `None` to store full
+            chunk text.
+    """
 
     def __init__(
         self,
@@ -48,18 +59,7 @@ class WorkforceLogger(WorkforceCallback, WorkforceMetrics):
         log_stream_chunks: bool = False,
         stream_chunk_text_limit: Optional[int] = 1000,
     ):
-        """Initializes the WorkforceLogger.
-
-        Args:
-            workforce_id (str): The unique identifier for the workforce.
-            log_stream_chunks (bool): Whether to persist streaming chunk
-                events. Disabled by default to avoid unbounded in-memory logs
-                for high-volume streams.
-            stream_chunk_text_limit (Optional[int]): Maximum number of
-                characters to store for each stream chunk when
-                `log_stream_chunks` is enabled. Set to `None` to store full
-                chunk text.
-        """
+        r"""Initializes the WorkforceLogger."""
         if stream_chunk_text_limit is not None and stream_chunk_text_limit < 0:
             raise ValueError("stream_chunk_text_limit must be non-negative")
 

--- a/camel/societies/workforce/workforce_metrics.py
+++ b/camel/societies/workforce/workforce_metrics.py
@@ -16,18 +16,44 @@ from typing import Any, Dict
 
 
 class WorkforceMetrics(ABC):
+    r"""Abstract base class for collecting workforce metrics.
+
+    Subclasses implement tracking of task-related data within a
+    workforce and expose the collected metrics in different
+    representations.
+    """
+
     @abstractmethod
     def reset_task_data(self) -> None:
+        r"""Reset all collected task data to its initial state."""
         pass
 
     @abstractmethod
     def dump_to_json(self, file_path: str) -> None:
+        r"""Dump the collected metrics to a JSON file.
+
+        Args:
+            file_path (str): The path of the file to write the
+                metrics to.
+        """
         pass
 
     @abstractmethod
     def get_ascii_tree_representation(self) -> str:
+        r"""Get an ASCII tree representation of the metrics.
+
+        Returns:
+            str: The ASCII tree representation of the collected
+                metrics.
+        """
         pass
 
     @abstractmethod
     def get_kpis(self) -> Dict[str, Any]:
+        r"""Get the key performance indicators of the workforce.
+
+        Returns:
+            Dict[str, Any]: A dictionary mapping KPI names to their
+                current values.
+        """
         pass


### PR DESCRIPTION
## Description

This PR standardizes the docstrings in the `camel/societies/` scope as part of #911.

Changes:
- **events.py**: added compliant docstrings (raw `r"""` prefix, `Attributes:` sections following the style used for pydantic models elsewhere in the codebase, e.g. `MemoryRecord`) to all 14 event classes
- **workforce.py**: added missing `r"""` prefixes on 14 methods; documented `WorkforceSnapshot` constructor params in the class docstring `Args:` section per the guideline
- **utils.py**: added missing `r"""` prefixes on 10 `PipelineTaskBuilder` methods (Args/Returns sections already present)
- **workforce_logger.py**: moved the `Args:` section into the class docstring per guideline point 8 (pattern matches `BaseModelBackend`), fixed raw prefix
- **workforce_metrics.py**: added docstrings to the ABC and all abstract methods
- **workflow_memory_manager.py**: fixed one nested helper docstring

No runtime behavior is changed — docstrings only.

## Testing

- All modified modules compile and import successfully on Python 3.12
- Runtime sanity checks pass: `WorkforceLogger` instantiation, `PipelineTaskBuilder` add/fork/join/build chaining, event instantiation
- Ran `test/workforce/` suite before and after the change with identical results (34 passed; the 15 failures are pre-existing on master and require live LLM API access), confirming no regressions
- All added docstring lines respect the 79-character limit

Refs #911
