### PR TITLE
feat: make Serper base URL configurable via SERPER_API_BASE

### DIFF
--- a/camel/toolkits/search_toolkit.py
+++ b/camel/toolkits/search_toolkit.py
@@ -81,8 +81,11 @@ class SearchToolkit(BaseToolkit):
                 'peopleAlsoAsk', etc.
         """
         SERPER_API_KEY = os.getenv("SERPER_API_KEY")
+        SERPER_API_BASE = os.getenv(
+            "SERPER_API_BASE", "https://google.serper.dev"
+        ).rstrip("/")
 
-        url = "https://google.serper.dev/search"
+        url = f"{SERPER_API_BASE}/search"
 
         payload = {
             "q": query,


### PR DESCRIPTION
In `search_toolkit.py`, `search_google` reads its key from the environment but hardcodes the endpoint:

```python
SERPER_API_KEY = os.getenv("SERPER_API_KEY")

url = "https://google.serper.dev/search"
```

So anyone who needs the request to go elsewhere has to edit the file. That comes up with an egress proxy on a restricted network, a regional endpoint chosen for latency or data residency, and pointing the toolkit at a local mock during tests so the suite does not make live calls.

### Change

Reads the base URL from the environment next to the key, defaulting to the current endpoint:

```python
SERPER_API_KEY = os.getenv("SERPER_API_KEY")
SERPER_API_BASE = os.getenv(
    "SERPER_API_BASE", "https://google.serper.dev"
).rstrip("/")

url = f"{SERPER_API_BASE}/search"
```

Four added lines, one file, no signature change and no new dependency — so existing callers and tests are untouched. `rstrip("/")` means `https://host` and `https://host/` behave the same, and an unset variable resolves to exactly the current URL.

Happy to document `SERPER_API_BASE` alongside `SERPER_API_KEY` in the toolkit reference if that is wanted — just point me at the right file.