### PR TITLE
fix: disable strict mode for open function schemas

### DIFF
--- a/camel/toolkits/function_tool.py
+++ b/camel/toolkits/function_tool.py
@@ -334,32 +334,36 @@ def sanitize_and_enforce_required(parameters_dict):
     requirements:
     - Removes invalid 'default' fields from the parameters schema.
     - Ensures all fields are marked as required or have null type for optional
-    fields.
+      fields.
     - Recursively adds additionalProperties: false to all nested objects.
+    - Disables strict mode when an object intentionally allows additional
+      properties.
 
     Args:
         parameters_dict (dict): The dictionary representing the function
             schema.
 
     Returns:
-        dict: The updated dictionary with invalid defaults removed and all
-            fields properly configured for strict mode.
+        dict: The updated dictionary with invalid defaults removed and strict
+            mode enabled only when every object schema is closed.
     """
 
     def _add_additional_properties_false(obj):
-        r"""Recursively add additionalProperties: false to all objects."""
+        r"""Close unspecified objects and report strict compatibility."""
+        strict_compatible = True
         if isinstance(obj, dict):
-            if (
-                obj.get("type") == "object"
-                and "additionalProperties" not in obj
-            ):
-                obj["additionalProperties"] = False
+            if obj.get("type") == "object":
+                if "additionalProperties" not in obj:
+                    obj["additionalProperties"] = False
+                elif obj["additionalProperties"] is not False:
+                    strict_compatible = False
 
             # Process nested structures
             for key, value in obj.items():
                 if key == "properties" and isinstance(value, dict):
                     for prop_value in value.values():
-                        _add_additional_properties_false(prop_value)
+                        if not _add_additional_properties_false(prop_value):
+                            strict_compatible = False
                 elif key in [
                     "items",
                     "allOf",
@@ -367,13 +371,17 @@ def sanitize_and_enforce_required(parameters_dict):
                     "anyOf",
                 ] and isinstance(value, (dict, list)):
                     if isinstance(value, dict):
-                        _add_additional_properties_false(value)
+                        if not _add_additional_properties_false(value):
+                            strict_compatible = False
                     elif isinstance(value, list):
                         for item in value:
-                            _add_additional_properties_false(item)
+                            if not _add_additional_properties_false(item):
+                                strict_compatible = False
                 elif key == "$defs" and isinstance(value, dict):
                     for def_value in value.values():
-                        _add_additional_properties_false(def_value)
+                        if not _add_additional_properties_false(def_value):
+                            strict_compatible = False
+        return strict_compatible
 
     # Check if 'function' and 'parameters' exist
     if (
@@ -441,8 +449,12 @@ def sanitize_and_enforce_required(parameters_dict):
         # Set all fields as required (strict mode requirement)
         parameters['required'] = required_fields
 
-        # Recursively add additionalProperties: false to all objects
-        _add_additional_properties_false(parameters)
+        # Recursively close object schemas that do not explicitly opt into
+        # additional properties. Open mappings cannot be represented in
+        # strict mode without changing their accepted arguments, so preserve
+        # their schema and fall back to best-effort function calling.
+        if not _add_additional_properties_false(parameters):
+            parameters_dict['function']['strict'] = False
 
     return parameters_dict
 

--- a/test/toolkits/test_openai_function.py
+++ b/test/toolkits/test_openai_function.py
@@ -14,7 +14,7 @@
 import copy
 import json
 from datetime import datetime
-from typing import List
+from typing import Dict, List, Optional
 
 import pytest
 from jsonschema.exceptions import SchemaError
@@ -186,6 +186,27 @@ def test_get_openai_tool_schema():
         assert openai_tool_schema == expect_res_v2
     else:
         assert openai_tool_schema == expect_res_v1
+
+
+def test_open_mapping_parameter_disables_strict_mode():
+    def submit_prompts(
+        allowed_prompts: Optional[List[Dict[str, str]]] = None,
+    ) -> None:
+        r"""Submit allowed tool and prompt pairs.
+
+        Args:
+            allowed_prompts: Tool and prompt pairs to submit.
+        """
+
+    schema = get_openai_tool_schema(submit_prompts)
+    function_schema = schema["function"]
+    allowed_prompts_schema = function_schema["parameters"]["properties"][
+        "allowed_prompts"
+    ]
+    mapping_schema = allowed_prompts_schema["anyOf"][0]["items"]
+
+    assert function_schema["strict"] is False
+    assert mapping_schema["additionalProperties"] == {"type": "string"}
 
 
 def test_different_docstring_style():


### PR DESCRIPTION
### Related Issue

Follow-up to #2629 and the strict-mode fallback introduced in #2656.

### Description

`get_openai_tool_schema()` currently marks every generated function schema as
`strict: true`. Pydantic represents open mappings such as
`Optional[List[Dict[str, str]]]` with a schema-valued
`additionalProperties`, which is incompatible with OpenAI strict mode. This
causes providers that validate strict schemas to reject the entire request.

This change keeps explicit open-mapping schemas intact and falls back to
`strict: false` when any object permits additional properties. Closed objects
continue to receive `additionalProperties: false` and remain strict. A
regression test covers the same nested mapping shape used by
`PlanningWorktreeToolkit.planning_exit_plan_mode`.

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Validation

- `pytest test/toolkits/test_openai_function.py test/toolkits/test_planning_worktree_toolkit.py -q` — 24 passed
- `ruff format --check camel/toolkits/function_tool.py test/toolkits/test_openai_function.py` — passed
- `ruff check camel/toolkits/function_tool.py test/toolkits/test_openai_function.py` — passed
- `mypy camel/toolkits/function_tool.py` — passed

### Checklist

- [x] I have read and agree to the [AI-Generated Code Policy](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md#ai-generated-code-policy) (**required**)
- [x] I have linked this PR to an issue (**required**)
- [x] I have checked whether dependencies need to be added or updated; none are required
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*)
- [x] Documentation changes are not needed for this internal schema-generation fix
- [ ] I have added examples if this is a new feature (not applicable)
