### PR TITLE
release: 0.2.91a6

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -26,7 +26,7 @@ body:
     attributes:
       label: What version of camel are you using?
       description: Run command `python3 -c 'print(__import__("camel").__version__)'` in your shell and paste the output here.
-      placeholder: E.g., 0.2.91a5
+      placeholder: E.g., 0.2.91a6
     validations:
       required: true
 

--- a/camel/__init__.py
+++ b/camel/__init__.py
@@ -14,7 +14,7 @@
 
 from camel.logger import disable_logging, enable_logging, set_log_level
 
-__version__ = '0.2.91a5'
+__version__ = '0.2.91a6'
 
 __all__ = [
     '__version__',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ sys.path.insert(0, os.path.abspath('..'))
 project = 'CAMEL'
 copyright = '2024, CAMEL-AI.org'
 author = 'CAMEL-AI.org'
-release = '0.2.91a5'
+release = '0.2.91a6'
 
 html_favicon = (
     'https://raw.githubusercontent.com/camel-ai/camel/master/misc/favicon.png'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "camel-ai"
-version = "0.2.91a5"
+version = "0.2.91a6"
 description = "Communicative Agents for AI Society Study"
 authors = [{ name = "CAMEL-AI.org" }]
 requires-python = ">=3.10,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -898,7 +898,7 @@ wheels = [
 
 [[package]]
 name = "camel-ai"
-version = "0.2.91a5"
+version = "0.2.91a6"
 source = { editable = "." }
 dependencies = [
     { name = "astor" },


### PR DESCRIPTION
### Related Issue

N/A — routine prerelease version bump.

### Description

Bump CAMEL from `0.2.91a5` to `0.2.91a6` in the package metadata, runtime version, documentation config, bug report template, and lockfile.

### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other: prerelease version bump

### Validation

- `uv lock --check`
- `uv build` (built `camel_ai-0.2.91a6` wheel and sdist)
- Runtime import reports `camel.__version__ == "0.2.91a6"`
- `git diff --check`
- Ruff, Ruff format, codespell, gitleaks, end-of-file, and trailing-whitespace hooks passed
- The repository-wide mypy hook reports pre-existing missing optional dependencies; the local license hook expects a `python` executable that is unavailable in this environment. License headers in the changed Python files were verified directly.

### Checklist

- [x] I have read and agree to the [AI-Generated Code Policy](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md#ai-generated-code-policy)
- [ ] I have linked this PR to an issue (not applicable for this release bump)
- [x] I checked dependencies and ran `uv lock`
- [x] No test changes are needed because this does not change runtime behavior
- [x] I updated the affected documentation version
- [x] No examples are needed for this release bump
