### PR TITLE
release: 0.2.91a7 with dependency compatibility fixes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -26,7 +26,7 @@ body:
     attributes:
       label: What version of camel are you using?
       description: Run command `python3 -c 'print(__import__("camel").__version__)'` in your shell and paste the output here.
-      placeholder: E.g., 0.2.91a6
+      placeholder: E.g., 0.2.91a7
     validations:
       required: true
 

--- a/camel/__init__.py
+++ b/camel/__init__.py
@@ -14,7 +14,7 @@
 
 from camel.logger import disable_logging, enable_logging, set_log_level
 
-__version__ = '0.2.91a6'
+__version__ = '0.2.91a7'
 
 __all__ = [
     '__version__',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ sys.path.insert(0, os.path.abspath('..'))
 project = 'CAMEL'
 copyright = '2024, CAMEL-AI.org'
 author = 'CAMEL-AI.org'
-release = '0.2.91a6'
+release = '0.2.91a7'
 
 html_favicon = (
     'https://raw.githubusercontent.com/camel-ai/camel/master/misc/favicon.png'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "camel-ai"
-version = "0.2.91a6"
+version = "0.2.91a7"
 description = "Communicative Agents for AI Society Study"
 authors = [{ name = "CAMEL-AI.org" }]
 requires-python = ">=3.10,<3.15"
@@ -21,7 +21,7 @@ keywords = [
     "large-language-models",
 ]
 dependencies = [
-    "mcp>=1.3.0",
+    "mcp>=1.3.0,<2",
     "tiktoken>=0.7.0,<=0.12",
     "colorama>=0.4.6,<0.5",
     "jsonschema>=4,<5",
@@ -189,7 +189,7 @@ dev_tools = [
     "tree-sitter-python>=0.23.6,<0.24",
     "tree-sitter>=0.23.2,<0.24",
     "typer>=0.15.2",
-    "mcp>=1.3.0",
+    "mcp>=1.3.0,<2",
     "daytona-sdk>=0.20.0",
     "aci-sdk>=1.0.0b1",
     "langfuse>=2.60.5",
@@ -433,7 +433,7 @@ all = [
     "html2text>=2024.2.26",
     "docx>=0.2.4",
     "websockets>=13.0,<15.1",
-    "mcp>=1.3.0",
+    "mcp>=1.3.0,<2",
     "typer>=0.15.2",
     "mem0ai>=0.1.67",
     "math-verify>=0.7.0,<0.8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "pydantic>=2.10.6,<=2.12.0",
     "httpx>=0.28.0,<1.0.0dev",
     "psutil>=5.9.8,<6",
-    "openai>=1.86.0",
+    "openai>=1.86.0,<3",
     "websockets>=13.0,<15.1",
     "astor>=0.8.1",
     "pillow>=10.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -898,7 +898,7 @@ wheels = [
 
 [[package]]
 name = "camel-ai"
-version = "0.2.91a6"
+version = "0.2.91a7"
 source = { editable = "." }
 dependencies = [
     { name = "astor" },
@@ -1549,9 +1549,9 @@ requires-dist = [
     { name = "math-verify", marker = "extra == 'all'", specifier = ">=0.7.0,<0.8" },
     { name = "math-verify", marker = "extra == 'data-tools'", specifier = ">=0.7.0,<0.8" },
     { name = "matplotlib", marker = "extra == 'earth-science'", specifier = ">=3.10.7" },
-    { name = "mcp", specifier = ">=1.3.0" },
-    { name = "mcp", marker = "extra == 'all'", specifier = ">=1.3.0" },
-    { name = "mcp", marker = "extra == 'dev-tools'", specifier = ">=1.3.0" },
+    { name = "mcp", specifier = ">=1.3.0,<2" },
+    { name = "mcp", marker = "extra == 'all'", specifier = ">=1.3.0,<2" },
+    { name = "mcp", marker = "extra == 'dev-tools'", specifier = ">=1.3.0,<2" },
     { name = "mcp-server-fetch", marker = "extra == 'eigent'", specifier = "==2025.1.17" },
     { name = "mcp-server-fetch", marker = "extra == 'owl'", specifier = "==2025.1.17" },
     { name = "mcp-simple-arxiv", marker = "extra == 'eigent'", specifier = "==0.2.2" },

--- a/uv.lock
+++ b/uv.lock
@@ -1594,7 +1594,7 @@ requires-dist = [
     { name = "onnxruntime", marker = "extra == 'document-tools'", specifier = "<=1.19.2" },
     { name = "onnxruntime", marker = "extra == 'eigent'", specifier = "<=1.19.2" },
     { name = "onnxruntime", marker = "extra == 'owl'", specifier = "<=1.19.2" },
-    { name = "openai", specifier = ">=1.86.0" },
+    { name = "openai", specifier = ">=1.86.0,<3" },
     { name = "openapi-spec-validator", marker = "extra == 'all'", specifier = ">=0.7.1,<0.8" },
     { name = "openapi-spec-validator", marker = "extra == 'document-tools'", specifier = ">=0.7.1,<0.8" },
     { name = "openapi-spec-validator", marker = "extra == 'owl'", specifier = ">=0.7.1,<0.8" },


### PR DESCRIPTION
### Related Issue

Follow-up to #4312 and the dependency-related CI failures on `master`.

### Description

- Constrain `mcp` to `>=1.3.0,<2` in the base, `dev_tools`, and `all` dependency sets.
- Constrain `openai` to `>=1.86.0,<3` until CAMEL migrates its HTTP-layer integrations to HTTPX2.
- Bump CAMEL from `0.2.91a6` to `0.2.91a7` across package metadata, runtime version, documentation config, bug report template, and lockfile.

MCP v2 renamed `FastMCP` to `MCPServer` and removed the v1 import path. CAMEL still uses the MCP v1 API in several modules, so constraining the dependency is the smallest compatible fix; a full v2 migration can be handled separately.

OpenAI SDK v3 uses HTTPX2 objects by default. CAMEL currently has integrations and tests built around legacy HTTPX objects, so this release stays on OpenAI SDK v1/v2 pending a dedicated migration.

- MCP v2 migration reference: https://github.com/modelcontextprotocol/python-sdk/blob/main/docs/whats-new.md
- OpenAI HTTPX2 migration reference: https://github.com/openai/openai-python/blob/main/httpx2.md

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other: prerelease version bump

### Validation

- Fresh Python 3.10 install of `.[all, dev, docs]` resolved `mcp==1.29.1` and `openai==2.54.0`.
- Imports succeeded for `camel.agents`, `camel.societies`, and `camel.societies.workforce`.
- `test/integration_test/test_minimal_dependency.py`: 8 passed.
- `apps/` collection: 9 tests collected; the corresponding GitHub Actions job passed.
- `examples/` collection: 19 tests collected; the corresponding GitHub Actions job passed.
- `test_openai_compatible_model_apikey_from_env`: passed with the fresh dependency resolution.
- Full pre-commit run passed; applicable hooks also passed after the OpenAI constraint update.
- `uv lock --check` passed with both the repository and latest uv versions.
- Built the `camel_ai-0.2.91a7` wheel and sdist; wheel metadata contains the MCP and OpenAI upper bounds.

### Checklist

- [x] I have read and agree to the [AI-Generated Code Policy](https://github.com/camel-ai/camel/blob/master/CONTRIBUTING.md#ai-generated-code-policy)
- [ ] I have linked this PR to an issue (not applicable for this release hotfix)
- [x] I updated and verified `uv.lock`
- [x] I ran the relevant tests
- [x] I updated the affected documentation version
- [x] No examples are needed for these dependency compatibility fixes
